### PR TITLE
fix: indexers orpheus torrent url

### DIFF
--- a/internal/indexer/definitions/orpheus.yaml
+++ b/internal/indexer/definitions/orpheus.yaml
@@ -13,10 +13,6 @@ supports:
   - rss
 source: gazelle
 settings:
-  - name: authkey
-    type: text
-    label: Auth key
-    help: Right click DL on a torrent and get the authkey.
   - name: torrent_pass
     type: text
     label: Torrent pass
@@ -65,4 +61,4 @@ parse:
         - baseUrl
 
   match:
-    torrenturl: "{{ .baseUrl }}&authkey={{ .authkey }}&torrent_pass={{ .torrent_pass }}"
+    torrenturl: "{{ .baseUrl }}&torrent_pass={{ .torrent_pass }}"


### PR DESCRIPTION
Looks like OPS has recently made changes and does not require the `authkey` anymore, and does not even provide it anywhere. This removes the setting for `authkey` and updates the download url to not need it.