### PR TITLE
fix(web): modal double state update

### DIFF
--- a/web/src/screens/settings/Releases.tsx
+++ b/web/src/screens/settings/Releases.tsx
@@ -13,13 +13,11 @@ function ReleaseSettings() {
   const deleteMutation = useMutation(() => APIClient.release.delete(), {
     onSuccess: () => {
       toast.custom((t) => (
-        <Toast type="success" body={"All releases was deleted"} t={t}/>
+        <Toast type="success" body={"All releases were deleted"} t={t}/>
       ));
 
       // Invalidate filters just in case, most likely not necessary but can't hurt.
       queryClient.invalidateQueries("releases");
-
-      toggleDeleteModal();
     }
   });
 


### PR DESCRIPTION
possible todo: childless modals (i.e. those who do not have child components with a state) should all be using toggling internally, instead of doing it outside of the component?