### PR TITLE
qBittorrent: add resume, recheck, and forceStart

### DIFF
--- a/pkg/qbittorrent/domain.go
+++ b/pkg/qbittorrent/domain.go
@@ -109,7 +109,7 @@ const (
 	TorrentStateCheckingDl TorrentState = "checkingDL"
 
 	// Torrent is forced to downloading to ignore queue limit
-	TorrentStateForceDl TorrentState = "forceDL"
+	TorrentStateForcedDl TorrentState = "forcedDL"
 
 	// Checking resume data on qBt startup
 	TorrentStateCheckingResumeData TorrentState = "checkingResumeData"

--- a/pkg/qbittorrent/go.mod
+++ b/pkg/qbittorrent/go.mod
@@ -1,0 +1,2 @@
+module qbittorrent
+go 1.17

--- a/pkg/qbittorrent/methods.go
+++ b/pkg/qbittorrent/methods.go
@@ -286,3 +286,74 @@ func (c *Client) GetTransferInfo() (*TransferInfo, error) {
 
 	return &info, nil
 }
+
+func (c *Client) Resume(hashes []string) error {
+	v := url.Values{}
+
+	// Add hashes together with | separator
+	hv := strings.Join(hashes, "|")
+	v.Add("hashes", hv)
+
+	encodedHashes := v.Encode()
+
+	resp, err := c.get("torrents/resume?"+encodedHashes, nil)
+	if err != nil {
+		log.Error().Err(err).Msgf("resume error: %v", hashes)
+		return err
+	} else if resp.StatusCode != http.StatusOK {
+		log.Error().Err(err).Msgf("resume error bad status: %v", hashes)
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func (c *Client) SetForceStart(hashes []string, value bool) error {
+	v := url.Values{}
+
+	// Add hashes together with | separator
+	hv := strings.Join(hashes, "|")
+	v.Add("hashes", hv)
+	v.Add("value", strconv.FormatBool(value))
+
+	encodedHashes := v.Encode()
+
+	resp, err := c.get("torrents/setForceStart?"+encodedHashes, nil)
+	if err != nil {
+		log.Error().Err(err).Msgf("resume error: %v", hashes)
+		return err
+	} else if resp.StatusCode != http.StatusOK {
+		log.Error().Err(err).Msgf("resume error bad status: %v", hashes)
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func (c *Client) Recheck(hashes []string) error {
+	v := url.Values{}
+
+	// Add hashes together with | separator
+	hv := strings.Join(hashes, "|")
+	v.Add("hashes", hv)
+
+	encodedHashes := v.Encode()
+
+	resp, err := c.get("torrents/recheck?"+encodedHashes, nil)
+	if err != nil {
+		log.Error().Err(err).Msgf("recheck error: %v", hashes)
+		return err
+	} else if resp.StatusCode != http.StatusOK {
+		log.Error().Err(err).Msgf("recheck error bad status: %v", hashes)
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	return nil
+}
+


### PR DESCRIPTION
I didn't realize you already put in all this work to create golang bindings for qBittorrent - this alone is immense value (beyond thankful for you sharing all this). I've added three methods that I'm interested in to fix stalls, and other nuances.

Outside of these additions, there was a typo on forceDL which breaks the stable API. Based on the fact this didn't work with TorrentState, the hope is there were no consumers of this.