### PR TITLE
fix(web): indexer options stale caching

### DIFF
--- a/web/src/screens/filters/list.tsx
+++ b/web/src/screens/filters/list.tsx
@@ -550,7 +550,7 @@ const ListboxFilter = ({
 // a unique option from a list
 const IndexerSelectFilter = ({ dispatch }: any) => {
   const { data, isSuccess } = useQuery(
-    "release_indexers",
+    "indexers_options",
     () => APIClient.indexers.getOptions(),
     {
       keepPreviousData: true,


### PR DESCRIPTION
- de-duplicate incompatible queries which led to a stale type-unsafe caching bug