### PR TITLE
docs: removed deluge reannounce from feature list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Installation guide and documentation can be found at https://autobrr.com
     - With built in reannounce
   - Deluge
     - v1+ and v2 support
-    - With built in reannounce
   - Radarr
   - Sonarr
   - Lidarr


### PR DESCRIPTION
Not sure where I got that from in the first place. My bad.