### PR TITLE
fix(indexers): use torrentsize instead of size

### DIFF
--- a/internal/indexer/definitions/morethantv.yaml
+++ b/internal/indexer/definitions/morethantv.yaml
@@ -51,7 +51,7 @@ parse:
       pattern: '^(.*?) - Size: ([0-9]+?.*?) - Uploader: (.*?) - Tags: (.*(hd.episode|hd.season|sd.episode|sd.eason|sd.movies|hd.movie)) - (https?:\/\/.*torrents.php\?)torrentid=(.*)$'
       vars:
         - torrentName
-        - size
+        - torrentSize
         - uploader
         - tags
         - category

--- a/internal/indexer/definitions/torrentday.yaml
+++ b/internal/indexer/definitions/torrentday.yaml
@@ -52,7 +52,7 @@ parse:
         - freeleech
         - baseUrl
         - torrentId
-        - size
+        - torrentSize
 
   match:
     torrenturl: "{{ .baseUrl }}/download.php/{{ .torrentId }}/{{ .torrentName }}.torrent?torrent_pass={{ .passkey }}"

--- a/internal/indexer/definitions/torrentseeds.yaml
+++ b/internal/indexer/definitions/torrentseeds.yaml
@@ -54,7 +54,7 @@ parse:
       vars:
         - torrentName
         - category
-        - size
+        - torrentSize
         - baseUrl
         - torrentId
         - uploader


### PR DESCRIPTION
Some indexers were using the wrong var for size, and thus not matching correctly.