### PR TITLE
docker: Add curl to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV HOME="/config" \
 XDG_CONFIG_HOME="/config" \
 XDG_DATA_HOME="/config"
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates curl
 
 WORKDIR /app
 


### PR DESCRIPTION
cURL is a very useful utility to have in the image - I'm using it with exec to notify other applications of the event.