### PR TITLE
feat(indexers): Improve arr compatability for animebytes

### DIFF
--- a/internal/indexer/definitions/animebytes.yaml
+++ b/internal/indexer/definitions/animebytes.yaml
@@ -74,4 +74,4 @@ parse:
 
   match:
     torrenturl: "{{ .baseUrl }}/torrent/{{ .torrentId }}/download/{{ .passkey }}"
-    torrentname: "{{ if .releaseGroup }}[{{ .releaseGroup }}] {{ end }}{{ .torrentName }} ({{ .year }}) {{ if .releaseEpisode }}{{ printf \"- %02s \" .releaseEpisode }}{{ end }}{{ print \"[\" .releaseTags \"]\" | replace \" / \" \"][\" }}"
+    torrentname: "{{ if .releaseGroup }}[{{ .releaseGroup }}] {{ end }}{{ .torrentName }} {{ if .releaseEpisode }}{{ printf \"- %02s \" .releaseEpisode }}{{ end }} {{ if .year }}[{{ .year }}]{{ end }}{{ print \"[\" .releaseTags \"]\" | replace \" / \" \"][\" }}"


### PR DESCRIPTION
Place the year inside square brackets before the release tags. This makes sure that the arrs don't think the release year is part of the title.