### PR TITLE
fix(download-clients): qBit transform speed limit from B to KB

### DIFF
--- a/internal/action/qbittorrent.go
+++ b/internal/action/qbittorrent.go
@@ -56,10 +56,10 @@ func (s *service) qbittorrent(qbt *qbittorrent.Client, action domain.Action, rel
 		options["tags"] = tagsArgs
 	}
 	if action.LimitUploadSpeed > 0 {
-		options["upLimit"] = strconv.FormatInt(action.LimitUploadSpeed, 10)
+		options["upLimit"] = (strconv.FormatInt(action.LimitUploadSpeed, 10) * 1000)
 	}
 	if action.LimitDownloadSpeed > 0 {
-		options["dlLimit"] = strconv.FormatInt(action.LimitDownloadSpeed, 10)
+		options["dlLimit"] = (strconv.FormatInt(action.LimitDownloadSpeed, 10) * 1000)
 	}
 	if action.LimitRatio > 0 {
 		options["ratioLimit"] = strconv.FormatFloat(action.LimitRatio, 'r', 2, 64)


### PR DESCRIPTION
qBittorrent transparently moves this from B/s to KB/s in the UI and POST request. Presently if you specify 500 in the autobrr KB/s field for qBittorrent you get a staggering 500B/s.