### PR TITLE
refactor(discord): remove hardcoded username

### DIFF
--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -15,9 +15,8 @@ import (
 )
 
 type DiscordMessage struct {
-	Content  interface{}     `json:"content"`
-	Embeds   []DiscordEmbeds `json:"embeds,omitempty"`
-	Username string          `json:"username"`
+	Content interface{}     `json:"content"`
+	Embeds  []DiscordEmbeds `json:"embeds,omitempty"`
 }
 
 type DiscordEmbeds struct {
@@ -53,9 +52,8 @@ func NewDiscordSender(log logger.Logger, settings domain.Notification) domain.No
 
 func (a *discordSender) Send(event domain.NotificationEvent, payload domain.NotificationPayload) error {
 	m := DiscordMessage{
-		Content:  nil,
-		Embeds:   []DiscordEmbeds{a.buildEmbed(event, payload)},
-		Username: "brr",
+		Content: nil,
+		Embeds:  []DiscordEmbeds{a.buildEmbed(event, payload)},
 	}
 
 	jsonData, err := json.Marshal(m)


### PR DESCRIPTION
Let the Discord Webhook use it's set name. The webhook cannot be created without a username so it should not create issues.

This way the webhook is not always named `brr`.