### PR TITLE
feat(filters): add priority

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -68,6 +68,7 @@ CREATE TABLE filter
     min_size              TEXT,
     max_size              TEXT,
     delay                 INTEGER,
+    priority              INTEGER DEFAULT 0 NOT NULL,
     match_releases        TEXT,
     except_releases       TEXT,
     use_regex             BOOLEAN,
@@ -339,6 +340,10 @@ var migrations = []string{
 	`
 	ALTER TABLE "filter"
 		ADD COLUMN media TEXT []   DEFAULT '{}';
+	`,
+	`
+	ALTER TABLE "filter"
+		ADD COLUMN priority INTEGER DEFAULT 0 NOT NULL;
 	`,
 }
 

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -32,6 +32,7 @@ type Filter struct {
 	MinSize             string    `json:"min_size"`
 	MaxSize             string    `json:"max_size"`
 	Delay               int       `json:"delay"`
+	Priority            int32     `json:"priority"`
 	MatchReleases       string    `json:"match_releases"`
 	ExceptReleases      string    `json:"except_releases"`
 	UseRegex            bool      `json:"use_regex"`

--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -245,6 +245,7 @@ export default function FilterDetails() {
                                         min_size: filter.min_size,
                                         max_size: filter.max_size,
                                         delay: filter.delay,
+                                        priority: filter.priority,
                                         shows: filter.shows,
                                         years: filter.years,
                                         resolutions: filter.resolutions || [],
@@ -359,6 +360,7 @@ function General() {
                     <TextField name="min_size" label="Min size" columns={6} placeholder="" />
                     <TextField name="max_size" label="Max size" columns={6} placeholder="" />
                     <NumberField name="delay" label="Delay" placeholder="" />
+                    <NumberField name="priority" label="Priority" placeholder="" />
                 </div>
             </div>
 

--- a/web/src/types/Filter.d.ts
+++ b/web/src/types/Filter.d.ts
@@ -7,6 +7,7 @@ interface Filter {
   min_size: string;
   max_size: string;
   delay: number;
+  priority: number;
   match_releases: string;
   except_releases: string;
   use_regex: boolean;


### PR DESCRIPTION
Add support for priority on filters.

When making the filter check it will fetch filters and order and run them by `priority`, highest to lowest.

Supports positive and negative numbers. Default `priority` is set to `0`.