### PR TITLE
fix: pin react-ridge-state

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
     "react-hot-toast": "^2.1.1",
     "react-multi-select-component": "^4.0.2",
     "react-query": "^3.18.1",
-    "react-ridge-state": "^4.2.2",
+    "react-ridge-state": "4.2.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^5.0.0",
     "react-select": "5.0.0-beta.0",


### PR DESCRIPTION
Breaking changes in `react-ridge-state` `4.2.4` so lets pin `4.2.2` until it's fixed.

Related issue: https://github.com/web-ridge/react-ridge-state/issues/26