### PR TITLE
fix(rss): ignore max_age for old feed items

### DIFF
--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -96,7 +96,7 @@ func (j *RSSJob) processItem(item *gofeed.Item) *domain.Release {
 	now := time.Now()
 
 	if j.Feed.MaxAge > 0 {
-		if item.PublishedParsed != nil {
+		if item.PublishedParsed != nil && item.PublishedParsed.After(time.Date(1970, time.April, 1, 0, 0, 0, 0, time.UTC)) {
 			if !isNewerThanMaxAge(j.Feed.MaxAge, *item.PublishedParsed, now) {
 				return nil
 			}


### PR DESCRIPTION
Feed dates are not always initialized, which defaults (if present) to epoch on some feed items. When this happens the results can be unpredictable, and not expected for what users are intending for. As such to have sane defaults, we ignore the date if it's before April 1st 1970, because nothing really happened before this date.