### PR TITLE
fix(indexers): GGn regex pattern

### DIFF
--- a/internal/indexer/definitions/gazellegames.yaml
+++ b/internal/indexer/definitions/gazellegames.yaml
@@ -85,7 +85,7 @@ parse:
     - test:
         - "Uploader :-: Nintendo 3DS :-: Cool.Game.KOR.3DS-BigBlueBox in Cool Game [2013] ::Korean, Multi-Region, Scene:: https://gazellegames.net/torrents.php?torrentid=00000 - adventure, role_playing_game, nintendo;"
         - "Uploader :-: Windows :-: Other.Game-HI2U in Other Game [2016] ::English, Scene:: FREELEECH! :: https://gazellegames.net/torrents.php?torrentid=00000 - action, adventure, casual, indie, role.playing.game;"
-      pattern: '^(.+) :-: (.+) :-: (.+) \[(\d+)\] ::(.+?)?:: ?(.+?)?(?:! ::)? (https?:\/\/[^\/]+\/)torrents.php\?torrentid=(\d+) ?-? ?(.*?)?;?$'
+      pattern: '^(.+) :-: (.+) :-: (.+) \[(\d+)?\] ::(.+?)?:: ?(.+?)?(?:! ::)? (https?:\/\/[^\/]+\/)torrents.php\?torrentid=(\d+)(?: - )?([a-zA-Z0-9, _\.]+)?;?(?:[ :]*(?:[NSFW]*)?[! :]*)?$'
       vars:
         - uploader
         - category

--- a/internal/indexer/definitions/gazellegames.yaml
+++ b/internal/indexer/definitions/gazellegames.yaml
@@ -91,8 +91,8 @@ parse:
         - category
         - torrentName
         - year
-        - flags
-        - bonus
+        - releaseTags
+        - freeleech
         - baseUrl
         - torrentId
         - tags

--- a/internal/indexer/definitions/gazellegames.yaml
+++ b/internal/indexer/definitions/gazellegames.yaml
@@ -72,7 +72,7 @@ parse:
     - test:
         - "Uploader :-: Nintendo 3DS :-: Cool.Game.KOR.3DS-BigBlueBox in Cool Game [2013] ::Korean, Multi-Region, Scene:: https://gazellegames.net/torrents.php?torrentid=00000 - adventure, role_playing_game, nintendo;"
         - "Uploader :-: Windows :-: Other.Game-HI2U in Other Game [2016] ::English, Scene:: FREELEECH! :: https://gazellegames.net/torrents.php?torrentid=00000 - action, adventure, casual, indie, role.playing.game;"
-      pattern: '^(.+) :-: (.+) :-: (.+) \[(\d+)\] ::(.+?):: ?(.+? ::)? (https?:\/\/[^\/]+\/)torrents.php\?torrentid=(\d+) ?-? ?(.*?)?;?$'
+      pattern: '^(.+) :-: (.+) :-: (.+) \[(\d+)\] ::(.+?)?:: ?(.+? ::)? (https?:\/\/[^\/]+\/)torrents.php\?torrentid=(\d+) ?-? ?(.*?)?;?$'
       vars:
         - uploader
         - category

--- a/internal/indexer/definitions/gazellegames.yaml
+++ b/internal/indexer/definitions/gazellegames.yaml
@@ -85,7 +85,7 @@ parse:
     - test:
         - "Uploader :-: Nintendo 3DS :-: Cool.Game.KOR.3DS-BigBlueBox in Cool Game [2013] ::Korean, Multi-Region, Scene:: https://gazellegames.net/torrents.php?torrentid=00000 - adventure, role_playing_game, nintendo;"
         - "Uploader :-: Windows :-: Other.Game-HI2U in Other Game [2016] ::English, Scene:: FREELEECH! :: https://gazellegames.net/torrents.php?torrentid=00000 - action, adventure, casual, indie, role.playing.game;"
-      pattern: '^(.+) :-: (.+) :-: (.+) \[(\d+)\] ::(.+?)?:: ?(.+? ::)? (https?:\/\/[^\/]+\/)torrents.php\?torrentid=(\d+) ?-? ?(.*?)?;?$'
+      pattern: '^(.+) :-: (.+) :-: (.+) \[(\d+)\] ::(.+?)?:: ?(.+?)?(?:! ::)? (https?:\/\/[^\/]+\/)torrents.php\?torrentid=(\d+) ?-? ?(.*?)?;?$'
       vars:
         - uploader
         - category


### PR DESCRIPTION
[f96dd2d](https://github.com/autobrr/autobrr/pull/516/commits/f96dd2dffc9f4bb0788cdc27da34221f19674831)
Fixed regex to still match the announce if there are no flags in it.
	Made the capture group 5 lazy/optional/ungreedy. 

[2aad404](https://github.com/autobrr/autobrr/pull/516/commits/2aad40415395dca3cad9e47464a6edc1b0b6b654)
Customized the regex to only match the word `FREELEECH` instead of `FREELEECH! ::`

[d832a4c](https://github.com/autobrr/autobrr/pull/516/commits/d832a4cdb95e21fb96b80d66bf991f7d6916c53b)
Fix match when there is no year given (instead of 0) for a release. 
	Made capture group 4 lazy/optional/ungreedy.

Created a non-capturing group for the `:: NSFW! ::` section to exclude the seperators and the tag itself from the tags var.
	I think we should exclude a possible `:: NSFW! ::` section after the tags section from matching for 2 reasons:
	1. There is already an "adult" tag. Use it.
	2. The `:: NSFW! ::` may get truncated if the announce line is too long. Matching the tag against `adult` is more consistent.

Fix match when `:: NSFW! ::` section gets truncated because the announce line is too long.

Tested with a sample size of 554 announces of which 554 resulted in a match.

















