### PR TITLE
build: revert to old way of docker job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,19 +90,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Download web production build
         uses: actions/download-artifact@v3
         with:
@@ -129,3 +116,55 @@ jobs:
         with:
           name: autobrr
           path: dist/*
+
+  docker:
+    name: Build and publish Docker images
+    runs-on: self-hosted
+    needs: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Download web production build
+        uses: actions/download-artifact@v3
+        with:
+          name: web-build
+          path: web/build
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/autobrr/autobrr
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile.ci
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            REVISION=${{ github.event.pull_request.head.sha }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,66 +64,6 @@ archives:
     replacements:
       amd64: x86_64
 
-dockers:
-  - use: buildx
-    goos: linux
-    goarch: amd64
-    ids:
-      - autobrr
-      - autobrrctl
-    dockerfile: goreleaser.Dockerfile
-    image_templates:
-      - "ghcr.io/autobrr/autobrr:{{ .Tag }}"
-      - "ghcr.io/autobrr/autobrr:latest"
-    build_flag_templates:
-      - "--pull"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - use: buildx
-    goos: linux
-    goarch: arm64
-    goarm: 6
-    ids:
-      - autobrr
-      - autobrrctl
-    dockerfile: goreleaser.Dockerfile
-    image_templates:
-      - "ghcr.io/autobrr/autobrr:{{ .Tag }}"
-      - "ghcr.io/autobrr/autobrr:latest"
-    build_flag_templates:
-      - "--pull"
-      - "--platform=linux/arm64/v8"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - use: buildx
-    goos: linux
-    goarch: arm
-    goarm: 6
-    ids:
-      - autobrr
-      - autobrrctl
-    dockerfile: goreleaser.Dockerfile
-    image_templates:
-      - "ghcr.io/autobrr/autobrr:{{ .Tag }}"
-      - "ghcr.io/autobrr/autobrr:latest"
-    build_flag_templates:
-      - "--pull"
-      - "--platform=linux/arm/v7"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-docker_manifests:
-  - name_template: ghcr.io/autobrr/autobrr:{{ .Tag }}
-    image_templates:
-      - ghcr.io/autobrr/autobrr:{{ .Tag }}
-      - ghcr.io/autobrr/autobrr:latest
-
 release:
   prerelease: auto
   footer: |


### PR DESCRIPTION
The docker builds with `goreleaser` lacked the possibility to only push images and not binaries at the same time. Ok for tags but not builds on PRs or `develop`.