### PR TITLE
fix(indexers): only load definitions with .yaml ext

### DIFF
--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -318,27 +318,30 @@ func (s *service) LoadIndexerDefinitions() error {
 	}
 
 	for _, f := range entries {
-		filePath := "definitions/" + f.Name()
-
-		if strings.Contains(f.Name(), ".yaml") {
-			log.Trace().Msgf("parsing: %v", filePath)
-
-			var d domain.IndexerDefinition
-
-			data, err := fs.ReadFile(Definitions, filePath)
-			if err != nil {
-				log.Error().Stack().Err(err).Msgf("failed reading file: %v", filePath)
-				return err
-			}
-
-			err = yaml.Unmarshal(data, &d)
-			if err != nil {
-				log.Error().Stack().Err(err).Msgf("failed unmarshal file: %v", filePath)
-				return err
-			}
-
-			s.indexerDefinitions[d.Identifier] = d
+		fileExtension := filepath.Ext(f.Name())
+		if fileExtension != ".yaml" {
+			continue
 		}
+
+		file := "definitions/" + f.Name()
+
+		log.Trace().Msgf("parsing: %v", file)
+
+		var d domain.IndexerDefinition
+
+		data, err := fs.ReadFile(Definitions, file)
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("failed reading file: %v", file)
+			return err
+		}
+
+		err = yaml.Unmarshal(data, &d)
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("failed unmarshal file: %v", file)
+			return err
+		}
+
+		s.indexerDefinitions[d.Identifier] = d
 	}
 
 	log.Debug().Msgf("Loaded %d indexer definitions", len(s.indexerDefinitions))
@@ -368,30 +371,33 @@ func (s *service) LoadCustomIndexerDefinitions() error {
 	customCount := 0
 
 	for _, f := range entries {
+		fileExtension := filepath.Ext(f.Name())
+		if fileExtension != ".yaml" {
+			continue
+		}
+
 		file := filepath.Join(s.config.CustomDefinitions, f.Name())
 
-		if strings.Contains(f.Name(), ".yaml") {
-			log.Trace().Msgf("parsing custom: %v", file)
+		log.Trace().Msgf("parsing custom: %v", file)
 
-			var d domain.IndexerDefinition
+		var d domain.IndexerDefinition
 
-			//data, err := fs.ReadFile(Definitions, filePath)
-			data, err := os.ReadFile(file)
-			if err != nil {
-				log.Error().Stack().Err(err).Msgf("failed reading file: %v", file)
-				return err
-			}
-
-			err = yaml.Unmarshal(data, &d)
-			if err != nil {
-				log.Error().Stack().Err(err).Msgf("failed unmarshal file: %v", file)
-				return err
-			}
-
-			s.indexerDefinitions[d.Identifier] = d
-
-			customCount++
+		//data, err := fs.ReadFile(Definitions, filePath)
+		data, err := os.ReadFile(file)
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("failed reading file: %v", file)
+			return err
 		}
+
+		err = yaml.Unmarshal(data, &d)
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("failed unmarshal file: %v", file)
+			return err
+		}
+
+		s.indexerDefinitions[d.Identifier] = d
+
+		customCount++
 	}
 
 	log.Debug().Msgf("Loaded %d custom indexer definitions", customCount)


### PR DESCRIPTION
Background:

> 
> Currently autobrr loads all custom indexer definition files which contain the string .yaml from a given input directory. See https://github.com/autobrr/autobrr/commit/2d643af05dc3ecb07aa4f75594f803e4811b51f8#diff-9c51825dc11242e2fc4fbd0a973487828c090200ff21d88b605bf07c3144623eR373
> 
> The problem with this is that some people may end up experimenting and creating a backup file, say, test.yaml.bak which certainly shouldn't be loaded. Rather, just check if the file ends with .yaml (i.e. use HasSuffix or an equivalent function).

Fixes #187 