### PR TITLE
feat(indexers): definitions set forcesizeunit

### DIFF
--- a/internal/announce/announce.go
+++ b/internal/announce/announce.go
@@ -217,7 +217,7 @@ func (a *announceProcessor) parseExtract(pattern string, vars []string, tmpVars 
 func (a *announceProcessor) onLinesMatched(def domain.IndexerDefinition, vars map[string]string, release *domain.Release) error {
 	var err error
 
-	err = release.MapVars(vars)
+	err = release.MapVars(def, vars)
 	if err != nil {
 		log.Error().Stack().Err(err).Msg("announce: could not map vars for release")
 		return err

--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -91,9 +91,10 @@ func (i IndexerIRC) ValidChannel(channel string) bool {
 }
 
 type IndexerParse struct {
-	Type  string                `json:"type"`
-	Lines []IndexerParseExtract `json:"lines"`
-	Match IndexerParseMatch     `json:"match"`
+	Type          string                `json:"type"`
+	Lines         []IndexerParseExtract `json:"lines"`
+	Match         IndexerParseMatch     `json:"match"`
+	ForceSizeUnit string                `json:"forceSizeUnit"`
 }
 
 type IndexerParseExtract struct {

--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -92,9 +92,9 @@ func (i IndexerIRC) ValidChannel(channel string) bool {
 
 type IndexerParse struct {
 	Type          string                `json:"type"`
+	ForceSizeUnit string                `json:"forcesizeunit"`
 	Lines         []IndexerParseExtract `json:"lines"`
 	Match         IndexerParseMatch     `json:"match"`
-	ForceSizeUnit string                `json:"forceSizeUnit"`
 }
 
 type IndexerParseExtract struct {

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -918,7 +918,7 @@ func (r *Release) CheckSizeFilter(minSize string, maxSize string) bool {
 }
 
 // MapVars better name
-func (r *Release) MapVars(varMap map[string]string) error {
+func (r *Release) MapVars(def IndexerDefinition, varMap map[string]string) error {
 
 	if torrentName, err := getStringMapValue(varMap, "torrentName"); err != nil {
 		return errors.Wrap(err, "failed parsing required field")
@@ -956,12 +956,16 @@ func (r *Release) MapVars(varMap map[string]string) error {
 	}
 
 	if torrentSize, err := getStringMapValue(varMap, "torrentSize"); err == nil {
+		// handling for indexer who doesn't explicitly set which size unit is used like (AR)
+		if def.Parse.ForceSizeUnit != "" {
+			torrentSize = fmt.Sprintf("%v %v", torrentSize, def.Parse.ForceSizeUnit)
+		}
+
 		size, err := humanize.ParseBytes(torrentSize)
 		if err != nil {
 			// log could not parse into bytes
 		}
 		r.Size = size
-		// TODO implement other size checks in filter
 	}
 
 	if scene, err := getStringMapValue(varMap, "scene"); err == nil {

--- a/internal/domain/release_test.go
+++ b/internal/domain/release_test.go
@@ -1258,7 +1258,8 @@ func TestRelease_CheckFilter(t *testing.T) {
 
 func TestRelease_MapVars(t *testing.T) {
 	type args struct {
-		varMap map[string]string
+		varMap     map[string]string
+		definition IndexerDefinition
 	}
 	tests := []struct {
 		name   string
@@ -1394,11 +1395,36 @@ func TestRelease_MapVars(t *testing.T) {
 				"tags":             "hip.hop,rhythm.and.blues, 2000s",
 			}},
 		},
+		{
+			name:   "8",
+			fields: &Release{},
+			want: &Release{
+				TorrentName:      "Good show S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-GROUP2",
+				Category:         "tv",
+				Year:             2020,
+				FreeleechPercent: 100,
+				Uploader:         "Anon",
+				Size:             uint64(10000000000),
+				Tags:             []string{"hip.hop", "rhythm.and.blues", "2000s"},
+			},
+			args: args{
+				varMap: map[string]string{
+					"torrentName":      "Good show S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-GROUP2",
+					"category":         "tv",
+					"year":             "2020",
+					"freeleechPercent": "100%",
+					"uploader":         "Anon",
+					"torrentSize":      "10000",
+					"tags":             "hip.hop,rhythm.and.blues, 2000s",
+				},
+				definition: IndexerDefinition{Parse: IndexerParse{ForceSizeUnit: "MB"}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := tt.fields
-			_ = r.MapVars(tt.args.varMap)
+			_ = r.MapVars(tt.args.definition, tt.args.varMap)
 
 			assert.Equal(t, tt.want, r)
 		})

--- a/internal/indexer/definitions/alpharatio.yaml
+++ b/internal/indexer/definitions/alpharatio.yaml
@@ -51,7 +51,7 @@ irc:
 
 parse:
   type: multi
-  forceSizeUnit: MB
+  forcesizeunit: MB
   lines:
     - test:
         - "[New Release]-[MovieHD]-[That.Movie.2017.INTERNAL.1080p.BluRay.CRF.x264-GROUP]-[URL]-[ https://alpharatio.cc/torrents.php?id=000000 ]-[ 000000 ]-[ Uploaded 2 Mins, 59 Secs after pre. ]"

--- a/internal/indexer/definitions/alpharatio.yaml
+++ b/internal/indexer/definitions/alpharatio.yaml
@@ -51,6 +51,7 @@ irc:
 
 parse:
   type: multi
+  forceSizeUnit: MB
   lines:
     - test:
         - "[New Release]-[MovieHD]-[That.Movie.2017.INTERNAL.1080p.BluRay.CRF.x264-GROUP]-[URL]-[ https://alpharatio.cc/torrents.php?id=000000 ]-[ 000000 ]-[ Uploaded 2 Mins, 59 Secs after pre. ]"


### PR DESCRIPTION
This PR add support to force set what size unit to be used. 

## Why?

AR does not specify a size unit in the announce, but it's always sent as megabytes (MB) so this adds support to set what unit should be used.