### PR TITLE
fix(release): edge case resolution parsing

### DIFF
--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"golang.org/x/net/publicsuffix"
 	"html"
 	"io"
 	"net/http"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"golang.org/x/net/publicsuffix"
 
 	"github.com/autobrr/autobrr/pkg/wildcard"
 
@@ -191,7 +192,7 @@ func (r *Release) extractEpisode() error {
 }
 
 func (r *Release) extractResolution() error {
-	v, err := findLast(r.TorrentName, `\b(?i)(([0-9]{3,4}p|i))\b`)
+	v, err := findLast(r.TorrentName, `\b(?i)[0-9]{3,4}(?:p|i)\b`)
 	if err != nil {
 		return err
 	}

--- a/internal/domain/release_test.go
+++ b/internal/domain/release_test.go
@@ -245,6 +245,26 @@ func TestRelease_Parse(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "parse_movies_case_1",
+			fields: Release{
+				TorrentName: "I Am Movie 2007 Theatrical UHD BluRay 2160p DTS-HD MA 5.1 DV HEVC HYBRID REMUX-GROUP1",
+			},
+			want: Release{
+				TorrentName: "I Am Movie 2007 Theatrical UHD BluRay 2160p DTS-HD MA 5.1 DV HEVC HYBRID REMUX-GROUP1",
+				Clean:       "I Am Movie 2007 Theatrical UHD BluRay 2160p DTS HD MA 5 1 DV HEVC HYBRID REMUX GROUP1",
+				Resolution:  "2160p",
+				Source:      "BluRay",
+				Codec:       "HEVC",
+				HDR:         "DV",
+				Audio:       "DTS-HD MA 5.1", // need to fix audio parsing
+				Edition:     "Theatrical",
+				Hybrid:      true,
+				Year:        2007,
+				Group:       "GROUP1",
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Ran into a case where resolution would be parsed into I instead of 2160p with the release `I Am Movie 2007 Theatrical UHD BluRay 2160p DTS-HD MA 5.1 DV HEVC HYBRID REMUX-GROUP1`.