### PR TITLE
feat: change default port

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,9 +8,9 @@ host = "127.0.0.1"
 
 # Port
 #
-# Default: 8989
+# Default: 7474
 #
-port = 8989
+port = 7474
 
 # Base url
 # Set custom baseUrl eg /autobrr/ to serve in subdirectory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,5 @@ services:
     volumes:
       - ./config:/config
     ports:
-      - 8989:8989
+      - "7474:7474"
     restart: unless-stopped

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ var Config domain.Config
 func Defaults() domain.Config {
 	return domain.Config{
 		Host:              "localhost",
-		Port:              8989,
+		Port:              7474,
 		LogLevel:          "TRACE",
 		LogPath:           "",
 		BaseURL:           "/",
@@ -59,9 +59,9 @@ host = "127.0.0.1"
 
 # Port
 #
-# Default: 8989
+# Default: 7474
 #
-port = 8989
+port = 7474
 
 # Base url
 # Set custom baseUrl eg /autobrr/ to serve in subdirectory.

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://127.0.0.1:8989",
+  "proxy": "http://127.0.0.1:7474",
   "homepage": ".",
   "dependencies": {
     "@fontsource/inter": "^4.5.4",

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -26,7 +26,7 @@ export function baseUrl() {
 // get sseBaseUrl for SSE
 export function sseBaseUrl() {
     if (process.env.NODE_ENV === "development")
-        return `http://localhost:8989/`;
+        return `http://localhost:7474/`;
 
     return `${window.location.origin}${baseUrl()}`;
 }


### PR DESCRIPTION
Change default port from `8989` to `7474` to not collide with any existing apps in the Hotio or Linuxserver catalogue. 

Should only affect new installs.