### PR TITLE
feat: add ability for the user to choose the log dir during onboarding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/autobrr/autobrr
 go 1.17
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/squirrel v1.5.1
 	github.com/anacrolix/torrent v1.11.0
 	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -3,11 +3,10 @@ package auth
 import (
 	"context"
 	"errors"
+
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/user"
 	"github.com/autobrr/autobrr/pkg/argon2id"
-	"os"
-	"strings"
 )
 
 type Service interface {
@@ -70,16 +69,6 @@ func (s *service) CreateUser(ctx context.Context, user domain.CreateUserRequest)
 
 	if userCount > 0 {
 		return errors.New("only 1 user account is supported at the moment")
-	}
-
-	// create log dir before inserting a user into the database
-	// (in case problems arise)
-	// empty LogDir indicates that no log file is needed
-	if strings.TrimSpace(user.LogDir) != "" {
-		err = os.MkdirAll(user.LogDir, os.ModePerm)
-		if err != nil {
-			return errors.New("failed to create log dir: " + err.Error())
-		}
 	}
 
 	hashed, err := argon2id.CreateHash(user.Password, argon2id.DefaultParams)

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -3,16 +3,17 @@ package auth
 import (
 	"context"
 	"errors"
-
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/user"
 	"github.com/autobrr/autobrr/pkg/argon2id"
+	"os"
+	"strings"
 )
 
 type Service interface {
 	GetUserCount(ctx context.Context) (int, error)
 	Login(ctx context.Context, username, password string) (*domain.User, error)
-	CreateUser(ctx context.Context, username, password string) error
+	CreateUser(ctx context.Context, user domain.CreateUserRequest) error
 }
 
 type service struct {
@@ -57,8 +58,8 @@ func (s *service) Login(ctx context.Context, username, password string) (*domain
 	return u, nil
 }
 
-func (s *service) CreateUser(ctx context.Context, username, password string) error {
-	if username == "" || password == "" {
+func (s *service) CreateUser(ctx context.Context, user domain.CreateUserRequest) error {
+	if user.Username == "" || user.Password == "" {
 		return errors.New("empty credentials supplied")
 	}
 
@@ -71,13 +72,23 @@ func (s *service) CreateUser(ctx context.Context, username, password string) err
 		return errors.New("only 1 user account is supported at the moment")
 	}
 
-	hashed, err := argon2id.CreateHash(password, argon2id.DefaultParams)
+	// create log dir before inserting a user into the database
+	// (in case problems arise)
+	// empty LogDir indicates that no log file is needed
+	if strings.TrimSpace(user.LogDir) != "" {
+		err = os.MkdirAll(user.LogDir, os.ModePerm)
+		if err != nil {
+			return errors.New("failed to create log dir: " + err.Error())
+		}
+	}
+
+	hashed, err := argon2id.CreateHash(user.Password, argon2id.DefaultParams)
 	if err != nil {
 		return errors.New("failed to hash password")
 	}
 
 	newUser := domain.User{
-		Username: username,
+		Username: user.Username,
 		Password: hashed,
 	}
 	if err := s.userSvc.CreateUser(context.Background(), newUser); err != nil {

--- a/internal/domain/auth.go
+++ b/internal/domain/auth.go
@@ -1,0 +1,6 @@
+package domain
+
+type OnboardingPreferences struct {
+	LogDir    string   `json:"log_dir"`
+	LogErrors []string `json:"log_errors,omitempty"`
+}

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -1,8 +1,15 @@
 package domain
 
+import (
+	"os"
+	"path"
+
+	"github.com/BurntSushi/toml"
+)
+
 type Config struct {
-	Version           string
-	ConfigPath        string
+	Version           string `toml:"-"`
+	ConfigPath        string `toml:"-"`
 	Host              string `toml:"host"`
 	Port              int    `toml:"port"`
 	LogLevel          string `toml:"logLevel"`
@@ -16,4 +23,73 @@ type Config struct {
 	PostgresDatabase  string `toml:"postgresDatabase"`
 	PostgresUser      string `toml:"postgresUser"`
 	PostgresPass      string `toml:"postgresPass"`
+}
+
+func (c Config) GetPreferredLogDir() (string, []string) {
+	// 0. Check if ~/.config/autobrr/ is accessible to the current user
+	// 1. Check if ~/.config/autobrr/log/ is accessible to the current user
+	// 2. Check if golang can find the temp directory and use that.
+	// 3. If neither 1 nor 2 were successful, bail with an error message.
+	// NOTE: If neither $XDG_CONFIG_HOME nor $HOME are defined, UserConfigDir will return an error.
+	configDir, err := os.UserConfigDir()
+
+	// Keep track of errors, if any. Might help diagnose misconfiguration problems and such.
+	var discoveredErrors []string
+	if err == nil {
+		// If we managed to find the user config directory,
+		// then return ~/.config/autobrr/logs as the preferred log dir
+		logDir := path.Join(configDir, "autobrr", "logs")
+		return logDir, discoveredErrors
+	} else {
+		discoveredErrors = append(discoveredErrors, err.Error())
+	}
+
+	for _, dir := range [3]string{"/var/log/", "/opt/", os.TempDir()} {
+		if stat, err := os.Stat(dir); err == nil && stat.IsDir() {
+			return path.Join(dir, "autobrr", "logs"), discoveredErrors
+		} else {
+			discoveredErrors = append(discoveredErrors, err.Error())
+		}
+	}
+
+	return "", discoveredErrors
+}
+
+func (c *Config) UpdateConfig(file string) error {
+	c.LogPath = file
+
+	//// create log dir before
+	//// (in case problems arise)
+	//// empty LogPath indicates that no log file is needed
+	//if strings.TrimSpace(user.LogPath) != "" {
+	//	err = os.MkdirAll(user.LogPath, os.ModePerm)
+	//	if err != nil {
+	//		return errors.New("failed to create log dir: " + err.Error())
+	//	}
+	//}
+
+	cfgPath := path.Join(c.ConfigPath, "config.toml")
+
+	f, err := os.OpenFile(cfgPath, os.O_CREATE|os.O_RDWR, os.ModePerm)
+	//f, err := os.Open("./config.toml")
+	if err != nil {
+		// failed to create/open the file
+		//log.Fatal(err)
+		return err
+	}
+	//defer f.Close()
+
+	if err := toml.NewEncoder(f).Encode(c); err != nil {
+		// failed to encode
+		//log.Fatal(err)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		// failed to close the file
+		//log.Fatal(err)
+		return err
+
+	}
+
+	return nil
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -18,5 +18,5 @@ type User struct {
 type CreateUserRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
-	LogDir   string `json:"log_dir"`
+	LogPath  string `json:"log_dir"`
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -14,3 +14,9 @@ type User struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
 }
+
+type CreateUserRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	LogDir   string `json:"log_dir"`
+}

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
+	"path"
 
 	"github.com/go-chi/chi"
 	"github.com/gorilla/sessions"
@@ -14,7 +16,7 @@ import (
 type authService interface {
 	GetUserCount(ctx context.Context) (int, error)
 	Login(ctx context.Context, username, password string) (*domain.User, error)
-	CreateUser(ctx context.Context, username, password string) error
+	CreateUser(ctx context.Context, user domain.CreateUserRequest) error
 }
 
 type authHandler struct {
@@ -39,6 +41,7 @@ func (h authHandler) Routes(r chi.Router) {
 	r.Post("/logout", h.logout)
 	r.Post("/onboard", h.onboard)
 	r.Get("/onboard", h.canOnboard)
+	r.Get("/onboard/preferences", h.getOnboardingPreferences)
 	r.Get("/validate", h.validate)
 }
 
@@ -97,24 +100,17 @@ func (h authHandler) logout(w http.ResponseWriter, r *http.Request) {
 
 func (h authHandler) onboard(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	session, _ := h.cookieStore.Get(r, "user_session")
 
-	// Don't proceed if user is authenticated
-	if _, ok := session.Values["authenticated"].(bool); ok {
-		http.Error(w, "Forbidden", http.StatusForbidden)
-		return
-	}
-
-	var data domain.User
+	var data domain.CreateUserRequest
 	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
 		// encode error
 		h.encoder.StatusResponse(ctx, w, nil, http.StatusBadRequest)
 		return
 	}
 
-	err := h.service.CreateUser(ctx, data.Username, data.Password)
+	err := h.service.CreateUser(ctx, data)
 	if err != nil {
-		http.Error(w, "Forbidden", http.StatusForbidden)
+		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
 
@@ -140,6 +136,60 @@ func (h authHandler) canOnboard(w http.ResponseWriter, r *http.Request) {
 	// send empty response as ok
 	// (client can proceed with redirection to onboarding page)
 	h.encoder.StatusResponse(ctx, w, nil, http.StatusNoContent)
+}
+
+func GetPreferredLogDir() (string, []string) {
+	// 0. Check if ~/.config/autobrr/ is accessible to the current user
+	// 1. Check if ~/.config/autobrr/log/ is accessible to the current user
+	// 2. Check if golang can find the temp directory and use that.
+	// 3. If neither 1 nor 2 were successful, bail with an error message.
+	// NOTE: If neither $XDG_CONFIG_HOME nor $HOME are defined, UserConfigDir will return an error.
+	configDir, err := os.UserConfigDir()
+
+	// Keep track of errors, if any. Might help diagnose misconfiguration problems and such.
+	var discoveredErrors []string
+	if err == nil {
+		// If we managed to find the user config directory,
+		// then return ~/.config/autobrr/logs as the preferred log dir
+		logDir := path.Join(configDir, "autobrr", "logs")
+		return logDir, discoveredErrors
+	} else {
+		discoveredErrors = append(discoveredErrors, err.Error())
+	}
+
+	for _, dir := range [3]string{"/var/log/", "/opt/", os.TempDir()} {
+		if stat, err := os.Stat(dir); err == nil && stat.IsDir() {
+			return path.Join(dir, "autobrr", "logs"), discoveredErrors
+		} else {
+			discoveredErrors = append(discoveredErrors, err.Error())
+		}
+	}
+
+	return "", discoveredErrors
+}
+
+func (h authHandler) getOnboardingPreferences(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	userCount, err := h.service.GetUserCount(ctx)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if userCount > 0 {
+		// send 503 service onboarding unavailable
+		http.Error(w, "Onboarding unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	logDir, logErrors := GetPreferredLogDir()
+	result := domain.OnboardingPreferences{
+		LogDir:    logDir,
+		LogErrors: logErrors,
+	}
+
+	h.encoder.StatusResponse(r.Context(), w, result, http.StatusOK)
 }
 
 func (h authHandler) validate(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/onboard.go
+++ b/internal/http/onboard.go
@@ -1,0 +1,106 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi"
+
+	"github.com/autobrr/autobrr/internal/domain"
+)
+
+//type authService interface {
+//	GetUserCount(ctx context.Context) (int, error)
+//	Login(ctx context.Context, username, password string) (*domain.User, error)
+//	CreateUser(ctx context.Context, user domain.CreateUserRequest) error
+//}
+
+type onboardHandler struct {
+	encoder encoder
+	config  *domain.Config
+	service authService
+}
+
+func newOnboardHandler(encoder encoder, config *domain.Config, service authService) *onboardHandler {
+	return &onboardHandler{
+		encoder: encoder,
+		config:  config,
+		service: service,
+	}
+}
+
+func (h onboardHandler) Routes(r chi.Router) {
+	r.Post("/", h.onboard)
+	r.Get("/", h.canOnboard)
+	r.Get("/preferences", h.getOnboardingPreferences)
+}
+
+func (h onboardHandler) onboard(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var data domain.CreateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		// encode error
+		h.encoder.StatusResponse(ctx, w, nil, http.StatusBadRequest)
+		return
+	}
+
+	err := h.config.UpdateConfig(data.LogPath)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
+	err = h.service.CreateUser(ctx, data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
+	// send empty response as ok
+	h.encoder.StatusResponse(ctx, w, nil, http.StatusNoContent)
+}
+
+func (h onboardHandler) canOnboard(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	userCount, err := h.service.GetUserCount(ctx)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if userCount > 0 {
+		// send 503 service onboarding unavailable
+		http.Error(w, "Onboarding unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	// send empty response as ok
+	// (client can proceed with redirection to onboarding page)
+	h.encoder.StatusResponse(ctx, w, nil, http.StatusNoContent)
+}
+
+func (h onboardHandler) getOnboardingPreferences(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	userCount, err := h.service.GetUserCount(ctx)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if userCount > 0 {
+		// send 503 service onboarding unavailable
+		http.Error(w, "Onboarding unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	logDir, logErrors := h.config.GetPreferredLogDir()
+	result := domain.OnboardingPreferences{
+		LogDir:    logDir,
+		LogErrors: logErrors,
+	}
+
+	h.encoder.StatusResponse(r.Context(), w, result, http.StatusOK)
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -102,13 +102,15 @@ func (s Server) Handler() http.Handler {
 		fileSystem.ServeHTTP(w, r)
 	})
 
-	r.Route("/api/auth", newAuthHandler(encoder, s.config, s.cookieStore, s.authService).Routes)
-	r.Route("/api/healthz", newHealthHandler(encoder, s.db).Routes)
+	r.Route("/api", func(r chi.Router) {
+		r.Route("/healthz", newHealthHandler(encoder, s.db).Routes)
 
-	r.Group(func(r chi.Router) {
-		r.Use(s.IsAuthenticated)
+		r.Route("/auth", newAuthHandler(encoder, s.config, s.cookieStore, s.authService).Routes)
+		r.Route("/onboard", newOnboardHandler(encoder, s.config, s.authService).Routes)
 
-		r.Route("/api", func(r chi.Router) {
+		r.Group(func(r chi.Router) {
+			r.Use(s.IsAuthenticated)
+
 			r.Route("/actions", newActionHandler(encoder, s.actionService).Routes)
 			r.Route("/config", newConfigHandler(encoder, s).Routes)
 			r.Route("/download_clients", newDownloadClientHandler(encoder, s.downloadClientService).Routes)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Onboarding } from "./screens/auth/onboarding";
 import { baseUrl } from "./utils";
 import { AuthContext, SettingsContext } from "./utils/Context";
 import { ErrorPage } from "./components/alerts";
-import Toast from "./components/notifications/Toast";
+import { Toast } from "./components/notifications/Toast";
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -72,14 +72,7 @@ export const APIClient = {
       password: password
     }),
     logout: () => appClient.Post("api/auth/logout", null),
-    validate: () => appClient.Get<void>("api/auth/validate"),
-    onboard: (username: string, password: string, logDir: string) => appClient.Post("api/auth/onboard", {
-      username: username,
-      password: password,
-      log_dir: logDir
-    }),
-    canOnboard: () => appClient.Get("api/auth/onboard"),
-    getOnboardingPreferences: () => appClient.Get<OnboardingPreferences>("api/auth/onboard/preferences")
+    validate: () => appClient.Get<void>("api/auth/validate")
   },
   actions: {
     create: (action: Action) => appClient.Post("api/actions", action),
@@ -138,6 +131,15 @@ export const APIClient = {
     create: (notification: Notification) => appClient.Post("api/notification", notification),
     update: (notification: Notification) => appClient.Put(`api/notification/${notification.id}`, notification),
     delete: (id: number) => appClient.Delete(`api/notification/${id}`)
+  },
+  onboard: {
+    create: (username: string, password: string, logDir: string) => appClient.Post("api/onboard", {
+      username: username,
+      password: password,
+      log_dir: logDir
+    }),
+    canOnboard: () => appClient.Get("api/onboard"),
+    getPreferences: () => appClient.Get<OnboardingPreferences>("api/onboard/preferences")
   },
   release: {
     find: (query?: string) => appClient.Get<ReleaseFindResponse>(`api/release${query}`),

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -73,11 +73,13 @@ export const APIClient = {
     }),
     logout: () => appClient.Post("api/auth/logout", null),
     validate: () => appClient.Get<void>("api/auth/validate"),
-    onboard: (username: string, password: string) => appClient.Post("api/auth/onboard", {
+    onboard: (username: string, password: string, logDir: string) => appClient.Post("api/auth/onboard", {
       username: username,
-      password: password
+      password: password,
+      log_dir: logDir
     }),
-    canOnboard: () => appClient.Get("api/auth/onboard")
+    canOnboard: () => appClient.Get("api/auth/onboard"),
+    getOnboardingPreferences: () => appClient.Get<OnboardingPreferences>("api/auth/onboard/preferences")
   },
   actions: {
     create: (action: Action) => appClient.Post("api/actions", action),

--- a/web/src/components/inputs/input.tsx
+++ b/web/src/components/inputs/input.tsx
@@ -94,35 +94,39 @@ export const PasswordField = ({
           {label} {required && <span className="text-gray-500">*</span>}
         </label>
       )}
-      <Field name={name} defaultValue={defaultValue}>
-        {({
-          field,
-          meta
-        }: FieldProps) => (
-          <div className="sm:col-span-2 relative">
-            <input
-              {...field}
-              id={name}
-              type={isVisible ? "text" : "password"}
-              autoComplete={autoComplete}
-              className={classNames(meta.touched && meta.error ? "focus:ring-red-500 focus:border-red-500 border-red-500" : "focus:ring-indigo-500 dark:focus:ring-blue-500 focus:border-indigo-500 dark:focus:border-blue-500 border-gray-300 dark:border-gray-700", "mt-2 block w-full dark:bg-gray-800 dark:text-gray-100 rounded-md")}
-              placeholder={placeholder}
-            />
+      <div>
+        <Field name={name} defaultValue={defaultValue}>
+          {({
+            field,
+            meta
+          }: FieldProps) => (
+            <>
+              <div className="sm:col-span-2 relative">
+                <input
+                  {...field}
+                  id={name}
+                  type={isVisible ? "text" : "password"}
+                  autoComplete={autoComplete}
+                  className={classNames(meta.touched && meta.error ? "focus:ring-red-500 focus:border-red-500 border-red-500" : "focus:ring-indigo-500 dark:focus:ring-blue-500 focus:border-indigo-500 dark:focus:border-blue-500 border-gray-300 dark:border-gray-700", "mt-2 block w-full dark:bg-gray-800 dark:text-gray-100 rounded-md")}
+                  placeholder={placeholder}
+                />
 
-            <div className="absolute inset-y-0 right-0 px-3 flex items-center" onClick={toggleVisibility}>
-              {!isVisible ? <EyeIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" /> : <EyeOffIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" />}
-            </div>
+                <div className="absolute inset-y-0 right-0 px-3 flex items-center" onClick={toggleVisibility}>
+                  {!isVisible ? <EyeIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" /> : <EyeOffIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" />}
+                </div>
 
-            {help && (
-              <p className="mt-2 text-sm text-gray-500" id="email-description">{help}</p>
-            )}
+              </div>
+              {help && (
+                <p className="mt-2 text-sm text-gray-500" id="email-description">{help}</p>
+              )}
 
-            {meta.touched && meta.error && (
-              <p className="error text-sm text-red-600 mt-1">* {meta.error}</p>
-            )}
-          </div>
-        )}
-      </Field>
+              {meta.touched && meta.error && (
+                <p className="error text-sm text-red-600 mt-1">* {meta.error}</p>
+              )}
+            </>
+          )}
+        </Field>
+      </div>
     </div>
   );
 };

--- a/web/src/components/notifications/Toast.tsx
+++ b/web/src/components/notifications/Toast.tsx
@@ -1,4 +1,3 @@
-import { FC } from "react";
 import { XIcon, CheckCircleIcon, ExclamationIcon, ExclamationCircleIcon } from "@heroicons/react/solid";
 import { toast, Toast as Tooast } from "react-hot-toast";
 import { classNames } from "../../utils";
@@ -9,7 +8,7 @@ type Props = {
   t?: Tooast;
 };
 
-const Toast: FC<Props> = ({ type, body, t }) => (
+export const Toast = ({ type, body, t }: Props) => (
   <div className={classNames(
     t?.visible ? "animate-enter" : "animate-leave",
     "max-w-sm w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden transition-all")}>
@@ -43,5 +42,3 @@ const Toast: FC<Props> = ({ type, body, t }) => (
     </div>
   </div>
 );
-
-export default Toast;

--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -9,7 +9,7 @@ import type { FieldProps } from "formik";
 import { queryClient } from "../../App";
 import { APIClient } from "../../api/APIClient";
 import DEBUG from "../../components/debug";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 
 interface filterAddFormProps {
     isOpen: boolean;

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -10,7 +10,7 @@ import { APIClient } from "../../api/APIClient";
 import { DownloadClientTypeOptions } from "../../domain/constants";
 
 import { toast } from "react-hot-toast";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 import { useToggle } from "../../hooks/hooks";
 import { DeleteModal } from "../../components/modals";
 import { NumberFieldWide, PasswordFieldWide, SwitchGroupWide, TextFieldWide } from "../../components/inputs/input_wide";

--- a/web/src/forms/settings/FeedForms.tsx
+++ b/web/src/forms/settings/FeedForms.tsx
@@ -2,7 +2,7 @@ import { useMutation } from "react-query";
 import { APIClient } from "../../api/APIClient";
 import { queryClient } from "../../App";
 import { toast } from "react-hot-toast";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 import { SlideOver } from "../../components/panels";
 import { NumberFieldWide, PasswordFieldWide, SwitchGroupWide, TextFieldWide } from "../../components/inputs";
 import { ImplementationMap } from "../../screens/settings/Feed";

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -24,7 +24,7 @@ import {
   SwitchGroupWide
 } from "../../components/inputs";
 import { SlideOver } from "../../components/panels";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 
 const Input = (props: InputProps) => {
   return (
@@ -534,7 +534,7 @@ export function IndexerUpdateForm({ isOpen, toggle, indexer }: UpdateProps) {
                 htmlFor="name"
                 className="block text-sm font-medium text-gray-900 dark:text-white sm:mt-px sm:pt-2"
               >
-                                Name
+                Name
               </label>
             </div>
             <Field name="name">

--- a/web/src/forms/settings/IrcForms.tsx
+++ b/web/src/forms/settings/IrcForms.tsx
@@ -14,7 +14,7 @@ import {
   NumberFieldWide
 } from "../../components/inputs";
 import { SlideOver } from "../../components/panels";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 
 interface ChannelsFieldArrayProps {
   channels: IrcChannel[];

--- a/web/src/forms/settings/NotifiactionForms.tsx
+++ b/web/src/forms/settings/NotifiactionForms.tsx
@@ -14,7 +14,7 @@ import { useMutation } from "react-query";
 import { APIClient } from "../../api/APIClient";
 import { queryClient } from "../../App";
 import { toast } from "react-hot-toast";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 import { SlideOver } from "../../components/panels";
 import { componentMapType } from "./DownloadClientForms";
 

--- a/web/src/screens/auth/login.tsx
+++ b/web/src/screens/auth/login.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useHistory } from "react-router-dom";
 import { useMutation } from "react-query";
 import { Form, Formik } from "formik";
@@ -7,7 +8,6 @@ import { TextField, PasswordField } from "../../components/inputs";
 
 import logo from "../../logo.png";
 import { AuthContext } from "../../utils/Context";
-import { useEffect } from "react";
 
 interface LoginData {
   username: string;

--- a/web/src/screens/auth/login.tsx
+++ b/web/src/screens/auth/login.tsx
@@ -21,7 +21,7 @@ export const Login = () => {
   useEffect(() => {
     // Check if onboarding is available for this instance
     // and redirect if needed
-    APIClient.auth.canOnboard()
+    APIClient.onboard.canOnboard()
       .then(() => history.push("/onboard"));
   }, [history]);
 

--- a/web/src/screens/auth/onboarding.tsx
+++ b/web/src/screens/auth/onboarding.tsx
@@ -35,7 +35,7 @@ export const Onboarding = () => {
 
   const { data: preferences, isError } = useQuery(
     "onboarding_preferences",
-    APIClient.auth.getOnboardingPreferences,
+    APIClient.onboard.getPreferences,
     {
       onSuccess: (responseData) => {
         // Show all errors/warnings encountered while searching for a preferred log directory.
@@ -57,7 +57,7 @@ export const Onboarding = () => {
 
   const mutation = useMutation(
     (data: InputValues) => (
-      APIClient.auth.onboard(
+      APIClient.onboard.create(
         data.username,
         data.password1,
         data.logDir
@@ -78,11 +78,11 @@ export const Onboarding = () => {
       <h1
         className="text-3xl text-center font-bold text-gray-900 dark:text-gray-200 my-4"
       >
-        {!isError ? "Create a new user" : "Onboarding is currently unavailable."}
+        {!isError ? "Initial setup" : "Onboarding is currently unavailable."}
       </h1>
       {preferences && !isError ? (
         <div className="sm:mx-auto sm:w-full sm:max-w-md shadow-lg">
-          <div className="bg-white dark:bg-gray-800 py-8 px-4 sm:rounded-lg sm:px-10">
+          <div className="bg-white dark:bg-gray-800 py-8 px-4 sm:rounded-lg sm:px-8">
             <Formik
               initialValues={{
                 username: "",
@@ -94,21 +94,27 @@ export const Onboarding = () => {
               validate={validate}
             >
               <Form>
-                <div className="space-y-3">
-                  <TextField name="username" label="Username" columns={6} autoComplete="username" />
-                  <PasswordField name="password1" label="Password" columns={6} autoComplete="current-password" />
-                  <PasswordField name="password2" label="Confirm password" columns={6} autoComplete="current-password" />
-                  <TextField name="logDir" label="Log dir" columns={6} />
+                <div>
+                  <div className="space-y-4">
+                    <h3 className="text-xl text-center font-bold text-gray-900 dark:text-gray-200 pt-2">Create user</h3>
+                    <TextField name="username" label="Username" columns={6} autoComplete="username" />
+                    <PasswordField name="password1" label="Password" columns={6} autoComplete="current-password" />
+                    <PasswordField name="password2" label="Confirm password" columns={6} autoComplete="current-password" />
+                  </div>
+                  <div className="mt-6">
+                    <h3 className="text-xl text-center font-bold text-gray-900 dark:text-gray-200 py-4">Settings</h3>
+                    <TextField name="logDir" label="Log dir" columns={6} />
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+                      Leave Log dir empty if you wish not to keep log files.
+                    </p>
+                  </div>
                 </div>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  Leave Log dir empty if you wish not to keep log files.
-                </p>
-                <div className="mt-4">
+                <div className="mt-8">
                   <button
                     type="submit"
                     className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 dark:bg-blue-600 hover:bg-indigo-700 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-blue-500"
                   >
-                    Create user!
+                    Save and continue
                   </button>
                 </div>
               </Form>

--- a/web/src/screens/auth/onboarding.tsx
+++ b/web/src/screens/auth/onboarding.tsx
@@ -1,14 +1,17 @@
 import { Form, Formik } from "formik";
-import { useMutation } from "react-query";
+import { useMutation, useQuery } from "react-query";
 import { useHistory } from "react-router-dom";
-import { APIClient } from "../../api/APIClient";
+import { toast } from "react-hot-toast";
 
+import { APIClient } from "../../api/APIClient";
+import { Toast } from "../../components/notifications/Toast";
 import { TextField, PasswordField } from "../../components/inputs";
 
 interface InputValues {
   username: string;
   password1: string;
   password2: string;
+  logDir: string;
 }
 
 export const Onboarding = () => {
@@ -30,10 +33,32 @@ export const Onboarding = () => {
     return obj;
   };
 
+  const { data: preferences, isError } = useQuery(
+    "onboarding_preferences",
+    APIClient.auth.getOnboardingPreferences,
+    {
+      onSuccess: (responseData) => {
+        // Show all errors/warnings encountered while searching for a preferred log directory.
+        if (responseData.log_errors === undefined)
+          return;
+        
+        responseData.log_errors.forEach((errString) => {
+          toast.custom((t) => <Toast type="error" body={errString} t={t} />);
+        });
+      }
+    }
+  );
+
   const history = useHistory();
 
   const mutation = useMutation(
-    (data: InputValues) => APIClient.auth.onboard(data.username, data.password1),
+    (data: InputValues) => (
+      APIClient.auth.onboard(
+        data.username,
+        data.password1,
+        data.logDir
+      )
+    ),
     {
       onSuccess: () => {
         history.push("/login");
@@ -41,44 +66,52 @@ export const Onboarding = () => {
     }
   );
 
+  if (!preferences)
+    return null;
+
   return (
     <div className="min-h-screen flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-      <div className="sm:mx-auto sm:w-full sm:max-w-md mb-6">
-        <h1
-          className="text-3xl font-bold leading-6 text-gray-900 dark:text-gray-200 mt-4"
-        >
-          Create a new user
-        </h1>
-      </div>
-      <div className="sm:mx-auto sm:w-full sm:max-w-md shadow-lg">
-        <div className="bg-white dark:bg-gray-800 py-8 px-4 sm:rounded-lg sm:px-10">
-          <Formik
-            initialValues={{
-              username: "",
-              password1: "",
-              password2: ""
-            }}
-            onSubmit={(data) => mutation.mutate(data)}
-            validate={validate}
-          >
-            <Form>
-              <div className="space-y-6">
-                <TextField name="username" label="Username" columns={6} autoComplete="username" />
-                <PasswordField name="password1" label="Password" columns={6} autoComplete="current-password" />
-                <PasswordField name="password2" label="Confirm password" columns={6} autoComplete="current-password" />
-              </div>
-              <div className="mt-6">
-                <button
-                  type="submit"
-                  className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 dark:bg-blue-600 hover:bg-indigo-700 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-blue-500"
-                >
-                  Create an account!
-                </button>
-              </div>
-            </Form>
-          </Formik>
+      <h1
+        className="text-3xl text-center font-bold text-gray-900 dark:text-gray-200 my-4"
+      >
+        {!isError ? "Create a new user" : "Onboarding is currently unavailable."}
+      </h1>
+      {preferences && !isError ? (
+        <div className="sm:mx-auto sm:w-full sm:max-w-md shadow-lg">
+          <div className="bg-white dark:bg-gray-800 py-8 px-4 sm:rounded-lg sm:px-10">
+            <Formik
+              initialValues={{
+                username: "",
+                password1: "",
+                password2: "",
+                logDir: preferences.log_dir
+              }}
+              onSubmit={(data) => mutation.mutate(data)}
+              validate={validate}
+            >
+              <Form>
+                <div className="space-y-3">
+                  <TextField name="username" label="Username" columns={6} autoComplete="username" />
+                  <PasswordField name="password1" label="Password" columns={6} autoComplete="current-password" />
+                  <PasswordField name="password2" label="Confirm password" columns={6} autoComplete="current-password" />
+                  <TextField name="logDir" label="Log dir" columns={6} />
+                </div>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  Leave Log dir empty if you wish not to keep log files.
+                </p>
+                <div className="mt-4">
+                  <button
+                    type="submit"
+                    className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 dark:bg-blue-600 hover:bg-indigo-700 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-blue-500"
+                  >
+                    Create user!
+                  </button>
+                </div>
+              </Form>
+            </Formik>
+          </div>
         </div>
-      </div>
+      ) : null}
     </div>
   );
 };

--- a/web/src/screens/auth/onboarding.tsx
+++ b/web/src/screens/auth/onboarding.tsx
@@ -43,6 +43,10 @@ export const Onboarding = () => {
           return;
         
         responseData.log_errors.forEach((errString) => {
+          // Don't notify about empty errors
+          if (!errString.trim().length)
+            return;
+
           toast.custom((t) => <Toast type="error" body={errString} t={t} />);
         });
       }

--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -46,7 +46,7 @@ import {
   CheckboxField
 } from "../../components/inputs";
 import DEBUG from "../../components/debug";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 import { AlertWarning } from "../../components/alerts";
 import { DeleteModal } from "../../components/modals";
 import { TitleSubtitle } from "../../components/headings";

--- a/web/src/screens/filters/list.tsx
+++ b/web/src/screens/filters/list.tsx
@@ -15,7 +15,7 @@ import { classNames } from "../../utils";
 import { FilterAddForm } from "../../forms";
 import { useToggle } from "../../hooks/hooks";
 import { APIClient } from "../../api/APIClient";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 import { EmptyListState } from "../../components/emptystates";
 import { DeleteModal } from "../../components/modals";
 

--- a/web/src/screens/settings/Feed.tsx
+++ b/web/src/screens/settings/Feed.tsx
@@ -6,7 +6,7 @@ import { Menu, Switch, Transition } from "@headlessui/react";
 import { classNames } from "../../utils";
 import { Fragment, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 import { queryClient } from "../../App";
 import { DeleteModal } from "../../components/modals";
 import {

--- a/web/src/screens/settings/Releases.tsx
+++ b/web/src/screens/settings/Releases.tsx
@@ -3,7 +3,7 @@ import { useMutation } from "react-query";
 import { toast } from "react-hot-toast";
 
 import { APIClient } from "../../api/APIClient";
-import Toast from "../../components/notifications/Toast";
+import { Toast } from "../../components/notifications/Toast";
 import { queryClient } from "../../App";
 import { useToggle } from "../../hooks/hooks";
 import { DeleteModal } from "../../components/modals";

--- a/web/src/types/Global.d.ts
+++ b/web/src/types/Global.d.ts
@@ -1,3 +1,8 @@
 interface APP {
   baseUrl: string;
 }
+
+interface OnboardingPreferences {
+  log_dir: string;
+  log_errors?: Array<string>;
+}


### PR DESCRIPTION
refactor(config): change default logPath parent directory from `log` to `logs` for better wording.
refactor(domain): added a custom CreateUserRequest structure to use for the onboarding POST endpoint and refactored related code
feat(onboarding): added possibility to configure log directory from frontend onboarding page. added /onboard/preferences GET endpoint which is currently used to recommend a log directory. maybe the endpoint should account for an already non-standard logPath provided in config.toml
refactor(http/auth): removed cookie/is user authenticated checks which are redundant and are already implied with the userCount > 0 checks.
refactor(frontend/App): moved toaster a bit up in the hierarchy and made it available to unauthorized routes, so now for example, the Login page displays a toast on error, ditto for the Onboarding page.
refactor(frontend/HttpClient): removed specialized 403/404 error handling case.
refactor(frontend/Onboard): adapted for above-mentioned changes and fixed a few styling-related things.

remarks:
- GetPreferredLogDir() keeps tracks of errors it finds and passes them to frontend. The idea behind this is to report potential misconfiguration to the end-user.
- This PR only helps solve at which directory should the log file be located at, and the idea is for non-advanced users for the log file name to be "autobrr.log" and leave custom configuring to more advanced users.

TODO: Doesn't actually save the logPath to config.toml