### PR TITLE
refactor: filter and action flow

### DIFF
--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -11,10 +11,10 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/autobrr/autobrr/internal/action"
+	"github.com/autobrr/autobrr/internal/announce"
 	"github.com/autobrr/autobrr/internal/auth"
 	"github.com/autobrr/autobrr/internal/config"
 	"github.com/autobrr/autobrr/internal/database"
-	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/download_client"
 	"github.com/autobrr/autobrr/internal/events"
 	"github.com/autobrr/autobrr/internal/filter"
@@ -29,7 +29,6 @@ import (
 )
 
 var (
-	cfg     domain.Config
 	version = "dev"
 	commit  = ""
 	date    = ""
@@ -41,7 +40,7 @@ func main() {
 	pflag.Parse()
 
 	// read config
-	cfg = config.Read(configPath)
+	cfg := config.Read(configPath)
 
 	// setup server-sent-events
 	serverEvents := sse.New()
@@ -87,8 +86,9 @@ func main() {
 		apiService            = indexer.NewAPIService()
 		indexerService        = indexer.NewService(cfg, indexerRepo, apiService)
 		filterService         = filter.NewService(filterRepo, actionRepo, apiService, indexerService)
-		releaseService        = release.NewService(releaseRepo, actionService)
-		ircService            = irc.NewService(ircRepo, filterService, indexerService, releaseService)
+		releaseService        = release.NewService(releaseRepo)
+		announceService       = announce.NewService(actionService, filterService, releaseService)
+		ircService            = irc.NewService(ircRepo, announceService, indexerService)
 		notificationService   = notification.NewService(notificationRepo)
 		userService           = user.NewService(userRepo)
 		authService           = auth.NewService(userService)

--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -69,8 +69,8 @@ func main() {
 
 	// setup repos
 	var (
-		actionRepo         = database.NewActionRepo(db)
 		downloadClientRepo = database.NewDownloadClientRepo(db)
+		actionRepo         = database.NewActionRepo(db, downloadClientRepo)
 		filterRepo         = database.NewFilterRepo(db)
 		indexerRepo        = database.NewIndexerRepo(db)
 		ircRepo            = database.NewIrcRepo(db)

--- a/internal/action/service.go
+++ b/internal/action/service.go
@@ -17,7 +17,7 @@ type Service interface {
 	ToggleEnabled(actionID int) error
 
 	RunActions(actions []domain.Action, release domain.Release) error
-	RunAction(action domain.Action, release domain.Release) ([]string, error)
+	RunAction(action *domain.Action, release domain.Release) ([]string, error)
 	CheckCanDownload(actions []domain.Action) bool
 }
 

--- a/internal/action/service.go
+++ b/internal/action/service.go
@@ -17,6 +17,7 @@ type Service interface {
 	ToggleEnabled(actionID int) error
 
 	RunActions(actions []domain.Action, release domain.Release) error
+	RunAction(action domain.Action, release domain.Release) ([]string, error)
 	CheckCanDownload(actions []domain.Action) bool
 }
 

--- a/internal/announce/service.go
+++ b/internal/announce/service.go
@@ -51,6 +51,14 @@ func (s *service) Process(release *domain.Release) {
 	// save both client type and client id to potentially try another client of same type
 	triedActionClients := map[actionClientTypeKey]struct{}{}
 
+	// save release
+	//release.FilterStatus = domain.ReleaseStatusFilterApproved
+	err = s.releaseSvc.Store(context.Background(), release)
+	if err != nil {
+		log.Error().Err(err).Msgf("announce.Service.Process: error writing release to database: %+v", release)
+		return
+	}
+
 	// loop over and check filters
 	for _, f := range filters {
 		// save filter on release
@@ -73,14 +81,6 @@ func (s *service) Process(release *domain.Release) {
 		}
 
 		log.Info().Msgf("Matched '%v' (%v) for %v", release.TorrentName, release.Filter.Name, release.Indexer)
-
-		// save release
-		release.FilterStatus = domain.ReleaseStatusFilterApproved
-		err = s.releaseSvc.Store(context.Background(), release)
-		if err != nil {
-			log.Error().Err(err).Msgf("announce.Service.Process: error writing release to database: %+v", release)
-			return
-		}
 
 		var rejections []string
 

--- a/internal/announce/service.go
+++ b/internal/announce/service.go
@@ -88,7 +88,7 @@ func (s *service) Process(release *domain.Release) {
 		for _, a := range release.Filter.Actions {
 			// only run enabled actions
 			if !a.Enabled {
-				log.Trace().Msgf("announce.Service.Process: indexer: %v, filter: %v release: %v action not enabled, skip", release.Indexer, release.Filter.Name, release.TorrentName)
+				log.Trace().Msgf("announce.Service.Process: indexer: %v, filter: %v release: %v action '%v' not enabled, skip", release.Indexer, release.Filter.Name, release.TorrentName, a.Name)
 				continue
 			}
 

--- a/internal/announce/service.go
+++ b/internal/announce/service.go
@@ -1,0 +1,132 @@
+package announce
+
+import (
+	"context"
+	"strings"
+
+	"github.com/autobrr/autobrr/internal/action"
+	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/autobrr/autobrr/internal/filter"
+	"github.com/autobrr/autobrr/internal/release"
+
+	"github.com/rs/zerolog/log"
+)
+
+type Service interface {
+	Process(release *domain.Release)
+}
+
+type service struct {
+	actionSvc  action.Service
+	filterSvc  filter.Service
+	releaseSvc release.Service
+}
+
+type actionClientTypeKey struct {
+	Type     domain.ActionType
+	ClientID int32
+}
+
+func NewService(actionSvc action.Service, filterSvc filter.Service, releaseSvc release.Service) Service {
+	return &service{
+		actionSvc:  actionSvc,
+		filterSvc:  filterSvc,
+		releaseSvc: releaseSvc,
+	}
+}
+
+func (s *service) Process(release *domain.Release) {
+	// TODO check in config for "Save all releases"
+	// TODO cross-seed check
+	// TODO dupe checks
+
+	// get filters by priority
+	filters, err := s.filterSvc.FindByIndexerIdentifier(release.Indexer)
+	if err != nil {
+		log.Error().Err(err).Msgf("announce.Service.Process: error finding filters for indexer: %v", release.Indexer)
+		return
+	}
+
+	// keep track of action clients to avoid sending the same thing all over again
+	// save both client type and client id to potentially try another client of same type
+	triedActionClients := map[actionClientTypeKey]struct{}{}
+
+	// loop over and check filters
+	for _, f := range filters {
+		// save filter on release
+		release.Filter = &f
+		release.FilterName = f.Name
+		release.FilterID = f.ID
+
+		// TODO filter limit checks
+
+		// test filter
+		match, err := s.filterSvc.CheckFilter(f, release)
+		if err != nil {
+			log.Error().Err(err).Msg("announce.Service.Process: could not find filter")
+			return
+		}
+
+		if !match {
+			log.Trace().Msgf("announce.Service.Process: indexer: %v, filter: %v release: %v, no match", release.Indexer, release.Filter.Name, release.TorrentName)
+			continue
+		}
+
+		log.Info().Msgf("Matched '%v' (%v) for %v", release.TorrentName, release.Filter.Name, release.Indexer)
+
+		// save release
+		release.FilterStatus = domain.ReleaseStatusFilterApproved
+		err = s.releaseSvc.Store(context.Background(), release)
+		if err != nil {
+			log.Error().Err(err).Msgf("announce.Service.Process: error writing release to database: %+v", release)
+			return
+		}
+
+		var rejections []string
+
+		// run actions (watchFolder, test, exec, qBittorrent, Deluge, arr etc.)
+		for _, a := range release.Filter.Actions {
+			// only run enabled actions
+			if !a.Enabled {
+				log.Trace().Msgf("announce.Service.Process: indexer: %v, filter: %v release: %v action not enabled, skip", release.Indexer, release.Filter.Name, release.TorrentName)
+				continue
+			}
+
+			log.Trace().Msgf("announce.Service.Process: indexer: %v, filter: %v release: %v , run action: %v", release.Indexer, release.Filter.Name, release.TorrentName, a.Name)
+
+			// keep track of action clients to avoid sending the same thing all over again
+			_, tried := triedActionClients[actionClientTypeKey{Type: a.Type, ClientID: a.ClientID}]
+			if tried {
+				log.Trace().Msgf("announce.Service.Process: indexer: %v, filter: %v release: %v action client already tried, skip", release.Indexer, release.Filter.Name, release.TorrentName)
+				continue
+			}
+
+			rejections, err = s.actionSvc.RunAction(a, *release)
+			if err != nil {
+				log.Error().Stack().Err(err).Msgf("announce.Service.Process: error running actions for filter: %v", release.Filter.Name)
+				continue
+			}
+
+			if len(rejections) > 0 {
+				// if we get a rejection, remember which action client it was from
+				triedActionClients[actionClientTypeKey{Type: a.Type, ClientID: a.ClientID}] = struct{}{}
+
+				// log something and fire events
+				log.Debug().Msgf("announce.Service.Process: indexer: %v, filter: %v release: %v, rejected: %v", release.Indexer, release.Filter.Name, release.TorrentName, strings.Join(rejections, ", "))
+			}
+
+			// if no rejections consider action approved, run next
+			continue
+		}
+
+		// if we have rejections from arr, continue to next filter
+		if len(rejections) > 0 {
+			continue
+		}
+
+		// all actions run, decide to stop or continue here
+		break
+	}
+
+	return
+}

--- a/internal/domain/action.go
+++ b/internal/domain/action.go
@@ -4,37 +4,38 @@ import "context"
 
 type ActionRepo interface {
 	Store(ctx context.Context, action Action) (*Action, error)
-	StoreFilterActions(ctx context.Context, actions []Action, filterID int64) ([]Action, error)
+	StoreFilterActions(ctx context.Context, actions []*Action, filterID int64) ([]*Action, error)
 	DeleteByFilterID(ctx context.Context, filterID int) error
-	FindByFilterID(ctx context.Context, filterID int) ([]Action, error)
+	FindByFilterID(ctx context.Context, filterID int) ([]*Action, error)
 	List(ctx context.Context) ([]Action, error)
 	Delete(actionID int) error
 	ToggleEnabled(actionID int) error
 }
 
 type Action struct {
-	ID                 int        `json:"id"`
-	Name               string     `json:"name"`
-	Type               ActionType `json:"type"`
-	Enabled            bool       `json:"enabled"`
-	ExecCmd            string     `json:"exec_cmd,omitempty"`
-	ExecArgs           string     `json:"exec_args,omitempty"`
-	WatchFolder        string     `json:"watch_folder,omitempty"`
-	Category           string     `json:"category,omitempty"`
-	Tags               string     `json:"tags,omitempty"`
-	Label              string     `json:"label,omitempty"`
-	SavePath           string     `json:"save_path,omitempty"`
-	Paused             bool       `json:"paused,omitempty"`
-	IgnoreRules        bool       `json:"ignore_rules,omitempty"`
-	LimitUploadSpeed   int64      `json:"limit_upload_speed,omitempty"`
-	LimitDownloadSpeed int64      `json:"limit_download_speed,omitempty"`
-	WebhookHost        string     `json:"webhook_host,omitempty"`
-	WebhookType        string     `json:"webhook_type,omitempty"`
-	WebhookMethod      string     `json:"webhook_method,omitempty"`
-	WebhookData        string     `json:"webhook_data,omitempty"`
-	WebhookHeaders     []string   `json:"webhook_headers,omitempty"`
-	FilterID           int        `json:"filter_id,omitempty"`
-	ClientID           int32      `json:"client_id,omitempty"`
+	ID                 int            `json:"id"`
+	Name               string         `json:"name"`
+	Type               ActionType     `json:"type"`
+	Enabled            bool           `json:"enabled"`
+	ExecCmd            string         `json:"exec_cmd,omitempty"`
+	ExecArgs           string         `json:"exec_args,omitempty"`
+	WatchFolder        string         `json:"watch_folder,omitempty"`
+	Category           string         `json:"category,omitempty"`
+	Tags               string         `json:"tags,omitempty"`
+	Label              string         `json:"label,omitempty"`
+	SavePath           string         `json:"save_path,omitempty"`
+	Paused             bool           `json:"paused,omitempty"`
+	IgnoreRules        bool           `json:"ignore_rules,omitempty"`
+	LimitUploadSpeed   int64          `json:"limit_upload_speed,omitempty"`
+	LimitDownloadSpeed int64          `json:"limit_download_speed,omitempty"`
+	WebhookHost        string         `json:"webhook_host,omitempty"`
+	WebhookType        string         `json:"webhook_type,omitempty"`
+	WebhookMethod      string         `json:"webhook_method,omitempty"`
+	WebhookData        string         `json:"webhook_data,omitempty"`
+	WebhookHeaders     []string       `json:"webhook_headers,omitempty"`
+	FilterID           int            `json:"filter_id,omitempty"`
+	ClientID           int32          `json:"client_id,omitempty"`
+	Client             DownloadClient `json:"client,omitempty"`
 }
 
 type ActionType string

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -11,6 +11,7 @@ type EventsReleasePushed struct {
 	Status         ReleasePushStatus
 	Action         string
 	ActionType     ActionType
+	ActionClient   string
 	Rejections     []string
 	Protocol       ReleaseProtocol       // torrent
 	Implementation ReleaseImplementation // irc, rss, api

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -71,6 +71,6 @@ type Filter struct {
 	ExceptTags          string    `json:"except_tags"`
 	TagsAny             string    `json:"tags_any"`
 	ExceptTagsAny       string    `json:"except_tags_any"`
-	Actions             []Action  `json:"actions"`
+	Actions             []*Action `json:"actions"`
 	Indexers            []Indexer `json:"indexers"`
 }

--- a/internal/domain/release_test.go
+++ b/internal/domain/release_test.go
@@ -1249,7 +1249,7 @@ func TestRelease_CheckFilter(t *testing.T) {
 			r := tt.fields // Release
 
 			_ = r.Parse() // Parse TorrentName into struct
-			got := r.CheckFilter(tt.args.filter)
+			_, got := r.CheckFilter(tt.args.filter)
 
 			assert.Equal(t, tt.want, got)
 		})

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -16,6 +16,7 @@ type Service interface {
 	FindByID(ctx context.Context, filterID int) (*domain.Filter, error)
 	FindByIndexerIdentifier(indexer string) ([]domain.Filter, error)
 	FindAndCheckFilters(release *domain.Release) (bool, *domain.Filter, error)
+	CheckFilter(f domain.Filter, release *domain.Release) (bool, error)
 	ListFilters(ctx context.Context) ([]domain.Filter, error)
 	Store(ctx context.Context, filter domain.Filter) (*domain.Filter, error)
 	Update(ctx context.Context, filter domain.Filter) (*domain.Filter, error)
@@ -333,6 +334,123 @@ func (s *service) FindAndCheckFilters(release *domain.Release) (bool, *domain.Fi
 
 	// if no match, return nil
 	return false, nil, nil
+}
+
+func (s *service) CheckFilter(f domain.Filter, release *domain.Release) (bool, error) {
+
+	log.Trace().Msgf("filter.Service.CheckFilter: checking filter: %+v", f.Name)
+
+	matchedFilter := release.CheckFilter(f)
+	if matchedFilter {
+		// if matched, do additional size check if needed, attach actions and return the filter
+
+		log.Debug().Msgf("filter.Service.CheckFilter: found and matched filter: %+v", f.Name)
+
+		// Some indexers do not announce the size and if size (min,max) is set in a filter then it will need
+		// additional size check. Some indexers have api implemented to fetch this data and for the others
+		// it will download the torrent file to parse and make the size check. This is all to minimize the amount of downloads.
+
+		// do additional size check against indexer api or torrent for size
+		if release.AdditionalSizeCheckRequired {
+			log.Debug().Msgf("filter.Service.CheckFilter: (%v) additional size check required", f.Name)
+			ok, err := s.AdditionalSizeCheck(f, release)
+			if err != nil {
+				log.Error().Stack().Err(err).Msgf("filter.Service.CheckFilter: (%v) additional size check error", f.Name)
+				return false, err
+			}
+
+			if !ok {
+				return false, nil
+			}
+		}
+
+		// found matching filter, lets find the filter actions and attach
+		actions, err := s.actionRepo.FindByFilterID(context.TODO(), f.ID)
+		if err != nil {
+			log.Error().Err(err).Msgf("filter.Service.CheckFilter: could not find actions for filter: %+v", f.Name)
+		}
+
+		// if no actions, continue to next filter
+		if len(actions) == 0 {
+			log.Trace().Msgf("filter.Service.CheckFilter: no actions found for filter '%v', trying next one..", f.Name)
+			return false, err
+		}
+		release.Filter.Actions = actions
+
+		return true, nil
+	}
+
+	// if no match, return nil
+	return false, nil
+}
+
+func (s *service) AdditionalSizeCheck(f domain.Filter, release *domain.Release) (bool, error) {
+
+	// save outside of loop to check multiple filters with only one fetch
+	// TODO put on filter to reuse
+	var torrentInfo *domain.TorrentBasic
+
+	// Some indexers do not announce the size and if size (min,max) is set in a filter then it will need
+	// additional size check. Some indexers have api implemented to fetch this data and for the others
+	// it will download the torrent file to parse and make the size check. This is all to minimize the amount of downloads.
+
+	// do additional size check against indexer api or torrent for size
+	log.Debug().Msgf("filter-service.find_and_check_filters: (%v) additional size check required", f.Name)
+
+	// check if indexer = btn, ptp, ggn or red
+	if release.Indexer == "ptp" || release.Indexer == "btn" || release.Indexer == "ggn" || release.Indexer == "redacted" {
+		// fetch torrent info from api
+		// save outside of loop to check multiple filters with only one fetch
+		if torrentInfo == nil {
+			torrentInfo, err := s.apiService.GetTorrentByID(release.Indexer, release.TorrentID)
+			if err != nil || torrentInfo == nil {
+				log.Error().Stack().Err(err).Msgf("filter-service.find_and_check_filters: (%v) could not get torrent: '%v' from: %v", f.Name, release.TorrentID, release.Indexer)
+				return false, err
+			}
+
+			log.Debug().Msgf("filter-service.find_and_check_filters: (%v) got torrent info: %+v", f.Name, torrentInfo)
+		}
+
+		// compare size against filters
+		match, err := checkSizeFilter(f.MinSize, f.MaxSize, torrentInfo.ReleaseSizeBytes())
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("filter-service.find_and_check_filters: (%v) could not check size filter", f.Name)
+			return false, err
+		}
+
+		// no match, lets continue to next filter
+		if !match {
+			log.Debug().Msgf("filter-service.find_and_check_filters: (%v) filter did not match after additional size check, trying next", f.Name)
+			return false, nil
+		}
+
+		// store size on the release
+		release.Size = torrentInfo.ReleaseSizeBytes()
+	} else {
+		log.Trace().Msgf("filter-service.find_and_check_filters: (%v) additional size check required: preparing to download metafile", f.Name)
+
+		// if indexer doesn't have api, download torrent and add to tmpPath
+		err := release.DownloadTorrentFile()
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("filter-service.find_and_check_filters: (%v) could not download torrent file with id: '%v' from: %v", f.Name, release.TorrentID, release.Indexer)
+			return false, err
+		}
+
+		// compare size against filter
+		match, err := checkSizeFilter(f.MinSize, f.MaxSize, release.Size)
+		if err != nil {
+			log.Error().Stack().Err(err).Msgf("filter-service.find_and_check_filters: (%v) could not check size filter", f.Name)
+			return false, err
+		}
+
+		// no match, lets continue to next filter
+		if !match {
+			log.Debug().Msgf("filter-service.find_and_check_filters: (%v) filter did not match after additional size check, trying next", f.Name)
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func checkSizeFilter(minSize string, maxSize string, releaseSize uint64) (bool, error) {

--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -40,7 +40,7 @@ func discordNotification(event domain.EventsReleasePushed, webhookURL string) {
 		},
 	}
 
-	client := http.Client{Transport: t, Timeout: 15 * time.Second}
+	client := http.Client{Transport: t, Timeout: 30 * time.Second}
 
 	color := map[domain.ReleasePushStatus]int{
 		domain.ReleasePushStatusApproved: 5814783,

--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -72,13 +74,48 @@ func discordNotification(event domain.EventsReleasePushed, webhookURL string) {
 					{
 						Name:   "Action",
 						Value:  event.Action,
-						Inline: false,
+						Inline: true,
 					},
+					{
+						Name:   "Action type",
+						Value:  string(event.ActionType),
+						Inline: true,
+					},
+					//{
+					//	Name:   "Action client",
+					//	Value:  event.ActionClient,
+					//	Inline: true,
+					//},
 				},
 				Timestamp: time.Now(),
 			},
 		},
 		Username: "brr",
+	}
+
+	if event.ActionClient == "" {
+		rej := DiscordEmbedsFields{
+			Name:   "Action client",
+			Value:  "n/a",
+			Inline: true,
+		}
+		m.Embeds[0].Fields = append(m.Embeds[0].Fields, rej)
+	} else {
+		rej := DiscordEmbedsFields{
+			Name:   "Action client",
+			Value:  event.ActionClient,
+			Inline: true,
+		}
+		m.Embeds[0].Fields = append(m.Embeds[0].Fields, rej)
+	}
+
+	if len(event.Rejections) > 0 {
+		rej := DiscordEmbedsFields{
+			Name:   "Reasons",
+			Value:  fmt.Sprintf("```\n%v\n```", strings.Join(event.Rejections, " ,")),
+			Inline: false,
+		}
+		m.Embeds[0].Fields = append(m.Embeds[0].Fields, rej)
 	}
 
 	jsonData, err := json.Marshal(m)
@@ -89,7 +126,7 @@ func discordNotification(event domain.EventsReleasePushed, webhookURL string) {
 
 	req, err := http.NewRequest(http.MethodPost, webhookURL, bytes.NewBuffer(jsonData))
 	if err != nil {
-		//log.Error().Err(err).Msgf("webhook client request error: %v", action.WebhookHost)
+		log.Error().Err(err).Msgf("discord client request error: %v", event.ReleaseName)
 		return
 	}
 
@@ -98,7 +135,7 @@ func discordNotification(event domain.EventsReleasePushed, webhookURL string) {
 
 	res, err := client.Do(req)
 	if err != nil {
-		//log.Error().Err(err).Msgf("webhook client request error: %v", action.WebhookHost)
+		log.Error().Err(err).Msgf("discord client request error: %v", event.ReleaseName)
 		return
 	}
 

--- a/pkg/lidarr/lidarr.go
+++ b/pkg/lidarr/lidarr.go
@@ -34,7 +34,7 @@ type client struct {
 func New(config Config) Client {
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: time.Second * 30,
 	}
 
 	c := &client{

--- a/pkg/qbittorrent/client.go
+++ b/pkg/qbittorrent/client.go
@@ -23,7 +23,7 @@ var (
 		10 * time.Second,
 		20 * time.Second,
 	}
-	timeout = 20 * time.Second
+	timeout = 60 * time.Second
 )
 
 type Client struct {

--- a/pkg/radarr/radarr.go
+++ b/pkg/radarr/radarr.go
@@ -33,7 +33,7 @@ type client struct {
 func New(config Config) Client {
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: time.Second * 30,
 	}
 
 	c := &client{

--- a/pkg/sonarr/sonarr.go
+++ b/pkg/sonarr/sonarr.go
@@ -34,7 +34,7 @@ type client struct {
 func New(config Config) Client {
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: time.Second * 30,
 	}
 
 	c := &client{

--- a/pkg/whisparr/whisparr.go
+++ b/pkg/whisparr/whisparr.go
@@ -33,7 +33,7 @@ type client struct {
 func New(config Config) Client {
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: time.Second * 30,
 	}
 
 	c := &client{


### PR DESCRIPTION
Refactor of the filters and how actions are handled. Specifically how arr actions are handled with rejections.

A rejection from an arr app will now work similar as the other filter checks and simply run next filter. It keeps track of the arr instance by clientId to not try and send the same release again if another filter have the same action. If it finds it's already been run it will continue to next filter.

This now makes the filtering with arr actions work as part of the filtering decision which it did not do before.

This refactor will also help with adding pre-checks before filtering, like running a cross-seed match or ignore duplicate releases etc.

Fixes #163 

## Other work done

* Increase timeouts for arr clients to 30 seconds, up from 10.