### PR TITLE
fix(server): exclude tags from version check

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -65,7 +65,7 @@ func (c *Checker) get(ctx context.Context) (*Release, error) {
 }
 
 func (c *Checker) CheckNewVersion(ctx context.Context, version string) (bool, string, error) {
-	if version == "dev" {
+	if isDevelop(version) {
 		return false, "", nil
 	}
 
@@ -98,4 +98,16 @@ func (c *Checker) checkNewVersion(version string, release *Release) (bool, strin
 	}
 
 	return false, "", nil
+}
+
+func isDevelop(version string) bool {
+	tags := []string{"dev", "develop", "master", "latest"}
+
+	for _, tag := range tags {
+		if version == tag {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -107,3 +107,23 @@ func TestGitHubReleaseChecker_checkNewVersion(t *testing.T) {
 		})
 	}
 }
+
+func Test_isDevelop(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "test_1", version: "dev", want: true},
+		{name: "test_2", version: "develop", want: true},
+		{name: "test_3", version: "master", want: true},
+		{name: "test_4", version: "latest", want: true},
+		{name: "test_5", version: "v1.0.1", want: false},
+		{name: "test_6", version: "1.0.1", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, isDevelop(tt.version), "isDevelop(%v)", tt.version)
+		})
+	}
+}


### PR DESCRIPTION
On docker tags `develop` and `master` the version check would fail due to not being a valid semver tag and not getting properly checked.

For the future we might have to rework this to still be able to notify about updates on docker versions.
Probably by comparing latest commit to current commit.