### PR TITLE
fix(indexers): EMP parse line patterns

### DIFF
--- a/internal/indexer/definitions/emp.yaml
+++ b/internal/indexer/definitions/emp.yaml
@@ -48,7 +48,7 @@ parse:
   lines:
     - test:
         - "Some long funny title - Size: 2.54 GiB - Uploader: uploader1 - Tags: tag1,tag2 - https://www.empornium.is/torrents.php?torrentid=000000"
-    - pattern: '(.*) - Size: (.*) - Uploader: (.*) - Tags: (.*) - (https:\/\/.*torrents\.php\?)torrentid=(.*)'
+      pattern: '(.*) - Size: (.*) - Uploader: (.*) - Tags: (.*) - (https:\/\/.*torrents\.php\?)torrentid=(.*)'
       vars:
         - torrentName
         - torrentSize


### PR DESCRIPTION
Some releases wouldn't parse, and the culprit was the `lines` part where `pattern` was set as `- pattern` and that made the `lines` be split in two, even tho EMP is using single lines for announce and not multiple.