### PR TITLE
Fix(filters): use correct property for tags

### DIFF
--- a/web/src/domain/interfaces.ts
+++ b/web/src/domain/interfaces.ts
@@ -91,7 +91,7 @@ export interface Filter {
     except_release_groups: string;
     match_categories: string;
     except_categories: string;
-    match_tags: string;
+    tags: string;
     except_tags: string;
     match_uploaders: string;
     except_uploaders: string;

--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -241,7 +241,7 @@ export default function FilterDetails() {
                                         except_release_groups: data.except_release_groups,
                                         match_categories: data.match_categories,
                                         except_categories: data.except_categories,
-                                        match_tags: data.match_tags,
+                                        tags: data.tags,
                                         except_tags: data.except_tags,
                                         match_uploaders: data.match_uploaders,
                                         except_uploaders: data.except_uploaders,
@@ -473,7 +473,7 @@ function Advanced() {
                         <TextField name="match_categories" label="Match categories" columns={6} placeholder="eg. *category*,category1" />
                         <TextField name="except_categories" label="Except categories" columns={6} placeholder="eg. *category*" />
 
-                        <TextField name="match_tags" label="Match tags" columns={6} placeholder="eg. tag1,tag2" />
+                        <TextField name="tags" label="Match tags" columns={6} placeholder="eg. tag1,tag2" />
                         <TextField name="except_tags" label="Except tags" columns={6} placeholder="eg. tag1,tag2" />
                     </div>
                 )}


### PR DESCRIPTION
What: The filter page used the wrong property for tags and could therefore not save or load them correctly.

Fix: Change from `match_tags` to `tags`.