### PR TITLE
fix(releases): ParseReleaseTags container matching

### DIFF
--- a/internal/domain/releasetags.go
+++ b/internal/domain/releasetags.go
@@ -98,7 +98,7 @@ func init() {
 	container := []*TagInfo{
 		{tag: "avi", title: "Audio Video Interleave (avi)", regexp: "", re: nil},
 		{tag: "img", title: "IMG", regexp: "", re: nil},
-		{tag: "iso", title: "ISO", regexp: "", re: nil},
+		{tag: "iso", title: "ISO", regexp: "\\biso\\b", re: nil},
 		{tag: "mkv", title: "Matroska (mkv)", regexp: "", re: nil},
 		{tag: "mov", title: "MOV", regexp: "", re: nil},
 		{tag: "mp4", title: "MP4", regexp: "", re: nil},

--- a/internal/domain/releasetags_test.go
+++ b/internal/domain/releasetags_test.go
@@ -47,8 +47,8 @@ func TestParseReleaseTagString(t *testing.T) {
 		{name: "movies_6", args: args{tags: "H.264, DVD"}, want: ReleaseTags{Codec: "H.264", Source: "DVD"}},
 		{name: "movies_7", args: args{tags: "H.264, DVD, Freeleech"}, want: ReleaseTags{Codec: "H.264", Source: "DVD", Bonus: []string{"Freeleech"}}},
 		{name: "movies_8", args: args{tags: "H.264, DVD, Freeleech!"}, want: ReleaseTags{Codec: "H.264", Source: "DVD", Bonus: []string{"Freeleech"}}},
-		{name: "anime_1", args: args{tags: "Web / MKV / h264 / 1080p / AAC 2.0 / Softsubs (SubsPlease) / Episode 22 / Freeleech"}, want: ReleaseTags{Audio: []string{"AAC"}, Channels: "2.0", Source: "WEB", Resolution: "1080p", Container: "iso", Codec: "H.264", Bonus: []string{"Freeleech"}}},
-		{name: "anime_2", args: args{tags: "Web | MKV | h264 | 1080p | AAC 2.0 | Softsubs (SubsPlease) | Episode 22 | Freeleech"}, want: ReleaseTags{Audio: []string{"AAC"}, Channels: "2.0", Source: "WEB", Resolution: "1080p", Container: "iso", Codec: "H.264", Bonus: []string{"Freeleech"}}},
+		{name: "anime_1", args: args{tags: "Web / MKV / h264 / 1080p / AAC 2.0 / Softsubs (SubsPlease) / Episode 22 / Freeleech"}, want: ReleaseTags{Audio: []string{"AAC"}, Channels: "2.0", Source: "WEB", Resolution: "1080p", Container: "mkv", Codec: "H.264", Bonus: []string{"Freeleech"}}},
+		{name: "anime_2", args: args{tags: "Web | ISO | h264 | 1080p | AAC 2.0 | Softsubs (SubsPlease) | Episode 22 | Freeleech"}, want: ReleaseTags{Audio: []string{"AAC"}, Channels: "2.0", Source: "WEB", Resolution: "1080p", Container: "iso", Codec: "H.264", Bonus: []string{"Freeleech"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Makes Autobrr match video containers from AB properly! 