### PR TITLE
fix: empty tmpFile var passed to download client's action

### DIFF
--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -64,6 +64,8 @@ func (s *service) runAction(action domain.Action, release domain.Release) error 
 			}
 
 			tmpFile = t.TmpFileName
+		} else {
+			tmpFile = release.TorrentTmpFile
 		}
 
 		s.execCmd(release, action, tmpFile)
@@ -77,7 +79,10 @@ func (s *service) runAction(action domain.Action, release domain.Release) error 
 			}
 
 			tmpFile = t.TmpFileName
+		} else {
+			tmpFile = release.TorrentTmpFile
 		}
+
 		s.watchFolder(action.WatchFolder, tmpFile)
 
 	case domain.ActionTypeDelugeV1, domain.ActionTypeDelugeV2:
@@ -98,7 +103,10 @@ func (s *service) runAction(action domain.Action, release domain.Release) error 
 			}
 
 			tmpFile = t.TmpFileName
+		} else {
+			tmpFile = release.TorrentTmpFile
 		}
+
 		err = s.deluge(action, tmpFile)
 		if err != nil {
 			log.Error().Stack().Err(err).Msg("error sending torrent to Deluge")
@@ -124,7 +132,10 @@ func (s *service) runAction(action domain.Action, release domain.Release) error 
 
 			tmpFile = t.TmpFileName
 			hash = t.MetaInfo.HashInfoBytes().String()
+		} else {
+			tmpFile = release.TorrentTmpFile
 		}
+
 		err = s.qbittorrent(client, action, hash, tmpFile)
 		if err != nil {
 			log.Error().Stack().Err(err).Msg("error sending torrent to qBittorrent")


### PR DESCRIPTION
Related to #119

After some debugging I figured out that when `release.TorrentTmpFile` was not empty the `tmpFile` variable would not be set. 
Resulting in sending an empty variable to the download client's action function. That ultimately resulted in a file not found error when trying to send the torrent file to the download client.

Fixed by adding an else condition setting `tmpFile` to `release.TorrentTmpFile` (when it is not empty).

Even though this only happened to me on deluge, I added the else condition to all instances where this could possibly happen.

---

edit: I've tested it by building the container and deluge is now correctly getting the torrent added