### PR TITLE
Fix: Handle download failure

### DIFF
--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -631,7 +631,7 @@ func (r *Release) DownloadTorrentFile(opts map[string]string) (*DownloadTorrentF
 
 	if resp.StatusCode != http.StatusOK {
 		log.Error().Stack().Err(err).Msgf("error downloading file from: %v - bad status: %d", r.TorrentURL, resp.StatusCode)
-		return nil, err
+		return nil, fmt.Errorf("error downloading torrent (%v) file (%v) from '%v' - status code: %d", r.TorrentName, r.TorrentURL, r.Indexer, resp.StatusCode)
 	}
 
 	// Create tmp file

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -247,7 +247,7 @@ func (s *service) FindAndCheckFilters(release *domain.Release) (bool, *domain.Fi
 					torrentFileRes, err = release.DownloadTorrentFile(nil)
 					if err != nil {
 						log.Error().Stack().Err(err).Msgf("filter-service.find_and_check_filters: (%v) could not download torrent file with id: '%v' from: %v", f.Name, release.TorrentID, release.Indexer)
-						continue
+						return false, nil, err
 					}
 
 					// parse torrent metainfo


### PR DESCRIPTION
This fixes a bug where error on downloading torrent would cause a panic because of missing data. The file downloader didn't set a new error when status was not 200, and thus returning a `nil` error which could not be handled by the caller.