### PR TITLE
fix(qbittorrent): params url parsing

### DIFF
--- a/pkg/qbittorrent/domain.go
+++ b/pkg/qbittorrent/domain.go
@@ -50,12 +50,12 @@ type TorrentTrackersResponse struct {
 }
 
 type TorrentTracker struct {
-	//Tier          uint   `json:"tier"` // can be both empty "" and int
+	//Tier          int   `json:"tier"` // can be both empty "" and int
 	Url           string        `json:"url"`
 	Status        TrackerStatus `json:"status"`
 	NumPeers      int           `json:"num_peers"`
 	NumSeeds      int           `json:"num_seeds"`
-	NumLeechers   int           `json:"num_leechers"`
+	NumLeechers   int           `json:"num_leeches"`
 	NumDownloaded int           `json:"num_downloaded"`
 	Message       string        `json:"msg"`
 }


### PR DESCRIPTION
With the recent change of url parsing for qbit to support more urls, params stopped working.

This pr changes how url query params are added to http client requests.