### PR TITLE
fix(web): tooltips

### DIFF
--- a/web/src/components/data-table/Cells.tsx
+++ b/web/src/components/data-table/Cells.tsx
@@ -27,7 +27,7 @@ export const TitleCell = ({ value }: CellProps) => (
       label={value}
       maxWidth="max-w-[90vw]"
     >
-      <span className="whitespace-pre-wrap break-word">
+      <span className="whitespace-pre-wrap break-words">
         {value}
       </span>
     </Tooltip>
@@ -114,10 +114,10 @@ const CellLine = ({ title, children }: { title: string; children?: string; }) =>
     return null;
 
   return (
-    <div className="mt-1">
+    <div className="mt-0.5">
       <span className="font-bold">{title}</span>
       {": "}
-      <span className="whitespace-pre-wrap break-word leading-4">{children}</span>
+      <span className="whitespace-pre-wrap break-words leading-5">{children}</span>
     </div>
   );
 };
@@ -142,7 +142,7 @@ export const ReleaseStatusCell = ({ value }: ReleaseStatusCellProps) => (
             <CellLine title="Filter">{v.filter}</CellLine>
             <CellLine title="Time">{simplifyDate(v.timestamp)}</CellLine>
             {v.rejections.length ? (
-              <CellLine title="Filter">
+              <CellLine title="Rejected">
                 {v.rejections.toString()}
               </CellLine>
             ) : null}

--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -69,8 +69,8 @@ function TabNavLink({ item }: NavLinkProps) {
       to={item.href}
       end
       className={({ isActive }) => classNames(
-        "text-gray-500 hover:text-purple-600 dark:hover:text-white hover:border-purple-600 dark:hover:border-blue-500 whitespace-nowrap py-4 px-1 font-medium text-sm",
-        isActive ? "border-b-2 border-purple-600 dark:border-blue-500 text-purple-600 dark:text-white" : ""
+        "text-gray-500 hover:text-blue-600 dark:hover:text-white hover:border-blue-600 dark:hover:border-blue-500 whitespace-nowrap py-4 px-1 font-medium text-sm",
+        isActive ? "border-b-2 border-blue-600 dark:border-blue-500 text-blue-600 dark:text-white" : ""
       )}
       aria-current={splitLocation[2] === item.href ? "page" : undefined}
     >


### PR DESCRIPTION
fix: fixed broken wrapping in tooltip child elements (missed last letter)
enhancement: increased line height for tooltip child cells in case of wrapping for clearer text
enhancement: renamed filter rejections from `Filter` to `Rejected` in tooltips
chore: changed remaining purple highlights to blue.