### PR TITLE
feat(actions): reduce metadata collection

### DIFF
--- a/internal/action/exec.go
+++ b/internal/action/exec.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -13,7 +14,7 @@ import (
 func (s *service) execCmd(action domain.Action, release domain.Release) error {
 	s.log.Debug().Msgf("action exec: %v release: %v", action.Name, release.TorrentName)
 
-	if release.TorrentTmpFile == "" {
+	if release.TorrentTmpFile == "" && strings.Contains(action.ExecArgs, "TorrentPathName") {
 		if err := release.DownloadTorrentFile(); err != nil {
 			return errors.Wrap(err, "error downloading torrent file for release: %v", release.TorrentName)
 		}

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -171,7 +172,7 @@ func (s *service) watchFolder(action domain.Action, release domain.Release) erro
 }
 
 func (s *service) webhook(action domain.Action, release domain.Release) error {
-	if release.TorrentTmpFile == "" {
+	if release.TorrentTmpFile == "" && strings.Contains(action.WebhookData, "TorrentPathName") {
 		if err := release.DownloadTorrentFile(); err != nil {
 			return errors.Wrap(err, "webhook: could not download torrent file for release: %v", release.TorrentName)
 		}


### PR DESCRIPTION
Only download torrent if needed for Exec and Webhook action.

Determined by if the `Exec Args` or `Webhook data` contains the macro variable `TorrentPathName`.

Fixes #194