### PR TITLE
fix(cmd): add fallback tz information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG VERSION=dev
 ARG REVISION=dev
 ARG BUILDTIME
 
-RUN apk add --no-cache git make build-base
+RUN apk add --no-cache git make build-base tzdata
 
 ENV SERVICE=autobrr
 
@@ -43,7 +43,7 @@ ENV HOME="/config" \
 XDG_CONFIG_HOME="/config" \
 XDG_DATA_HOME="/config"
 
-RUN apk --no-cache add ca-certificates curl
+RUN apk --no-cache add ca-certificates curl tzdata
 
 WORKDIR /app
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -5,7 +5,7 @@ ARG VERSION=dev
 ARG REVISION=dev
 ARG BUILDTIME
 
-RUN apk add --no-cache git make build-base
+RUN apk add --no-cache git make build-base tzdata
 
 ENV SERVICE=autobrr
 
@@ -31,7 +31,7 @@ ENV HOME="/config" \
 XDG_CONFIG_HOME="/config" \
 XDG_DATA_HOME="/config"
 
-RUN apk --no-cache add ca-certificates curl
+RUN apk --no-cache add ca-certificates curl tzdata
 
 WORKDIR /app
 

--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -27,6 +27,8 @@ import (
 	"github.com/autobrr/autobrr/internal/scheduler"
 	"github.com/autobrr/autobrr/internal/server"
 	"github.com/autobrr/autobrr/internal/user"
+
+	_ "time/tzdata"
 )
 
 var (


### PR DESCRIPTION
Presently we have code support for tz loading in golang, specifically for RSS feeds.

Golang has 3 lookup modes
* first using the ZONEINFO envvar
* second if golang is installed - loading $GOROOT/lib/time/zoneinfo.zip
* third using and embedded time/tzdata package

For full coverage across the three operating systems we support, embedding the zoneinfo into the application itself using the native package seems to be the "most portable" solution. Presently this works for binary installations of autobrr, because the system likely has zoneinfo already present. For containerized installations, there's no zoneinfo present, which results in the "max age" field in autobrr having unpredictable results.