### PR TITLE
feat(config): loglevel default options add trace

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,7 +31,7 @@ port = 7474
 #
 # Default: "DEBUG"
 #
-# Options: "ERROR", "DEBUG", "INFO", "WARN"
+# Options: "ERROR", "DEBUG", "INFO", "WARN", "TRACE"
 #
 logLevel = "TRACE"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sync"
 	"strings"
+	"sync"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
@@ -81,7 +81,7 @@ port = 7474
 #
 # Default: "DEBUG"
 #
-# Options: "ERROR", "DEBUG", "INFO", "WARN"
+# Options: "ERROR", "DEBUG", "INFO", "WARN", "TRACE"
 #
 logLevel = "DEBUG"
 


### PR DESCRIPTION
Add `TRACE` in the list of log options. It's been a feature the whole time, just not explicit in the config.