### PR TITLE
Fix(indexers): BTN api client

### DIFF
--- a/internal/indexer/definitions/btn.yaml
+++ b/internal/indexer/definitions/btn.yaml
@@ -85,9 +85,10 @@ parse:
         - preTime
     - test:
         - "[ https://XXXXXXXXX/torrents.php?id=7338 / https://XXXXXXXXX/torrents.php?action=download&id=9116 ]"
-      pattern: ^\[ .* \/ (https?:\/\/.*id=\d+) \]
+      pattern: ^\[ .* \/ (https?:\/\/.*id=(\d+)) \]
       vars:
         - baseUrl
+        - torrentId
 
   match:
     torrenturl: "{{ .baseUrl }}&authkey={{ .authkey }}&torrent_pass={{ .torrent_pass }}"

--- a/pkg/btn/btn.go
+++ b/pkg/btn/btn.go
@@ -30,7 +30,7 @@ func (c *Client) GetTorrentByID(torrentID string) (*domain.TorrentBasic, error) 
 		return nil, fmt.Errorf("btn client: must have torrentID")
 	}
 
-	res, err := c.rpcClient.Call("getTorrentById", [2]string{torrentID, c.APIKey})
+	res, err := c.rpcClient.Call("getTorrentById", [2]string{c.APIKey, torrentID})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jsonrpc/jsonrpc.go
+++ b/pkg/jsonrpc/jsonrpc.go
@@ -98,6 +98,7 @@ func NewClientWithOpts(endpoint string, opts *ClientOpts) Client {
 
 func (c *rpcClient) Call(method string, params ...interface{}) (*RPCResponse, error) {
 	request := RPCRequest{
+		ID:      1,
 		JsonRPC: "2.0",
 		Method:  method,
 		Params:  Params(params...),


### PR DESCRIPTION
What: 
* Api key and torrentId in wrong order
* Set hardcoded ID in `jsonrpc` request object
* Parse`torrentId` from url

Fixes #68 