### PR TITLE
fix(scheduler): use time as opposed to cron fields

### DIFF
--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dcarbone/zadapters/zstdlog"
 	"github.com/rs/zerolog"
+	"time"
 )
 
 type Service interface {
@@ -34,7 +35,7 @@ type feedInstance struct {
 	URL               string
 	ApiKey            string
 	Implementation    string
-	CronSchedule      string
+	CronSchedule      time.Duration
 }
 
 type service struct {
@@ -274,15 +275,13 @@ func (s *service) startJob(f domain.Feed) error {
 	}
 
 	// cron schedule to run every X minutes
-	schedule := fmt.Sprintf("*/%d * * * *", f.Interval)
-
 	fi := feedInstance{
 		Name:              f.Name,
 		IndexerIdentifier: f.Indexer,
 		Implementation:    f.Type,
 		URL:               f.URL,
 		ApiKey:            f.ApiKey,
-		CronSchedule:      schedule,
+		CronSchedule:      time.Duration(f.Interval * time.Minute),
 	}
 
 	switch fi.Implementation {
@@ -302,8 +301,8 @@ func (s *service) addTorznabJob(f feedInstance) error {
 	if f.URL == "" {
 		return errors.New("torznab feed requires URL")
 	}
-	if f.CronSchedule == "" {
-		f.CronSchedule = "*/15 * * * *"
+	if f.CronSchedule < 1 {
+		f.CronSchedule = time.Duration(15 * time.Minute)
 	}
 
 	// setup logger

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -2,7 +2,6 @@ package feed
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
@@ -281,7 +280,7 @@ func (s *service) startJob(f domain.Feed) error {
 		Implementation:    f.Type,
 		URL:               f.URL,
 		ApiKey:            f.ApiKey,
-		CronSchedule:      time.Duration(f.Interval * time.Minute),
+		CronSchedule:      time.Duration(f.Interval) * time.Minute,
 	}
 
 	switch fi.Implementation {

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -300,7 +300,7 @@ func (s *service) addTorznabJob(f feedInstance) error {
 	if f.URL == "" {
 		return errors.New("torznab feed requires URL")
 	}
-	if f.CronSchedule < time.Duration(15 * time.Minute) {
+	if f.CronSchedule < time.Duration(5 * time.Minute) {
 		f.CronSchedule = time.Duration(15 * time.Minute)
 	}
 

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -300,7 +300,7 @@ func (s *service) addTorznabJob(f feedInstance) error {
 	if f.URL == "" {
 		return errors.New("torznab feed requires URL")
 	}
-	if f.CronSchedule < 1 {
+	if f.CronSchedule < time.Duration(15 * time.Minute) {
 		f.CronSchedule = time.Duration(15 * time.Minute)
 	}
 

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -74,7 +74,7 @@ func (s *service) Stop() {
 
 func (s *service) AddJob(job cron.Job, interval time.Duration, identifier string) (int, error) {
 
-	id, err := s.cron.Schedule(cron.ConstantDelaySchedule.Every(interval), cron.NewChain(
+	id := s.cron.Schedule(cron.Every(interval), cron.NewChain(
 		cron.SkipIfStillRunning(cron.DiscardLogger)).Then(job),
 	)
 	if err != nil {

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -14,7 +14,7 @@ import (
 type Service interface {
 	Start()
 	Stop()
-	AddJob(job cron.Job, interval string, identifier string) (int, error)
+	AddJob(job cron.Job, interval time.Duration, identifier string) (int, error)
 	RemoveJobByID(id cron.EntryID) error
 	RemoveJobByIdentifier(id string) error
 }
@@ -74,7 +74,7 @@ func (s *service) Stop() {
 
 func (s *service) AddJob(job cron.Job, interval time.Duration, identifier string) (int, error) {
 
-	id, err := s.cron.Schedule(cron.ConstantDelaySchedule(interval), cron.NewChain(
+	id, err := s.cron.Schedule(cron.ConstantDelaySchedule.Every(interval), cron.NewChain(
 		cron.SkipIfStillRunning(cron.DiscardLogger)).Then(job),
 	)
 	if err != nil {

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -63,7 +63,7 @@ func (s *service) addAppJobs() {
 		lastCheckVersion: "",
 	}
 
-	s.AddJob(checkUpdates, "2 */6 * * *", "app-check-updates")
+	s.AddJob(checkUpdates, time.Duration(36 * time.Hour), "app-check-updates")
 }
 
 func (s *service) Stop() {
@@ -72,9 +72,9 @@ func (s *service) Stop() {
 	return
 }
 
-func (s *service) AddJob(job cron.Job, interval string, identifier string) (int, error) {
+func (s *service) AddJob(job cron.Job, interval time.Duration, identifier string) (int, error) {
 
-	id, err := s.cron.AddJob(interval, cron.NewChain(
+	id, err := s.cron.Schedule(cron.ConstantDelaySchedule(interval), cron.NewChain(
 		cron.SkipIfStillRunning(cron.DiscardLogger)).Then(job),
 	)
 	if err != nil {

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -77,9 +77,6 @@ func (s *service) AddJob(job cron.Job, interval time.Duration, identifier string
 	id := s.cron.Schedule(cron.Every(interval), cron.NewChain(
 		cron.SkipIfStillRunning(cron.DiscardLogger)).Then(job),
 	)
-	if err != nil {
-		return 0, errors.Wrap(err, "scheduler: add job failed")
-	}
 
 	s.log.Debug().Msgf("scheduler.AddJob: job successfully added: %v", id)
 

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/internal/notification"
-	"github.com/autobrr/autobrr/pkg/errors"
 
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"


### PR DESCRIPTION
per https://github.com/autobrr/autobrr/issues/389 it seems to be a bit nutty right now where we're using cron fields to schedule work to be completed. This results not only in a thundering herd problem, but unexpected behaviour for people unfamiliar with the intricates of cron (and the specific flavour of implementation by the library owner).

This PR flips from fixed fields to use duration - it's completely untested and just from docs.