### PR TITLE
fix(clients): rtorrent use `directory` instead of `base_path`

### DIFF
--- a/internal/action/rtorrent.go
+++ b/internal/action/rtorrent.go
@@ -2,10 +2,9 @@ package action
 
 import (
 	"context"
-	"os"
-
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
+	"os"
 
 	"github.com/mrobinsn/go-rtorrent/rtorrent"
 )
@@ -47,13 +46,13 @@ func (s *service) rtorrent(action domain.Action, release domain.Release) ([]stri
 
 	if action.Label != "" {
 		args = append(args, &rtorrent.FieldValue{
-			Field: "d.custom1",
+			Field: rtorrent.DLabel,
 			Value: action.Label,
 		})
 	}
 	if action.SavePath != "" {
 		args = append(args, &rtorrent.FieldValue{
-			Field: "d.base_path",
+			Field: rtorrent.DDirectory,
 			Value: action.SavePath,
 		})
 	}


### PR DESCRIPTION
Fix error with rtorrent when using save path. Change to `directory` instead of `base_path`.

Tested on `0.9.6`, `0.9.8` and working fine.