### PR TITLE
feat(releases): search in ui

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -117,6 +117,11 @@ func (repo *ReleaseRepo) Find(ctx context.Context, params domain.ReleaseQueryPar
 		release.ActionStatus = statuses
 	}
 
+	if err = tx.Commit(); err != nil {
+		repo.log.Error().Stack().Err(err).Msg("error finding releases")
+		return nil, 0, 0, err
+	}
+
 	return releases, nextCursor, total, nil
 }
 
@@ -204,6 +209,82 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 	}
 
 	return res, nextCursor, countItems, nil
+}
+
+func (repo *ReleaseRepo) FindRecent(ctx context.Context) ([]*domain.Release, error) {
+	tx, err := repo.db.BeginTx(ctx, &sql.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	releases, err := repo.findRecentReleases(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, release := range releases {
+		statuses, err := repo.attachActionStatus(ctx, tx, release.ID)
+		if err != nil {
+			return releases, err
+		}
+		release.ActionStatus = statuses
+	}
+
+	if err = tx.Commit(); err != nil {
+		repo.log.Error().Stack().Err(err).Msg("error finding releases")
+		return nil, err
+	}
+
+	return releases, nil
+}
+
+func (repo *ReleaseRepo) findRecentReleases(ctx context.Context, tx *Tx) ([]*domain.Release, error) {
+	queryBuilder := repo.db.squirrel.
+		Select("r.id", "r.filter_status", "r.rejections", "r.indexer", "r.filter", "r.protocol", "r.title", "r.torrent_name", "r.size", "r.timestamp").
+		From("release r").
+		OrderBy("r.timestamp DESC").
+		Limit(10)
+
+	query, args, err := queryBuilder.ToSql()
+	repo.log.Trace().Str("database", "release.find").Msgf("query: '%v', args: '%v'", query, args)
+	if err != nil {
+		repo.log.Error().Stack().Err(err).Msg("error building query")
+		return nil, err
+	}
+
+	res := make([]*domain.Release, 0)
+
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		repo.log.Error().Stack().Err(err).Msg("error fetching releases")
+		return res, nil
+	}
+
+	defer rows.Close()
+
+	if err := rows.Err(); err != nil {
+		repo.log.Error().Stack().Err(err)
+		return res, err
+	}
+
+	for rows.Next() {
+		var rls domain.Release
+
+		var indexer, filter sql.NullString
+
+		if err := rows.Scan(&rls.ID, &rls.FilterStatus, pq.Array(&rls.Rejections), &indexer, &filter, &rls.Protocol, &rls.Title, &rls.TorrentName, &rls.Size, &rls.Timestamp); err != nil {
+			repo.log.Error().Stack().Err(err).Msg("release.find: error scanning data to struct")
+			return res, err
+		}
+
+		rls.Indexer = indexer.String
+		rls.FilterName = filter.String
+
+		res = append(res, &rls)
+	}
+
+	return res, nil
 }
 
 func (repo *ReleaseRepo) GetIndexerOptions(ctx context.Context) ([]string, error) {
@@ -368,7 +449,6 @@ func (repo *ReleaseRepo) Delete(ctx context.Context) error {
 	if err != nil {
 		repo.log.Error().Stack().Err(err).Msg("error deleting all releases")
 		return err
-
 	}
 
 	return nil

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -25,6 +25,7 @@ import (
 type ReleaseRepo interface {
 	Store(ctx context.Context, release *Release) (*Release, error)
 	Find(ctx context.Context, params ReleaseQueryParams) (res []*Release, nextCursor int64, count int64, err error)
+	FindRecent(ctx context.Context) ([]*Release, error)
 	GetIndexerOptions(ctx context.Context) ([]string, error)
 	GetActionStatusByReleaseID(ctx context.Context, releaseID int64) ([]ReleaseActionStatus, error)
 	Stats(ctx context.Context) (*ReleaseStats, error)

--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -10,7 +10,7 @@ type encoder struct{}
 
 type errorResponse struct {
 	Message string `json:"message"`
-	Status  int    `json:"status"`
+	Status  int    `json:"status,omitempty"`
 }
 
 func (e encoder) StatusResponse(ctx context.Context, w http.ResponseWriter, response interface{}, status int) {

--- a/internal/http/release.go
+++ b/internal/http/release.go
@@ -86,6 +86,7 @@ func (h releaseHandler) findReleases(w http.ResponseWriter, r *http.Request) {
 	indexer := vals["indexer"]
 
 	pushStatus := r.URL.Query().Get("push_status")
+	search := r.URL.Query().Get("q")
 
 	query := domain.ReleaseQueryParams{
 		Limit:  uint64(limit),
@@ -96,6 +97,7 @@ func (h releaseHandler) findReleases(w http.ResponseWriter, r *http.Request) {
 			Indexers   []string
 			PushStatus string
 		}{Indexers: indexer, PushStatus: pushStatus},
+		Search: search,
 	}
 
 	releases, nextCursor, count, err := h.service.Find(r.Context(), query)

--- a/internal/release/service.go
+++ b/internal/release/service.go
@@ -13,6 +13,7 @@ import (
 
 type Service interface {
 	Find(ctx context.Context, query domain.ReleaseQueryParams) (res []*domain.Release, nextCursor int64, count int64, err error)
+	FindRecent(ctx context.Context) ([]*domain.Release, error)
 	GetIndexerOptions(ctx context.Context) ([]string, error)
 	Stats(ctx context.Context) (*domain.ReleaseStats, error)
 	Store(ctx context.Context, release *domain.Release) error
@@ -47,6 +48,10 @@ func NewService(log logger.Logger, repo domain.ReleaseRepo, actionSvc action.Ser
 
 func (s *service) Find(ctx context.Context, query domain.ReleaseQueryParams) (res []*domain.Release, nextCursor int64, count int64, err error) {
 	return s.repo.Find(ctx, query)
+}
+
+func (s *service) FindRecent(ctx context.Context) (res []*domain.Release, err error) {
+	return s.repo.FindRecent(ctx)
 }
 
 func (s *service) GetIndexerOptions(ctx context.Context) ([]string, error) {

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -142,7 +142,7 @@ export const APIClient = {
     find: (query?: string) => appClient.Get<ReleaseFindResponse>(`api/release${query}`),
     findQuery: (offset?: number, limit?: number, filters?: Array<ReleaseFilter>) => {
       const params = new URLSearchParams();
-      if (offset !== undefined)
+      if (offset !== undefined && offset > 0)
         params.append("offset", offset.toString());
 
       if (limit !== undefined)
@@ -156,6 +156,8 @@ export const APIClient = {
           params.append("indexer", filter.value);
         else if (filter.id === "action_status")
           params.append("push_status", filter.value);
+        else if (filter.id == "torrent_name")
+          params.append("q", filter.value);
       });
 
       return appClient.Get<ReleaseFindResponse>(`api/release?${params.toString()}`);

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -140,6 +140,7 @@ export const APIClient = {
   },
   release: {
     find: (query?: string) => appClient.Get<ReleaseFindResponse>(`api/release${query}`),
+    findRecent: () => appClient.Get<ReleaseFindResponse>("api/release/recent"),
     findQuery: (offset?: number, limit?: number, filters?: Array<ReleaseFilter>) => {
       const params = new URLSearchParams();
       if (offset !== undefined && offset > 0)

--- a/web/src/screens/dashboard/ActivityTable.tsx
+++ b/web/src/screens/dashboard/ActivityTable.tsx
@@ -13,7 +13,6 @@ import { EmptyListState } from "../../components/emptystates";
 
 import * as Icons from "../../components/Icons";
 import * as DataTable from "../../components/data-table";
-import { Fragment } from "react";
 
 // This is a custom filter UI for selecting
 // a unique option from a list
@@ -180,8 +179,8 @@ export const ActivityTable = () => {
   ], []);
 
   const { isLoading, data } = useQuery(
-    "dash_release",
-    () => APIClient.release.find("?limit=10"),
+    "dash_recent_releases",
+    () => APIClient.release.findRecent(),
     { refetchOnWindowFocus: false }
   );
 

--- a/web/src/screens/releases/Filters.tsx
+++ b/web/src/screens/releases/Filters.tsx
@@ -10,6 +10,7 @@ import { APIClient } from "../../api/APIClient";
 import { classNames } from "../../utils";
 import { PushStatusOptions } from "../../domain/constants";
 import { FilterProps } from "react-table";
+import { DebounceInput } from "react-debounce-input";
 
 interface ListboxFilterProps {
     id: string;
@@ -77,6 +78,7 @@ export const IndexerSelectColumnFilter = ({
   return (
     <ListboxFilter
       id={id}
+      key={id}
       label={filterValue ?? "Indexer"}
       currentValue={filterValue}
       onChange={setFilter}
@@ -126,7 +128,7 @@ export const PushStatusSelectColumnFilter = ({
 }: FilterProps<object>) => {
   const label = filterValue ? PushStatusOptions.find((o) => o.value === filterValue && o.value)?.label : "Push status";
   return (
-    <div className="mr-3">
+    <div className="mr-3" key={id}>
       <ListboxFilter
         id={id}
         label={label ?? "Push status"}
@@ -137,5 +139,26 @@ export const PushStatusSelectColumnFilter = ({
           <FilterOption key={idx} value={status.value} label={status.label} />
         ))}
       </ListboxFilter>
+    </div>
+  );};
+
+export const SearchColumnFilter = ({
+  column: { filterValue, setFilter, id }
+}: FilterProps<object>) => {
+  return (
+    <div className="flex-1 mr-3 mt-1" key={id}>
+      <DebounceInput
+        minLength={2}
+        value={filterValue || undefined}
+        debounceTimeout={500}
+        onChange={e => {
+          setFilter(e.target.value || undefined); // Set undefined to remove the filter entirely
+        }}
+        id="filter"
+        type="text"
+        autoComplete="off"
+        className="relative w-full py-2 pl-3 pr-10 text-left bg-white dark:bg-gray-800 rounded-lg shadow-md cursor-default dark:text-gray-400 sm:text-sm border-none"
+        placeholder="Search releases..."
+      />
     </div>
   );};

--- a/web/src/screens/releases/ReleaseTable.tsx
+++ b/web/src/screens/releases/ReleaseTable.tsx
@@ -22,7 +22,7 @@ import * as DataTable from "../../components/data-table";
 
 import {
   IndexerSelectColumnFilter,
-  PushStatusSelectColumnFilter
+  PushStatusSelectColumnFilter, SearchColumnFilter
 } from "./Filters";
 
 type TableState = {
@@ -77,7 +77,8 @@ export const ReleaseTable = () => {
     {
       Header: "Release",
       accessor: "torrent_name",
-      Cell: DataTable.TitleCell
+      Cell: DataTable.TitleCell,
+      Filter: SearchColumnFilter
     },
     {
       Header: "Actions",
@@ -185,9 +186,7 @@ export const ReleaseTable = () => {
         {headerGroups.map((headerGroup) =>
           headerGroup.headers.map((column) => (
             column.Filter ? (
-              <div className="mt-2 sm:mt-0" key={column.id}>
-                <>{column.render("Filter")}</>
-              </div>
+              <React.Fragment key={column.id}>{column.render("Filter")}</React.Fragment>
             ) : null
           ))
         )}


### PR DESCRIPTION
Add ability to search releases in release list.

It's using basic `WHERE column LIKE '%something%'` to query data. Works for both `SQLite` and `postgres`.

## Future improvements

- Use FST (Full text search) built into both sqlite and postgres

## Other work

- refactor and optimize queries on dashboard