### PR TITLE
feat(http): add healthcheck endpoints liveness and readiness

### DIFF
--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -100,7 +100,7 @@ func main() {
 	errorChannel := make(chan error)
 
 	go func() {
-		httpServer := http.NewServer(cfg, serverEvents, version, commit, date, actionService, authService, downloadClientService, filterService, indexerService, ircService, notificationService, releaseService)
+		httpServer := http.NewServer(cfg, serverEvents, db, version, commit, date, actionService, authService, downloadClientService, filterService, indexerService, ircService, notificationService, releaseService)
 		errorChannel <- httpServer.Open()
 	}()
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -82,6 +82,10 @@ func (db *DB) Close() error {
 	return nil
 }
 
+func (db *DB) Ping() error {
+	return db.handler.Ping()
+}
+
 func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 	tx, err := db.handler.BeginTx(ctx, opts)
 	if err != nil {

--- a/internal/http/health.go
+++ b/internal/http/health.go
@@ -1,0 +1,50 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/autobrr/autobrr/internal/database"
+
+	"github.com/go-chi/chi"
+)
+
+type healthHandler struct {
+	encoder encoder
+	db      *database.DB
+}
+
+func newHealthHandler(encoder encoder, db *database.DB) *healthHandler {
+	return &healthHandler{
+		encoder: encoder,
+		db:      db,
+	}
+}
+
+func (h healthHandler) Routes(r chi.Router) {
+	r.Get("/liveness", h.handleLiveness)
+	r.Get("/readiness", h.handleReadiness)
+}
+
+func (h healthHandler) handleLiveness(w http.ResponseWriter, _ *http.Request) {
+	writeHealthy(w)
+}
+
+func (h healthHandler) handleReadiness(w http.ResponseWriter, _ *http.Request) {
+	if err := h.db.Ping(); err != nil {
+		writeUnhealthy(w)
+		return
+	}
+
+	writeHealthy(w)
+}
+
+func writeHealthy(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+func writeUnhealthy(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte("Unhealthy"))
+}

--- a/internal/http/health.go
+++ b/internal/http/health.go
@@ -43,8 +43,9 @@ func writeHealthy(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("OK"))
 }
+
 func writeUnhealthy(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusInternalServerError)
-	w.Write([]byte("Unhealthy"))
+	w.Write([]byte("Unhealthy. Database unreachable"))
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/autobrr/autobrr/internal/database"
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/web"
 
@@ -17,6 +18,7 @@ import (
 
 type Server struct {
 	sse *sse.Server
+	db  *database.DB
 
 	config      domain.Config
 	cookieStore *sessions.CookieStore
@@ -35,10 +37,11 @@ type Server struct {
 	releaseService        releaseService
 }
 
-func NewServer(config domain.Config, sse *sse.Server, version string, commit string, date string, actionService actionService, authService authService, downloadClientSvc downloadClientService, filterSvc filterService, indexerSvc indexerService, ircSvc ircService, notificationSvc notificationService, releaseSvc releaseService) Server {
+func NewServer(config domain.Config, sse *sse.Server, db *database.DB, version string, commit string, date string, actionService actionService, authService authService, downloadClientSvc downloadClientService, filterSvc filterService, indexerSvc indexerService, ircSvc ircService, notificationSvc notificationService, releaseSvc releaseService) Server {
 	return Server{
 		config:  config,
 		sse:     sse,
+		db:      db,
 		version: version,
 		commit:  commit,
 		date:    date,
@@ -98,6 +101,7 @@ func (s Server) Handler() http.Handler {
 	})
 
 	r.Route("/api/auth", newAuthHandler(encoder, s.config, s.cookieStore, s.authService).Routes)
+	r.Route("/api/health", newHealthHandler(encoder, s.db).Routes)
 
 	r.Group(func(r chi.Router) {
 		r.Use(s.IsAuthenticated)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -101,7 +101,7 @@ func (s Server) Handler() http.Handler {
 	})
 
 	r.Route("/api/auth", newAuthHandler(encoder, s.config, s.cookieStore, s.authService).Routes)
-	r.Route("/api/health", newHealthHandler(encoder, s.db).Routes)
+	r.Route("/api/healthz", newHealthHandler(encoder, s.db).Routes)
 
 	r.Group(func(r chi.Router) {
 		r.Use(s.IsAuthenticated)


### PR DESCRIPTION
Add healthcheck endpoints - liveness and readiness.

Useful for container deployments.

New endpoints. Both answers with appropiate status codes and body text as `text/plain`

- `/api/healtz/liveness` - 200 OK and OK in body
- `/api/healtz/readiness` - 200 OK and OK in body if databse ping is ok. If not, 500 and `Unhealthy. Database unreachable`