### PR TITLE
feat(irc): handle nickserv without mode change

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -433,6 +433,10 @@ func (h *Handler) handleNickServ(msg ircmsg.Message) {
 	// Password accepted - you are now recognized.
 	if contains(msg.Params[1], "you're now logged in as", "password accepted", "you are now recognized") {
 		h.log.Debug().Msgf("NOTICE nickserv logged in: %v", msg.Params)
+
+		if !h.authenticated {
+			h.setAuthenticated()
+		}
 	}
 
 	// fallback for networks that require both password and nick to NickServ IDENTIFY


### PR DESCRIPTION
Force NickServ auth for networks not setting new `MODE` reply.