### PR TITLE
fix(db): initial schema filter origins nullable

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -101,7 +101,7 @@ CREATE TABLE filter
     except_uploaders      TEXT,
     tags                  TEXT,
     except_tags           TEXT,
-	origins               TEXT []   DEFAULT '{}' NOT NULL,
+	origins               TEXT []   DEFAULT '{}',
     created_at            TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at            TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -52,7 +52,8 @@ function FilterAddForm({ isOpen, toggle }: any) {
                                         resolutions: [],
                                         codecs: [],
                                         sources: [],
-                                        containers: []
+                                        containers: [],
+                                        origins: [],
                                     }}
                                     onSubmit={handleSubmit}
                                     validate={validate}


### PR DESCRIPTION
Fix inconsistency in initial schema for sqlite where `filter.origins` was `NOT NULL` but the migrations was nullable.

- Fix initial schema (sqlite)
- Send empty origins array to fix current installs