### PR TITLE
fix(indexers): tn fix category parsing

### DIFF
--- a/internal/indexer/definitions/torrentnetwork.yaml
+++ b/internal/indexer/definitions/torrentnetwork.yaml
@@ -44,7 +44,7 @@ parse:
   lines:
     - test:
         - "{New Torrent} Name {Luke_EP--Wildstyle_-_Sump_Ting-(RNR002)-WEB-2016-OMA} Typ {Music|MP3} Pre {14 s}"
-      pattern: '\{New Torrent\} Name \{(.*)\} Typ \{(.*)\}(?: Pre \{(.*)\})?'
+      pattern: '\{New Torrent\} Name \{(.*)\} Typ \{(.+?)\}(?: Pre \{(.*)\})?'
       vars:
         - torrentName
         - category


### PR DESCRIPTION
Fixes category parsing of TN tracker.

Regex playground:

https://regex101.com/r/YfojxG/1

<img width="811" alt="image" src="https://user-images.githubusercontent.com/43699394/180607734-fdf90ed8-cfc9-496c-ac63-0a0edaae785d.png">

Fixes #368 