### PR TITLE
feat(actions): wait for the filter delay before performing actions

### DIFF
--- a/internal/release/service.go
+++ b/internal/release/service.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/autobrr/autobrr/internal/action"
 	"github.com/autobrr/autobrr/internal/domain"
@@ -127,6 +128,13 @@ func (s *service) Process(release *domain.Release) {
 				log.Error().Err(err).Msgf("announce.Service.Process: error writing release to database: %+v", release)
 				return
 			}
+		}
+
+		// sleep for the delay period specified in the filter before running actions
+		delay := release.Filter.Delay
+		if delay > 0 {
+			log.Debug().Msgf("Delaying processing of '%v' (%v) for %v by %d seconds as specified in the filter", release.TorrentName, release.Filter.Name, release.Indexer, delay)
+			time.Sleep(time.Duration(delay) * time.Second)
 		}
 
 		var rejections []string


### PR DESCRIPTION
I haven't had a filter match yet to actually validate the delay, but I'll comment here when I do. It's the same logic as https://github.com/autobrr/autobrr/pull/255/commits/9a5b58beb3e295bd1d9f603aab50fe81a41d5f16 just in the new location.