### PR TITLE
feat(filters): list actions count

### DIFF
--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -54,62 +54,63 @@ type Filter struct {
 	Enabled                     bool                   `json:"enabled"`
 	CreatedAt                   time.Time              `json:"created_at"`
 	UpdatedAt                   time.Time              `json:"updated_at"`
-	MinSize                     string                 `json:"min_size"`
-	MaxSize                     string                 `json:"max_size"`
-	Delay                       int                    `json:"delay"`
-	Priority                    int32                  `json:"priority"`
-	MaxDownloads                int                    `json:"max_downloads"`
-	MaxDownloadsUnit            FilterMaxDownloadsUnit `json:"max_downloads_unit"`
-	MatchReleases               string                 `json:"match_releases"`
-	ExceptReleases              string                 `json:"except_releases"`
-	UseRegex                    bool                   `json:"use_regex"`
-	MatchReleaseGroups          string                 `json:"match_release_groups"`
-	ExceptReleaseGroups         string                 `json:"except_release_groups"`
-	Scene                       bool                   `json:"scene"`
-	Origins                     []string               `json:"origins"`
-	Bonus                       []string               `json:"bonus"`
-	Freeleech                   bool                   `json:"freeleech"`
-	FreeleechPercent            string                 `json:"freeleech_percent"`
-	Shows                       string                 `json:"shows"`
-	Seasons                     string                 `json:"seasons"`
-	Episodes                    string                 `json:"episodes"`
-	Resolutions                 []string               `json:"resolutions"` // SD, 480i, 480p, 576p, 720p, 810p, 1080i, 1080p.
-	Codecs                      []string               `json:"codecs"`      // XviD, DivX, x264, h.264 (or h264), mpeg2 (or mpeg-2), VC-1 (or VC1), WMV, Remux, h.264 Remux (or h264 Remux), VC-1 Remux (or VC1 Remux).
-	Sources                     []string               `json:"sources"`     // DSR, PDTV, HDTV, HR.PDTV, HR.HDTV, DVDRip, DVDScr, BDr, BD5, BD9, BDRip, BRRip, DVDR, MDVDR, HDDVD, HDDVDRip, BluRay, WEB-DL, TVRip, CAM, R5, TELESYNC, TS, TELECINE, TC. TELESYNC and TS are synonyms (you don't need both). Same for TELECINE and TC
-	Containers                  []string               `json:"containers"`
-	MatchHDR                    []string               `json:"match_hdr"`
-	ExceptHDR                   []string               `json:"except_hdr"`
-	MatchOther                  []string               `json:"match_other"`
-	ExceptOther                 []string               `json:"except_other"`
-	Years                       string                 `json:"years"`
-	Artists                     string                 `json:"artists"`
-	Albums                      string                 `json:"albums"`
-	MatchReleaseTypes           []string               `json:"match_release_types"` // Album,Single,EP
-	ExceptReleaseTypes          string                 `json:"except_release_types"`
-	Formats                     []string               `json:"formats"` // MP3, FLAC, Ogg, AAC, AC3, DTS
-	Quality                     []string               `json:"quality"` // 192, 320, APS (VBR), V2 (VBR), V1 (VBR), APX (VBR), V0 (VBR), q8.x (VBR), Lossless, 24bit Lossless, Other
-	Media                       []string               `json:"media"`   // CD, DVD, Vinyl, Soundboard, SACD, DAT, Cassette, WEB, Other
-	PerfectFlac                 bool                   `json:"perfect_flac"`
-	Cue                         bool                   `json:"cue"`
-	Log                         bool                   `json:"log"`
-	LogScore                    int                    `json:"log_score"`
-	MatchCategories             string                 `json:"match_categories"`
-	ExceptCategories            string                 `json:"except_categories"`
-	MatchUploaders              string                 `json:"match_uploaders"`
-	ExceptUploaders             string                 `json:"except_uploaders"`
-	Tags                        string                 `json:"tags"`
-	ExceptTags                  string                 `json:"except_tags"`
-	TagsAny                     string                 `json:"tags_any"`
-	ExceptTagsAny               string                 `json:"except_tags_any"`
-	ExternalScriptEnabled       bool                   `json:"external_script_enabled"`
-	ExternalScriptCmd           string                 `json:"external_script_cmd"`
-	ExternalScriptArgs          string                 `json:"external_script_args"`
-	ExternalScriptExpectStatus  int                    `json:"external_script_expect_status"`
-	ExternalWebhookEnabled      bool                   `json:"external_webhook_enabled"`
-	ExternalWebhookHost         string                 `json:"external_webhook_host"`
-	ExternalWebhookData         string                 `json:"external_webhook_data"`
-	ExternalWebhookExpectStatus int                    `json:"external_webhook_expect_status"`
-	Actions                     []*Action              `json:"actions"`
+	MinSize                     string                 `json:"min_size,omitempty"`
+	MaxSize                     string                 `json:"max_size,omitempty"`
+	Delay                       int                    `json:"delay,omitempty"`
+	Priority                    int32                  `json:"priority,omitempty"`
+	MaxDownloads                int                    `json:"max_downloads,omitempty"`
+	MaxDownloadsUnit            FilterMaxDownloadsUnit `json:"max_downloads_unit,omitempty"`
+	MatchReleases               string                 `json:"match_releases,omitempty"`
+	ExceptReleases              string                 `json:"except_releases,omitempty"`
+	UseRegex                    bool                   `json:"use_regex,omitempty"`
+	MatchReleaseGroups          string                 `json:"match_release_groups,omitempty"`
+	ExceptReleaseGroups         string                 `json:"except_release_groups,omitempty"`
+	Scene                       bool                   `json:"scene,omitempty"`
+	Origins                     []string               `json:"origins,omitempty"`
+	Bonus                       []string               `json:"bonus,omitempty"`
+	Freeleech                   bool                   `json:"freeleech,omitempty"`
+	FreeleechPercent            string                 `json:"freeleech_percent,omitempty"`
+	Shows                       string                 `json:"shows,omitempty"`
+	Seasons                     string                 `json:"seasons,omitempty"`
+	Episodes                    string                 `json:"episodes,omitempty"`
+	Resolutions                 []string               `json:"resolutions,omitempty"` // SD, 480i, 480p, 576p, 720p, 810p, 1080i, 1080p.
+	Codecs                      []string               `json:"codecs,omitempty"`      // XviD, DivX, x264, h.264 (or h264), mpeg2 (or mpeg-2), VC-1 (or VC1), WMV, Remux, h.264 Remux (or h264 Remux), VC-1 Remux (or VC1 Remux).
+	Sources                     []string               `json:"sources,omitempty"`     // DSR, PDTV, HDTV, HR.PDTV, HR.HDTV, DVDRip, DVDScr, BDr, BD5, BD9, BDRip, BRRip, DVDR, MDVDR, HDDVD, HDDVDRip, BluRay, WEB-DL, TVRip, CAM, R5, TELESYNC, TS, TELECINE, TC. TELESYNC and TS are synonyms (you don't need both). Same for TELECINE and TC
+	Containers                  []string               `json:"containers,omitempty"`
+	MatchHDR                    []string               `json:"match_hdr,omitempty"`
+	ExceptHDR                   []string               `json:"except_hdr,omitempty"`
+	MatchOther                  []string               `json:"match_other,omitempty"`
+	ExceptOther                 []string               `json:"except_other,omitempty"`
+	Years                       string                 `json:"years,omitempty"`
+	Artists                     string                 `json:"artists,omitempty"`
+	Albums                      string                 `json:"albums,omitempty"`
+	MatchReleaseTypes           []string               `json:"match_release_types,omitempty"` // Album,Single,EP
+	ExceptReleaseTypes          string                 `json:"except_release_types,omitempty"`
+	Formats                     []string               `json:"formats,omitempty"` // MP3, FLAC, Ogg, AAC, AC3, DTS
+	Quality                     []string               `json:"quality,omitempty"` // 192, 320, APS (VBR), V2 (VBR), V1 (VBR), APX (VBR), V0 (VBR), q8.x (VBR), Lossless, 24bit Lossless, Other
+	Media                       []string               `json:"media,omitempty"`   // CD, DVD, Vinyl, Soundboard, SACD, DAT, Cassette, WEB, Other
+	PerfectFlac                 bool                   `json:"perfect_flac,omitempty"`
+	Cue                         bool                   `json:"cue,omitempty"`
+	Log                         bool                   `json:"log,omitempty"`
+	LogScore                    int                    `json:"log_score,omitempty"`
+	MatchCategories             string                 `json:"match_categories,omitempty"`
+	ExceptCategories            string                 `json:"except_categories,omitempty"`
+	MatchUploaders              string                 `json:"match_uploaders,omitempty"`
+	ExceptUploaders             string                 `json:"except_uploaders,omitempty"`
+	Tags                        string                 `json:"tags,omitempty"`
+	ExceptTags                  string                 `json:"except_tags,omitempty"`
+	TagsAny                     string                 `json:"tags_any,omitempty"`
+	ExceptTagsAny               string                 `json:"except_tags_any,omitempty"`
+	ExternalScriptEnabled       bool                   `json:"external_script_enabled,omitempty"`
+	ExternalScriptCmd           string                 `json:"external_script_cmd,omitempty"`
+	ExternalScriptArgs          string                 `json:"external_script_args,omitempty"`
+	ExternalScriptExpectStatus  int                    `json:"external_script_expect_status,omitempty"`
+	ExternalWebhookEnabled      bool                   `json:"external_webhook_enabled,omitempty"`
+	ExternalWebhookHost         string                 `json:"external_webhook_host,omitempty"`
+	ExternalWebhookData         string                 `json:"external_webhook_data,omitempty"`
+	ExternalWebhookExpectStatus int                    `json:"external_webhook_expect_status,omitempty"`
+	ActionsCount                int                    `json:"actions_count"`
+	Actions                     []*Action              `json:"actions,omitempty"`
 	Indexers                    []Indexer              `json:"indexers"`
 	Downloads                   *FilterDownloads       `json:"-"`
 }

--- a/web/src/screens/filters/list.tsx
+++ b/web/src/screens/filters/list.tsx
@@ -76,16 +76,16 @@ function FilterList({ filters }: FilterListProps) {
       <table className="min-w-full">
         <thead className="bg-gray-50 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
           <tr>
-            {["Enabled", "Name", "Indexers"].map((label) => (
+            {["Enabled", "Name", "Actions", "Indexers"].map((label) => (
               <th
                 key={`th-${label}`}
                 scope="col"
-                className="px-6 pt-4 pb-3 text-left text-xs font-medium uppercase tracking-wider"
+                className="px-4 pt-4 pb-3 text-left text-xs font-medium uppercase tracking-wider"
               >
                 {label}
               </th>
             ))}
-            <th scope="col" className="relative px-6 py-3">
+            <th scope="col" className="relative px-4 py-3">
               <span className="sr-only">Edit</span>
             </th>
           </tr>
@@ -297,7 +297,7 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
       )}
     >
       <td
-        className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-100"
+        className="px-4 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-100"
       >
         <Switch
           checked={enabled}
@@ -317,7 +317,7 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
           />
         </Switch>
       </td>
-      <td className="px-6 w-full whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+      <td className="px-4 w-full whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
         <Link
           to={filter.id.toString()}
           className="hover:text-black dark:hover:text-gray-300 w-full py-4 flex"
@@ -325,7 +325,15 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
           {filter.name}
         </Link>
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+      <td className="px-4 w-full whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+        <Link
+          to={`${filter.id.toString()}/actions`}
+          className="hover:text-black dark:hover:text-gray-300 w-full py-4 flex"
+        >
+          <span className={classNames(filter.actions_count == 0 ? "text-red-500" : "")}>{filter.actions_count}</span>
+        </Link>
+      </td>
+      <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
         {filter.indexers && filter.indexers.map((t) => (
           <span
             key={t.id}
@@ -335,7 +343,7 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
           </span>
         ))}
       </td>
-      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+      <td className="px-4 py-4 whitespace-nowrap text-right text-sm font-medium">
         <FilterItemDropdown
           filter={filter}
           onToggle={toggleActive}

--- a/web/src/types/Filter.d.ts
+++ b/web/src/types/Filter.d.ts
@@ -50,6 +50,7 @@ interface Filter {
   except_tags: string;
   tags_any: string;
   except_tags_any: string;
+  actions_count: number;
   actions: Action[];
   indexers: Indexer[];
   external_script_enabled: boolean;


### PR DESCRIPTION
List number of actions on the filter list. As a visual marker if it's zero it will be red. Exposed in json as `actions_count`.

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/43699394/180612804-9b825f41-c4d1-4bc4-95fb-3d059f672c2b.png">

## Future enhancement

Return total and enabled count and make into a small badge like `[1/2]` or similar.

Fixes #366 
