### PR TITLE
Indexer: Adding Torrent-Syndikat

### DIFF
--- a/internal/indexer/definitions/torrentsyndikat.yaml
+++ b/internal/indexer/definitions/torrentsyndikat.yaml
@@ -1,0 +1,65 @@
+---
+#id: torrentsyndikat
+name: TorrentSyndikat
+identifier: tsyndikat
+description: TorrentSyndikat (TS) is a private german torrent tracker.
+language: de-DE
+urls:
+  - https://torrent-syndikat.org/
+privacy: private
+protocol: torrent
+supports:
+  - irc
+  - rss
+source: unknown
+settings:
+  - name: api_key
+    type: secret
+    label: Api-Key
+    help: "Generate an apikey with download scope and copy it. Profileinstellungen -> API-Keys -> API-Key erzeugen"
+
+irc:
+  network: TorrentSyndikat
+  server: irc.torrent-syndikat.org
+  port: 6697
+  tls: true
+  channels:
+    - "#ts-announce"
+  announcers:
+    - Synd1c4t3
+  settings:
+    - name: nickserv.account
+      type: text
+      required: true
+      label: NickServ Account
+      help: NickServ account. Make sure to group your user and bot. Eg. user-bot
+    - name: nickserv.password
+      type: secret
+      required: false
+      label: NickServ Password
+      help: NickServ password
+    - name: invite_command
+      type: secret
+      default: "Synd1c4t3 invite IRCKEY"
+      required: true
+      label: Invite command
+      help: Invite auth with Synd1c4t3. Replace IRCKEY
+
+parse:
+  type: single
+  lines:
+    - test:
+        - "NEU Welcome.to.the.N.H.K.S01E15.German.DL.AC3.720p.BluRay.x264-ABJ [Serien/720p] [P2P] [678.68 MB] -- https://torrent-syndikat.org/details.php?id=000000 | Animation, Anime, Comedy, Drama, Romance, Thriller, Encode, AVC, DL, PID:00000, tt0857297"
+        - "NEU KLIM_Beats-FireFlies-WEB-2016-KNOWN [Audio/Musik/MP3] [O-SCENE] [59.82 MB] -- https://torrent-syndikat.org/details.php?id=000000 | Hip-Hop"
+        - "NEU DarkSpar-DARKZER0 [Spiele/Windows] [O-SCENE] [54.46 MB] -- https://torrent-syndikat.org/details.php?id=000000 | "
+      pattern: '^NEU (.*) \[(.*)\] \[(.*)\] \[(.*)\] -- (https?\:\/\/[^\/]+)\/.*\?id=(\d+) \| (.*)'
+      vars:
+        - torrentName
+        - category
+        - origin
+        - torrentSize
+        - baseUrl
+        - torrentId
+        - releaseTags
+  match:
+    torrenturl: "{{ .baseUrl }}/download.php?id={{ .torrentId }}&apikey={{ .api_key }}"


### PR DESCRIPTION
Tested it for a while. Should work now.

I used origin to mark the release source. (P2P, SCENE, O-SCENE)
Scene is for unpacked Scene Releases and O-Scene for untouched Scene Releases.