### PR TITLE
fix(config): load sqlite from configdir

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,7 @@ func New(configPath string, version string) *AppConfig {
 	c := &AppConfig{}
 	c.defaults()
 	c.Config.Version = version
+	c.Config.ConfigPath = configPath
 
 	c.load(configPath)
 


### PR DESCRIPTION
Accidentally removed the configpath for sqlite in previous PR when refactoring the config.

This adds it back.