### PR TITLE
fix(feeds): torznab use link to download

### DIFF
--- a/internal/feed/torznab.go
+++ b/internal/feed/torznab.go
@@ -71,7 +71,7 @@ func (j *TorznabJob) process() error {
 		rls := domain.NewRelease(j.IndexerIdentifier)
 
 		rls.TorrentName = item.Title
-		rls.TorrentURL = item.GUID
+		rls.TorrentURL = item.Link
 		rls.Implementation = domain.ReleaseImplementationTorznab
 		rls.Indexer = j.IndexerIdentifier
 


### PR DESCRIPTION
The GUID is a download link but doesn't contain credentials.

Change `release.TorrentUrl` from `GUID` to `Link` from feed item.