### PR TITLE
fix(indexers): use rss download url for hdt

### DIFF
--- a/internal/indexer/definitions/hd-torrents.yaml
+++ b/internal/indexer/definitions/hd-torrents.yaml
@@ -16,11 +16,11 @@ source: xbtit
 settings:
   - name: key
     type: secret
-    label: Rss key
+    label: RSS key
     help: "Generate a RSS feed and copy key from URL"
   - name: token
     type: secret
-    label: Rss Tolen
+    label: RSS Token
     help: "Generate a RSS feed and copy token from URL"
 
 irc:

--- a/internal/indexer/definitions/hd-torrents.yaml
+++ b/internal/indexer/definitions/hd-torrents.yaml
@@ -14,10 +14,14 @@ supports:
   - rss
 source: xbtit
 settings:
-  - name: cookie
+  - name: key
     type: secret
-    label: Cookie
-    help: "Check how to get cookies in your browser and find the uid and pass cookies. Example: uid=1234; pass=asdf12347asdf13"
+    label: Rss key
+    help: "Generate a RSS feed and copy key from URL"
+  - name: token
+    type: secret
+    label: Rss Tolen
+    help: "Generate a RSS feed and copy token from URL"
 
 irc:
   network: P2P-Network
@@ -45,15 +49,15 @@ parse:
   lines:
     - test:
         - "New Torrent in category [Movies/Remux] That Movie (2008) Blu-ray 1080p REMUX AVC DTS-HD MA 7 1 (14.60 GB) uploaded! Download: https://hd-torrents.org/download.php?id=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-      pattern: 'New Torrent in category \[([^\]]*)\] (.*) \(([^\)]*)\) uploaded! Download\: (https?\:\/\/.*[&\?]id=.+)'
+      pattern: 'New Torrent in category \[([^\]]*)\] (.*) \(([^\)]*)\) uploaded! Download\: (https?\:\/\/[^\/]+\/).+id=(.+)'
       vars:
         - category
         - torrentName
         - torrentSize
         - baseUrl
+        - torrentId
 
   match:
-    torrenturl: "{{ .baseUrl }}&f={{ .torrentName }}.torrent"
-    cookie: true
+    torrenturl: "{{ .baseUrl }}rss/?action=download&key={{ .key }}&token={{ .token }}&hash={{ .torrentId }}&title={{ .torrentName }}"
     encode:
       - torrentName


### PR DESCRIPTION
Use rss download link and tokens instead of cookies.

## Semi breaking changes

You'll have to set `rss key` and `rss token`.