### PR TITLE
feat(actions): add more macro variables

### DIFF
--- a/internal/action/deluge.go
+++ b/internal/action/deluge.go
@@ -164,21 +164,21 @@ func delugeV1(client *domain.DownloadClient, settings delugeClient.Settings, act
 	// set options
 	options := delugeClient.Options{}
 
+	// macros handle args and replace vars
+	m := NewMacro(release)
+
 	if action.Paused {
 		options.AddPaused = &action.Paused
 	}
 	if action.SavePath != "" {
-		// handle args and replace vars
-		m := NewMacro(release)
-
 		// parse and replace values in argument string before continuing
-		savepathArgs, err := m.Parse(action.SavePath)
+		savePathArgs, err := m.Parse(action.SavePath)
 		if err != nil {
 			log.Error().Stack().Err(err).Msgf("could not parse macro: %v", action.SavePath)
 			return err
 		}
 
-		options.DownloadLocation = &savepathArgs
+		options.DownloadLocation = &savePathArgs
 	}
 	if action.LimitDownloadSpeed > 0 {
 		maxDL := int(action.LimitDownloadSpeed)
@@ -203,9 +203,6 @@ func delugeV1(client *domain.DownloadClient, settings delugeClient.Settings, act
 			log.Error().Stack().Err(err).Msgf("could not load label plugin: %v", client.Name)
 			return err
 		}
-
-		// handle args and replace vars
-		m := NewMacro(release)
 
 		// parse and replace values in argument string before continuing
 		labelArgs, err := m.Parse(action.Label)
@@ -258,13 +255,13 @@ func delugeV2(client *domain.DownloadClient, settings delugeClient.Settings, act
 	// set options
 	options := delugeClient.Options{}
 
+	// macros handle args and replace vars
+	m := NewMacro(release)
+
 	if action.Paused {
 		options.AddPaused = &action.Paused
 	}
 	if action.SavePath != "" {
-		// handle args and replace vars
-		m := NewMacro(release)
-
 		// parse and replace values in argument string before continuing
 		savePathArgs, err := m.Parse(action.SavePath)
 		if err != nil {
@@ -297,9 +294,6 @@ func delugeV2(client *domain.DownloadClient, settings delugeClient.Settings, act
 			log.Error().Stack().Err(err).Msgf("could not load label plugin: %v", client.Name)
 			return err
 		}
-
-		// handle args and replace vars
-		m := NewMacro(release)
 
 		// parse and replace values in argument string before continuing
 		labelArgs, err := m.Parse(action.Label)

--- a/internal/action/exec.go
+++ b/internal/action/exec.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (s *service) execCmd(release domain.Release, action domain.Action, torrentFile string) {
+func (s *service) execCmd(release domain.Release, action domain.Action) {
 	log.Debug().Msgf("action exec: %v release: %v", action.Name, release.TorrentName)
 
 	// check if program exists
@@ -21,11 +21,7 @@ func (s *service) execCmd(release domain.Release, action domain.Action, torrentF
 	}
 
 	// handle args and replace vars
-	m := Macro{
-		TorrentName:     release.TorrentName,
-		TorrentPathName: torrentFile,
-		TorrentUrl:      release.TorrentURL,
-	}
+	m := NewMacro(release)
 
 	// parse and replace values in argument string before continuing
 	parsedArgs, err := m.Parse(action.ExecArgs)
@@ -46,7 +42,7 @@ func (s *service) execCmd(release domain.Release, action domain.Action, torrentF
 	output, err := command.CombinedOutput()
 	if err != nil {
 		// everything other than exit 0 is considered an error
-		log.Error().Stack().Err(err).Msgf("command: %v args: %v failed, torrent: %v", cmd, parsedArgs, torrentFile)
+		log.Error().Stack().Err(err).Msgf("command: %v args: %v failed, torrent: %v", cmd, parsedArgs, release.TorrentTmpFile)
 	}
 
 	log.Trace().Msgf("executed command: '%v'", string(output))

--- a/internal/action/macros.go
+++ b/internal/action/macros.go
@@ -3,12 +3,43 @@ package action
 import (
 	"bytes"
 	"text/template"
+	"time"
+
+	"github.com/autobrr/autobrr/internal/domain"
 )
 
 type Macro struct {
 	TorrentName     string
 	TorrentPathName string
+	TorrentHash     string
 	TorrentUrl      string
+	Indexer         string
+	Year            int
+	Month           int
+	Day             int
+	Hour            int
+	Minute          int
+	Second          int
+}
+
+func NewMacro(release domain.Release) Macro {
+	currentTime := time.Now()
+
+	ma := Macro{
+		TorrentName:     release.TorrentName,
+		TorrentUrl:      release.TorrentURL,
+		TorrentPathName: release.TorrentTmpFile,
+		TorrentHash:     release.TorrentHash,
+		Indexer:         release.Indexer,
+		Year:            currentTime.Year(),
+		Month:           int(currentTime.Month()),
+		Day:             currentTime.Day(),
+		Hour:            currentTime.Hour(),
+		Minute:          currentTime.Minute(),
+		Second:          currentTime.Second(),
+	}
+
+	return ma
 }
 
 // Parse takes a string and replaces valid vars

--- a/internal/action/macros.go
+++ b/internal/action/macros.go
@@ -14,6 +14,11 @@ type Macro struct {
 	TorrentHash     string
 	TorrentUrl      string
 	Indexer         string
+	Resolution      string
+	Source          string
+	HDR             string
+	Season          int
+	Episode         int
 	Year            int
 	Month           int
 	Day             int
@@ -31,6 +36,11 @@ func NewMacro(release domain.Release) Macro {
 		TorrentPathName: release.TorrentTmpFile,
 		TorrentHash:     release.TorrentHash,
 		Indexer:         release.Indexer,
+		Resolution:      release.Resolution,
+		Source:          release.Source,
+		HDR:             release.HDR,
+		Season:          release.Season,
+		Episode:         release.Episode,
 		Year:            currentTime.Year(),
 		Month:           int(currentTime.Month()),
 		Day:             currentTime.Day(),

--- a/internal/action/macros_test.go
+++ b/internal/action/macros_test.go
@@ -126,6 +126,32 @@ func TestMacros_Parse(t *testing.T) {
 			want:    fmt.Sprintf("mock1-%v-race", currentTime.Year()),
 			wantErr: false,
 		},
+		{
+			name: "test_args_category_year",
+			release: domain.Release{
+				TorrentName: "This movie 2021",
+				TorrentURL:  "https://some.site/download/fakeid",
+				Indexer:     "mock1",
+				Resolution:  "2160p",
+				HDR:         "DV",
+			},
+			args:    args{text: "movies-{{.Resolution}}{{ if .HDR }}-{{.HDR}}{{ end }}"},
+			want:    "movies-2160p-DV",
+			wantErr: false,
+		},
+		{
+			name: "test_args_category_and_if",
+			release: domain.Release{
+				TorrentName: "This movie 2021",
+				TorrentURL:  "https://some.site/download/fakeid",
+				Indexer:     "mock1",
+				Resolution:  "2160p",
+				HDR:         "HDR",
+			},
+			args:    args{text: "movies-{{.Resolution}}{{ if .HDR }}-{{.HDR}}{{ end }}"},
+			want:    "movies-2160p-HDR",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -138,9 +164,7 @@ func TestMacros_Parse(t *testing.T) {
 				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("Parse() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/action/macros_test.go
+++ b/internal/action/macros_test.go
@@ -1,14 +1,21 @@
 package action
 
 import (
+	"fmt"
+	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestMacros_Parse(t *testing.T) {
+	currentTime := time.Now()
+
 	type fields struct {
 		TorrentName     string
 		TorrentPathName string
 		TorrentUrl      string
+		Indexer         string
 	}
 	type args struct {
 		text string
@@ -16,43 +23,60 @@ func TestMacros_Parse(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
+		release domain.Release
 		args    args
 		want    string
 		wantErr bool
 	}{
 		{
-			name:    "test_ok",
-			fields:  fields{TorrentPathName: "/tmp/a-temporary-file.torrent"},
+			name: "test_ok",
+			release: domain.Release{
+				TorrentName:    "This movie 2021",
+				TorrentTmpFile: "/tmp/a-temporary-file.torrent",
+				Indexer:        "mock1",
+			},
 			args:    args{text: "Print mee {{.TorrentPathName}}"},
 			want:    "Print mee /tmp/a-temporary-file.torrent",
 			wantErr: false,
 		},
 		{
-			name:    "test_bad",
-			fields:  fields{TorrentPathName: "/tmp/a-temporary-file.torrent"},
+			name: "test_bad",
+			release: domain.Release{
+				TorrentName:    "This movie 2021",
+				TorrentTmpFile: "/tmp/a-temporary-file.torrent",
+				Indexer:        "mock1",
+			},
 			args:    args{text: "Print mee {{TorrentPathName}}"},
 			want:    "",
 			wantErr: true,
 		},
 		{
-			name:    "test_program_arg",
-			fields:  fields{TorrentPathName: "/tmp/a-temporary-file.torrent"},
+			name: "test_program_arg",
+			release: domain.Release{
+				TorrentName:    "This movie 2021",
+				TorrentTmpFile: "/tmp/a-temporary-file.torrent",
+				Indexer:        "mock1",
+			},
 			args:    args{text: "add {{.TorrentPathName}} --category test"},
 			want:    "add /tmp/a-temporary-file.torrent --category test",
 			wantErr: false,
 		},
 		{
-			name:    "test_program_arg_bad",
-			fields:  fields{TorrentPathName: "/tmp/a-temporary-file.torrent"},
+			name: "test_program_arg_bad",
+			release: domain.Release{
+				TorrentTmpFile: "/tmp/a-temporary-file.torrent",
+				Indexer:        "mock1",
+			},
 			args:    args{text: "add {{.TorrenttPathName}} --category test"},
 			want:    "",
 			wantErr: true,
 		},
 		{
 			name: "test_program_arg",
-			fields: fields{
-				TorrentName:     "This movie 2021",
-				TorrentPathName: "/tmp/a-temporary-file.torrent",
+			release: domain.Release{
+				TorrentName:    "This movie 2021",
+				TorrentTmpFile: "/tmp/a-temporary-file.torrent",
+				Indexer:        "mock1",
 			},
 			args:    args{text: "add {{.TorrentPathName}} --category test --other {{.TorrentName}}"},
 			want:    "add /tmp/a-temporary-file.torrent --category test --other This movie 2021",
@@ -60,23 +84,55 @@ func TestMacros_Parse(t *testing.T) {
 		},
 		{
 			name: "test_args_long",
-			fields: fields{
+			release: domain.Release{
 				TorrentName: "This movie 2021",
-				TorrentUrl:  "https://some.site/download/fakeid",
+				TorrentURL:  "https://some.site/download/fakeid",
+				Indexer:     "mock1",
 			},
 			args:    args{text: "{{.TorrentName}} {{.TorrentUrl}} SOME_LONG_TOKEN"},
 			want:    "This movie 2021 https://some.site/download/fakeid SOME_LONG_TOKEN",
 			wantErr: false,
 		},
+		{
+			name: "test_args_long_1",
+			release: domain.Release{
+				TorrentName: "This movie 2021",
+				TorrentURL:  "https://some.site/download/fakeid",
+				Indexer:     "mock1",
+			},
+			args:    args{text: "{{.Indexer}} {{.TorrentName}} {{.TorrentUrl}} SOME_LONG_TOKEN"},
+			want:    "mock1 This movie 2021 https://some.site/download/fakeid SOME_LONG_TOKEN",
+			wantErr: false,
+		},
+		{
+			name: "test_args_category",
+			release: domain.Release{
+				TorrentName: "This movie 2021",
+				TorrentURL:  "https://some.site/download/fakeid",
+				Indexer:     "mock1",
+			},
+			args:    args{text: "{{.Indexer}}-race"},
+			want:    "mock1-race",
+			wantErr: false,
+		},
+		{
+			name: "test_args_category_year",
+			release: domain.Release{
+				TorrentName: "This movie 2021",
+				TorrentURL:  "https://some.site/download/fakeid",
+				Indexer:     "mock1",
+			},
+			args:    args{text: "{{.Indexer}}-{{.Year}}-race"},
+			want:    fmt.Sprintf("mock1-%v-race", currentTime.Year()),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := Macro{
-				TorrentPathName: tt.fields.TorrentPathName,
-				TorrentUrl:      tt.fields.TorrentUrl,
-				TorrentName:     tt.fields.TorrentName,
-			}
+			m := NewMacro(tt.release)
 			got, err := m.Parse(tt.args.text)
+
+			assert.Equal(t, currentTime.Year(), m.Year)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/action/qbittorrent.go
+++ b/internal/action/qbittorrent.go
@@ -17,15 +17,15 @@ const ReannounceInterval = 7000
 func (s *service) qbittorrent(qbt *qbittorrent.Client, action domain.Action, release domain.Release) error {
 	log.Debug().Msgf("action qBittorrent: %v", action.Name)
 
+	// macros handle args and replace vars
+	m := NewMacro(release)
+
 	options := map[string]string{}
 
 	if action.Paused {
 		options["paused"] = "true"
 	}
 	if action.SavePath != "" {
-		// handle args and replace vars
-		m := NewMacro(release)
-
 		// parse and replace values in argument string before continuing
 		actionArgs, err := m.Parse(action.SavePath)
 		if err != nil {
@@ -37,9 +37,6 @@ func (s *service) qbittorrent(qbt *qbittorrent.Client, action domain.Action, rel
 		options["autoTMM"] = "false"
 	}
 	if action.Category != "" {
-		// handle args and replace vars
-		m := NewMacro(release)
-
 		// parse and replace values in argument string before continuing
 		categoryArgs, err := m.Parse(action.Category)
 		if err != nil {
@@ -50,9 +47,6 @@ func (s *service) qbittorrent(qbt *qbittorrent.Client, action domain.Action, rel
 		options["category"] = categoryArgs
 	}
 	if action.Tags != "" {
-		// handle args and replace vars
-		m := NewMacro(release)
-
 		// parse and replace values in argument string before continuing
 		tagsArgs, err := m.Parse(action.Tags)
 		if err != nil {

--- a/internal/action/qbittorrent.go
+++ b/internal/action/qbittorrent.go
@@ -5,15 +5,16 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/qbittorrent"
-	"github.com/rs/zerolog/log"
 )
 
 const ReannounceMaxAttempts = 50
 const ReannounceInterval = 7000
 
-func (s *service) qbittorrent(qbt *qbittorrent.Client, action domain.Action, torrentFile string, hash string) error {
+func (s *service) qbittorrent(qbt *qbittorrent.Client, action domain.Action, release domain.Release) error {
 	log.Debug().Msgf("action qBittorrent: %v", action.Name)
 
 	options := map[string]string{}
@@ -22,14 +23,44 @@ func (s *service) qbittorrent(qbt *qbittorrent.Client, action domain.Action, tor
 		options["paused"] = "true"
 	}
 	if action.SavePath != "" {
-		options["savepath"] = action.SavePath
+		// handle args and replace vars
+		m := NewMacro(release)
+
+		// parse and replace values in argument string before continuing
+		actionArgs, err := m.Parse(action.SavePath)
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("could not parse macro: %v", action.SavePath)
+			return err
+		}
+
+		options["savepath"] = actionArgs
 		options["autoTMM"] = "false"
 	}
 	if action.Category != "" {
-		options["category"] = action.Category
+		// handle args and replace vars
+		m := NewMacro(release)
+
+		// parse and replace values in argument string before continuing
+		categoryArgs, err := m.Parse(action.Category)
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("could not parse macro: %v", action.Category)
+			return err
+		}
+
+		options["category"] = categoryArgs
 	}
 	if action.Tags != "" {
-		options["tags"] = action.Tags
+		// handle args and replace vars
+		m := NewMacro(release)
+
+		// parse and replace values in argument string before continuing
+		tagsArgs, err := m.Parse(action.Tags)
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("could not parse macro: %v", action.Tags)
+			return err
+		}
+
+		options["tags"] = tagsArgs
 	}
 	if action.LimitUploadSpeed > 0 {
 		options["upLimit"] = strconv.FormatInt(action.LimitUploadSpeed, 10)
@@ -40,21 +71,21 @@ func (s *service) qbittorrent(qbt *qbittorrent.Client, action domain.Action, tor
 
 	log.Trace().Msgf("action qBittorrent options: %+v", options)
 
-	err := qbt.AddTorrentFromFile(torrentFile, options)
+	err := qbt.AddTorrentFromFile(release.TorrentTmpFile, options)
 	if err != nil {
-		log.Error().Stack().Err(err).Msgf("could not add torrent %v to client: %v", torrentFile, qbt.Name)
+		log.Error().Stack().Err(err).Msgf("could not add torrent %v to client: %v", release.TorrentTmpFile, qbt.Name)
 		return err
 	}
 
-	if !action.Paused && hash != "" {
-		err = checkTrackerStatus(qbt, hash)
+	if !action.Paused && release.TorrentHash != "" {
+		err = checkTrackerStatus(qbt, release.TorrentHash)
 		if err != nil {
-			log.Error().Stack().Err(err).Msgf("could not reannounce torrent: %v", hash)
+			log.Error().Stack().Err(err).Msgf("could not reannounce torrent: %v", release.TorrentHash)
 			return err
 		}
 	}
 
-	log.Info().Msgf("torrent with hash %v successfully added to client: '%v'", hash, qbt.Name)
+	log.Info().Msgf("torrent with hash %v successfully added to client: '%v'", release.TorrentHash, qbt.Name)
 
 	return nil
 }


### PR DESCRIPTION
Add more variables to be used in fields for actions, and make them usable in more fields.

New variables:
* Indexer `{{.Indexer}}`
* TorrentHash `{{.TorrentHash}}`
* Resolution `{{.Resolution}}`
* Source `{{.Source}}`
* HDR `{{.HDR}}`
* Season `{{.Season}}`
* Episode `{{.Episode}}`
* Year `{{.Year}}`
* Month `{{.Month}}`
* Day `{{.Day}}`
* Hour `{{.Hour}}`
* Minute `{{.Minute}}`
* Second `{{.Second}}`

And usable in the action fields for:
* Watch folder
* Label
* Tags
* Category
* Save Path

Related issue #147 