### PR TITLE
fix: set theme

### DIFF
--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -11,13 +11,13 @@ export const InitializeGlobalContext = () => {
         SettingsContext.set(JSON.parse(settings_ctx));
     } else {
         // Only check for light theme, otherwise dark theme is the default
-        const userMedia = window.matchMedia("(prefers-color-scheme: light)");
-        if (userMedia.matches) {
-            SettingsContext.set((state) => ({
-                ...state,
-                darkTheme: false
-            }));
-        }
+        SettingsContext.set((state) => ({
+          ...state,
+          darkTheme: !(
+            window.matchMedia !== undefined &&
+            window.matchMedia("(prefers-color-scheme: light)").matches
+          )
+        }));
     }
 }
 


### PR DESCRIPTION
Fix set theme. 

Call SettingsContext.set regardless of browsers media preference (fixes the need to double toggle to apply the dark theme).

Fixes #110 