### PR TITLE
Fix: Store filter actions

### DIFF
--- a/internal/action/service.go
+++ b/internal/action/service.go
@@ -1,15 +1,19 @@
 package action
 
 import (
+	"context"
+
 	"github.com/asaskevich/EventBus"
+
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/download_client"
 )
 
 type Service interface {
-	Store(action domain.Action) (*domain.Action, error)
+	Store(ctx context.Context, action domain.Action) (*domain.Action, error)
 	Fetch() ([]domain.Action, error)
 	Delete(actionID int) error
+	DeleteByFilterID(ctx context.Context, filterID int) error
 	ToggleEnabled(actionID int) error
 
 	RunActions(actions []domain.Action, release domain.Release) error
@@ -25,10 +29,10 @@ func NewService(repo domain.ActionRepo, clientSvc download_client.Service, bus E
 	return &service{repo: repo, clientSvc: clientSvc, bus: bus}
 }
 
-func (s *service) Store(action domain.Action) (*domain.Action, error) {
+func (s *service) Store(ctx context.Context, action domain.Action) (*domain.Action, error) {
 	// validate data
 
-	a, err := s.repo.Store(action)
+	a, err := s.repo.Store(ctx, action)
 	if err != nil {
 		return nil, err
 	}
@@ -38,6 +42,14 @@ func (s *service) Store(action domain.Action) (*domain.Action, error) {
 
 func (s *service) Delete(actionID int) error {
 	if err := s.repo.Delete(actionID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) DeleteByFilterID(ctx context.Context, filterID int) error {
+	if err := s.repo.DeleteByFilterID(ctx, filterID); err != nil {
 		return err
 	}
 

--- a/internal/database/irc.go
+++ b/internal/database/irc.go
@@ -368,7 +368,6 @@ func (ir *IrcRepo) StoreNetworkChannels(ctx context.Context, networkID int64, ch
 	if err != nil {
 		log.Error().Stack().Err(err).Msgf("error deleting network: %v", networkID)
 		return err
-
 	}
 
 	return nil

--- a/internal/domain/action.go
+++ b/internal/domain/action.go
@@ -1,7 +1,11 @@
 package domain
 
+import "context"
+
 type ActionRepo interface {
-	Store(action Action) (*Action, error)
+	Store(ctx context.Context, action Action) (*Action, error)
+	StoreFilterActions(ctx context.Context, actions []Action, filterID int64) ([]Action, error)
+	DeleteByFilterID(ctx context.Context, filterID int) error
 	FindByFilterID(filterID int) ([]Action, error)
 	List() ([]Action, error)
 	Delete(actionID int) error

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -1,6 +1,9 @@
 package domain
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 /*
 Works the same way as for autodl-irssi
@@ -13,10 +16,11 @@ type FilterRepo interface {
 	FindByIndexerIdentifier(indexer string) ([]Filter, error)
 	ListFilters() ([]Filter, error)
 	Store(filter Filter) (*Filter, error)
-	Update(filter Filter) (*Filter, error)
-	Delete(filterID int) error
-	StoreIndexerConnection(filterID int, indexerID int) error
-	DeleteIndexerConnections(filterID int) error
+	Update(ctx context.Context, filter Filter) (*Filter, error)
+	Delete(ctx context.Context, filterID int) error
+	StoreIndexerConnection(ctx context.Context, filterID int, indexerID int) error
+	StoreIndexerConnections(ctx context.Context, filterID int, indexers []Indexer) error
+	DeleteIndexerConnections(ctx context.Context, filterID int) error
 }
 
 type Filter struct {

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -14,9 +15,8 @@ type filterService interface {
 	ListFilters() ([]domain.Filter, error)
 	FindByID(filterID int) (*domain.Filter, error)
 	Store(filter domain.Filter) (*domain.Filter, error)
-	Delete(filterID int) error
-	Update(filter domain.Filter) (*domain.Filter, error)
-	//StoreFilterAction(action domain.Action) error
+	Delete(ctx context.Context, filterID int) error
+	Update(ctx context.Context, filter domain.Filter) (*domain.Filter, error)
 }
 
 type filterHandler struct {
@@ -114,7 +114,7 @@ func (h filterHandler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filter, err := h.service.Update(data)
+	filter, err := h.service.Update(ctx, data)
 	if err != nil {
 		// encode error
 		return
@@ -131,7 +131,7 @@ func (h filterHandler) delete(w http.ResponseWriter, r *http.Request) {
 
 	id, _ := strconv.Atoi(filterID)
 
-	if err := h.service.Delete(id); err != nil {
+	if err := h.service.Delete(ctx, id); err != nil {
 		// return err
 	}
 

--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useRef } from "react";
 import { Dialog, Transition, Switch as SwitchBasic } from "@headlessui/react";
-import { ChevronDownIcon, ChevronRightIcon, ExclamationIcon, } from '@heroicons/react/solid'
+import { ChevronDownIcon, ChevronRightIcon, } from '@heroicons/react/solid'
 import { EmptyListState } from "../../components/emptystates";
 
 import {
@@ -126,7 +126,7 @@ export default function FilterDetails() {
         },
     )
 
-    const { data: indexers } = useQuery<Indexer[], Error>('indexerList', APIClient.indexers.getOptions,
+    const { data: indexers } = useQuery<Indexer[], Error>(["filter", "indexer_list"], APIClient.indexers.getOptions,
         {
             refetchOnWindowFocus: false
         }
@@ -142,10 +142,8 @@ export default function FilterDetails() {
     })
 
     const deleteMutation = useMutation((id: number) => APIClient.filters.delete(id), {
-        onSuccess: (filter) => {
-            // invalidate filters
-            queryClient.invalidateQueries("filter");
-            toast.custom((t) => <Toast type="success" body={`${filter.name} was deleted`} t={t} />)
+        onSuccess: () => {
+            toast.custom((t) => <Toast type="success" body={`${data?.name} was deleted`} t={t} />)
 
             // redirect
             history.push("/filters")
@@ -539,7 +537,7 @@ interface FilterActionsProps {
 }
 
 function FilterActions({ filter, values }: FilterActionsProps) {
-    const { data } = useQuery<DownloadClient[], Error>('downloadClients', APIClient.download_clients.getAll,
+    const { data } = useQuery<DownloadClient[], Error>(['filter', 'download_clients'], APIClient.download_clients.getAll,
         {
             refetchOnWindowFocus: false
         }


### PR DESCRIPTION
What: Filter actions could not be deleted or updated properly.

Fix: Run store in transaction and delete connections before store, to allow for updates as well as delete.

Also:
 - Improve the filter indexer connections handling
 - Update query keys for web data fetcher on filters for better caching etc