### PR TITLE
Indexers: Add AnimeBytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ autobrr monitors IRC announce channels to get releases as soon as they are avail
 ## Features:
 
 * Single binary + config for easy setup
-* Support for 15 trackers
+* Support for 21 trackers
 * Easy to use UI
 * Available torrent actions:
   * qBittorrent
@@ -26,6 +26,7 @@ Is your tracker missing? Add an issue to request it.
   <summary>Trackers</summary>
 
   * AlphaRatio
+  * AnimeBytes
   * BeyondHD
   * BTN
   * EMP
@@ -33,11 +34,16 @@ Is your tracker missing? Add an issue to request it.
   * GazelleGames
   * HD-Torrents
   * IPTorrents
+  * Milkie
+  * MoreThanTV
   * Nebulance
   * Orpheus
   * PTP
   * RED
   * Superbits
+  * TorrentDay
   * TorrentLeech
+  * TorrentSeeds
+  * TranceTraffic
   * UHDBits
 </details>

--- a/internal/indexer/definitions/animebytes.yaml
+++ b/internal/indexer/definitions/animebytes.yaml
@@ -49,9 +49,9 @@ parse:
   type: single
   lines:
     - test:
-        - "BanG Dream! 3rd Season - TV Series [2020] :: Blu-ray / MKV / h265 10-bit / 1080p / FLAC 5.0 / RAW (LoliHouse) / Freeleech || https://animebytes.tv/torrents.php?id=62837&torrentid=975926 || music || Uploaded by: Karenina"
+        - "BanG Dream! 3rd Season - TV Series [2020] :: Blu-ray / MKV / h265 10-bit / 1080p / FLAC 5.0 / RAW (LoliHouse) / Freeleech || https://animebytes.tv/torrents.php?id=622837&torrentid=97593126 || music || Uploaded by: Anonymous"
         - "Koi Kaze - TV Series [2004] :: DVD / MKV / h264 10-bit / 712x478 / FLAC 2.0 / Dual Audio / Softsubs (WSE) || https://animebytes.tv/torrents.php?id=1115&torrentid=975927 || coming.of.age, romance, seinen, slice.of.life, tragedy, incest || Uploaded by: Wyse"
-        - "Isshiki Yui and Kikuta Daisuke - Toraba! Original Sound Track [2011] :: MP3 / V0 (VBR) / CD || https://animebytes.tv/torrents2.php?id=74466&torrentid=975933 || soundtrack || Uploaded by: Julzer"
+        - "Isshiki Yui and Kikuta Daisuke - Toraba! Original Sound Track [2011] :: MP3 / V0 (VBR) / CD || https://animebytes.tv/torrents2.php?id=744166&torrentid=9752933 || soundtrack || Uploaded by: Test-Uploader"
       pattern: ^(.*)\[(\d+)\]\s?:*\s(.*)....(https.*)/torrents.*\?id=\d+&torrentid=(\d+).\|\|(.*)\|\|\sUploaded\sby:\s(.*)
       vars:
         - torrentName

--- a/internal/indexer/definitions/animebytes.yaml
+++ b/internal/indexer/definitions/animebytes.yaml
@@ -1,7 +1,7 @@
 ---
 #id: animebytes
 name: AnimeBytes
-identifier: ab
+identifier: animebytes
 description: AnimeBytes (AB) is a private torrent tracker for Anime, Manga, J-Music, OSTS, Hentai, Games and Light Novel.
 language: en-us
 urls:
@@ -21,7 +21,7 @@ settings:
 irc:
   network: AnimeBytes-IRC
   server: irc.animebytes.tv
-  port: 6697
+  port: 7000
   tls: true
   channels:
     - "#announce"
@@ -40,7 +40,7 @@ irc:
       help: NickServ password
     - name: invite_command
       type: secret
-      default: "/msg Satsuki enter #announce {AB username} ircKey"  
+      default: "/msg Satsuki enter #announce {AB username} ircKey"
       required: true
       label: Invite command
       help: Invite auth with Satsuki, animebytes.tv/irc
@@ -49,14 +49,14 @@ parse:
   type: single
   lines:
     - test:
-        - "BanG Dream! 3rd Season - TV Series [2020] :: Blu-ray / MKV / h265 10-bit / 1080p / FLAC 5.0 / RAW (LoliHouse) / Freeleech || https://animebytes.tv/torrents.php?id=622837&torrentid=97593126 || music || Uploaded by: Anonymous"
-        - "Koi Kaze - TV Series [2004] :: DVD / MKV / h264 10-bit / 712x478 / FLAC 2.0 / Dual Audio / Softsubs (WSE) || https://animebytes.tv/torrents.php?id=1115&torrentid=975927 || coming.of.age, romance, seinen, slice.of.life, tragedy, incest || Uploaded by: Wyse"
-        - "Isshiki Yui and Kikuta Daisuke - Toraba! Original Sound Track [2011] :: MP3 / V0 (VBR) / CD || https://animebytes.tv/torrents2.php?id=744166&torrentid=9752933 || soundtrack || Uploaded by: Test-Uploader"
-      pattern: ^(.*)\[(\d+)\]\s?:*\s(.*)....(https.*)/torrents.*\?id=\d+&torrentid=(\d+).\|\|(.*)\|\|\sUploaded\sby:\s(.*)
+        - "Other Show! 3rd Season - TV Series [2020] :: Blu-ray / MKV / h265 10-bit / 1080p / FLAC 5.0 / RAW (LoliHouse) / Freeleech || https://animebytes.tv/torrents.php?id=000000&torrentid=00000000 || music || Uploaded by: Anonymous"
+        - "Show 1 - TV Series [2004] :: DVD / MKV / h264 10-bit / 712x478 / FLAC 2.0 / Dual Audio / Softsubs (WSE) || https://animebytes.tv/torrents.php?id=0000&torrentid=000000 || coming.of.age, romance, seinen, slice.of.life, tragedy || Uploaded by: Uploader"
+        - "Artist - Album! Original Sound Track [2011] :: MP3 / V0 (VBR) / CD || https://animebytes.tv/torrents2.php?id=000000&torrentid=0000000 || soundtrack || Uploaded by: Test-Uploader"
+      pattern: '(.*)  \[(\d+)\] :: (.*) \|\| (https.*)\/torrents.*\?id=\d+&torrentid=(\d+) \|\| (.+?(?:(?:\|\| Uploaded by|$))?)(?:\|\| Uploaded by: (.*))?$'
       vars:
         - torrentName
         - year
-        - relaseTags
+        - releaseTags
         - baseUrl
         - torrentId
         - tags

--- a/internal/indexer/definitions/animebytes.yaml
+++ b/internal/indexer/definitions/animebytes.yaml
@@ -1,0 +1,66 @@
+---
+#id: animebytes
+name: AnimeBytes
+identifier: ab
+description: AnimeBytes (AB) is a private torrent tracker for Anime, Manga, J-Music, OSTS, Hentai, Games and Light Novel.
+language: en-us
+urls:
+  - https://animebytes.tv/
+privacy: private
+protocol: torrent
+supports:
+  - irc
+  - rss
+source: gazelle
+settings:
+  - name: passkey
+    type: secret
+    label: PassKey
+    help: Settings -> Account -> Passkey.
+
+irc:
+  network: AnimeBytes-IRC
+  server: irc.animebytes.tv
+  port: 6697
+  tls: true
+  channels:
+    - "#announce"
+  announcers:
+    - Satsuki
+  settings:
+    - name: nickserv.account
+      type: text
+      required: true
+      label: NickServ Account
+      help: NickServ account. Make sure to group your user and bot. Eg. user|autodl
+    - name: nickserv.password
+      type: secret
+      required: false
+      label: NickServ Password
+      help: NickServ password
+    - name: invite_command
+      type: secret
+      default: "/msg Satsuki enter #announce {AB username} ircKey"  
+      required: true
+      label: Invite command
+      help: Invite auth with Satsuki, animebytes.tv/irc
+
+parse:
+  type: single
+  lines:
+    - test:
+        - "BanG Dream! 3rd Season - TV Series [2020] :: Blu-ray / MKV / h265 10-bit / 1080p / FLAC 5.0 / RAW (LoliHouse) / Freeleech || https://animebytes.tv/torrents.php?id=62837&torrentid=975926 || music || Uploaded by: Karenina"
+        - "Koi Kaze - TV Series [2004] :: DVD / MKV / h264 10-bit / 712x478 / FLAC 2.0 / Dual Audio / Softsubs (WSE) || https://animebytes.tv/torrents.php?id=1115&torrentid=975927 || coming.of.age, romance, seinen, slice.of.life, tragedy, incest || Uploaded by: Wyse"
+        - "Isshiki Yui and Kikuta Daisuke - Toraba! Original Sound Track [2011] :: MP3 / V0 (VBR) / CD || https://animebytes.tv/torrents2.php?id=74466&torrentid=975933 || soundtrack || Uploaded by: Julzer"
+      pattern: ^(.*)\[(\d+)\]\s?:*\s(.*)....(https.*)/torrents.*\?id=\d+&torrentid=(\d+).\|\|(.*)\|\|\sUploaded\sby:\s(.*)
+      vars:
+        - torrentName
+        - year
+        - relaseTags
+        - baseUrl
+        - torrentId
+        - tags
+        - uploader
+
+  match:
+    torrenturl: "{{ .baseUrl }}/torrent/{{ .torrentId }}/download/{{ .passkey }}"

--- a/web/src/domain/constants.ts
+++ b/web/src/domain/constants.ts
@@ -25,17 +25,22 @@ export const codecs = [
     "h265",
     "x264",
     "x265",
+    "h264 10-bit",
+    "h265 10-bit",
+    "x264 10-bit",
+    "x265 10-bit",
     "XviD"
 ];
 
 export const CODECS_OPTIONS = codecs.map(v => ({ value: v, label: v, key: v}));
 
 export const sources = [
+    "WEB-DL",
+    "BluRay",
     "BD5",
     "BD9",
     "BDr",
     "BDRip",
-    "BluRay",
     "BRRip",
     "CAM",
     "DVDR",
@@ -48,7 +53,6 @@ export const sources = [
     "HDTV",
     "Mixed",
     "SiteRip",
-    "WEB-DL",
     "Webrip"
 ];
 


### PR DESCRIPTION
what the title says, but the regex need improvement so before merging, if you guys can help me improve the regex would be much appreciated I tested it with the current one it works great but sometimes AB doesn't provide the uploader or just missing some stuff for example;
```
Ore no Nounai Sentakushi ga, Gakuen Lovecome o Zenryoku de Jama Shiteiru - OVA  [2014] :: Blu-ray / MKV / h264 10-bit / 1080p / FLAC 2.0 / Softsubs (Drag) / Freeleech || https://animebytes.tv/torrents.php?id=18491&torrentid=97215968 || comedy, harem

BanG Dream! 3rd Season - TV Series  [2020] :: Blu-ray / MKV / h265 10-bit / 1080p / FLAC 5.0 / RAW (LoliHouse) / Freeleech || https://animebytes.tv/torrents.php?id=62837&torrentid=972135926 || music || Uploaded by: redacted

Koi Kaze - TV Series  [2004] :: DVD / MKV / h264 10-bit / 712x478 / FLAC 2.0 / Dual Audio / Softsubs (WSE) || https://animebytes.tv/torrents.php?id=1115&torrentid=975213927 || coming.of.age, romance, seinen, slice.of.life, tragedy, incest || Uploaded by: randUser

Inoue Taku - ALIENS EP  [2021] :: MP3 / V0 (VBR) / CD || https://animebytes.tv/torrents2.php?id=74461&torrentid=975213928 || vocal || Uploaded by: redacted

Dungeon Meshi - Manga  [2014] :: Translated (Yen Press) / Digital / Ongoing || https://animebytes.tv/torrents.php?id=50544&torrentid=975929 || adventure, comedy, fantasy, seinen

 Barbarian on the Groove - Koi de wa naku -- It's not love, but so where near. ORIGINAL SOUNDTRACK  [2011] :: FLAC / Lossless / CD / Log / Cue || https://animebytes.tv/torrents2.php?id=74465&torrentid=975912330 || soundtrack || Uploaded by: redacted

Barbarian on the Groove - Koi de wa naku -- It's not love, but so where near. ORIGINAL SOUNDTRACK  [2011] :: MP3 / V0 (VBR) / CD || https://animebytes.tv/torrents2.php?id=74465&torrentid=975123931 || soundtrack || Uploaded by: redacted
```

Regarding the apis
```

# AB supports api but it has interesting url endpoints or urls that are not supported by this 
# Just to put few examples here:
# Site stat
# Available on: https://animebytes.tv/api/stats/{:passkey}

# Status
# Available on: https://status.animebytes.tv/api/status

# Tracker metrics
# Available on: https://tracker.animebytes.tv/{:passkey}/metrics

# scrape
# Available on: https://animebytes.tv/scrape.php?torrent_pass={:passkey}&username={:username}&type={:type[music|anime]}

# It's more AB fault usually api has one url.
````