### PR TITLE
feat(actions): implement TorrentDataRawBytes macro

### DIFF
--- a/internal/action/exec.go
+++ b/internal/action/exec.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"io/ioutil"
 	"os/exec"
 	"strings"
 	"time"
@@ -18,6 +19,16 @@ func (s *service) execCmd(action domain.Action, release domain.Release) error {
 		if err := release.DownloadTorrentFile(); err != nil {
 			return errors.Wrap(err, "error downloading torrent file for release: %v", release.TorrentName)
 		}
+	}
+
+	// read the file into bytes we can then use in the macro
+	if len(release.TorrentDataRawBytes) == 0 && release.TorrentTmpFile != "" {
+		t, err := ioutil.ReadFile(release.TorrentTmpFile)
+		if err != nil {
+			return errors.Wrap(err, "could not read torrent file: %v", release.TorrentTmpFile)
+		}
+
+		release.TorrentDataRawBytes = t
 	}
 
 	// check if program exists

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -140,7 +140,7 @@ func (s *service) watchFolder(action domain.Action, release domain.Release) erro
 		}
 	}
 
-	if len(release.TorrentDataRawBytes) == 0 {
+	if len(release.TorrentDataRawBytes) == 0 && strings.Contains(action.WebhookData, "TorrentDataRawBytes") {
 		t, err := ioutil.ReadFile(release.TorrentTmpFile)
 		if err != nil {
 			return errors.Wrap(err, "could not read torrent file: %v", release.TorrentTmpFile)
@@ -200,7 +200,7 @@ func (s *service) webhook(action domain.Action, release domain.Release) error {
 		}
 	}
 
-	if len(release.TorrentDataRawBytes) == 0 {
+	if len(release.TorrentDataRawBytes) == 0 && strings.Contains(action.WebhookData, "TorrentDataRawBytes") {
 		t, err := ioutil.ReadFile(release.TorrentTmpFile)
 		if err != nil {
 			return errors.Wrap(err, "could not read torrent file: %v", release.TorrentTmpFile)

--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -14,6 +14,7 @@ type Macro struct {
 	TorrentPathName string
 	TorrentHash     string
 	TorrentUrl      string
+	TorrentDataRawBytes	[]byte
 	Indexer         string
 	Title           string
 	Resolution      string
@@ -38,6 +39,7 @@ func NewMacro(release Release) Macro {
 		TorrentName:     release.TorrentName,
 		TorrentUrl:      release.TorrentURL,
 		TorrentPathName: release.TorrentTmpFile,
+		TorrentDataRawBytes: release.TorrentDataRawBytes,
 		TorrentHash:     release.TorrentHash,
 		Indexer:         release.Indexer,
 		Title:           release.Title,

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -46,6 +46,7 @@ type Release struct {
 	TorrentID                   string                `json:"torrent_id"`
 	TorrentURL                  string                `json:"-"`
 	TorrentTmpFile              string                `json:"-"`
+	TorrentDataRawBytes         []byte                `json:"-"`
 	TorrentHash                 string                `json:"-"`
 	TorrentName                 string                `json:"torrent_name"` // full release name
 	Size                        uint64                `json:"size"`

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -448,6 +448,16 @@ func (s *service) execCmd(release *domain.Release, cmd string, args string) (int
 		}
 	}
 
+	// read the file into bytes we can then use in the macro
+	if len(release.TorrentDataRawBytes) == 0 && release.TorrentTmpFile != "" {
+		t, err := ioutil.ReadFile(release.TorrentTmpFile)
+		if err != nil {
+			return 0, errors.Wrap(err, "could not read torrent file: %v", release.TorrentTmpFile)
+		}
+
+		release.TorrentDataRawBytes = t
+	}
+
 	// check if program exists
 	cmd, err := exec.LookPath(cmd)
 	if err != nil {


### PR DESCRIPTION
shot in the dark implementation of TorrentDataRawBytes. The purpose behind this is to leave autobrr as the facilitator of providing valid data to actions. If the data isn't valid, the action shouldn't be run.