### PR TITLE
fix(notifications): Notifiarr check for valid api key

### DIFF
--- a/internal/notification/notifiarr.go
+++ b/internal/notification/notifiarr.go
@@ -115,7 +115,12 @@ func (s *notifiarrSender) CanSend(event domain.NotificationEvent) bool {
 }
 
 func (s *notifiarrSender) isEnabled() bool {
-	if s.Settings.Enabled && s.Settings.Webhook != "" {
+	if s.Settings.Enabled {
+		if s.Settings.APIKey == "" {
+			s.log.Warn().Msg("notifiarr missing api key")
+			return false
+		}
+
 		return true
 	}
 	return false


### PR DESCRIPTION
Check for non empty `API key` instead of `webhook`.