### PR TITLE
fix(web): infinitely retry queries, remove "ago" from age cells

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,7 +10,13 @@ import Toast from "./components/notifications/Toast";
 
 export const queryClient = new QueryClient({
   defaultOptions: {
-    queries: { useErrorBoundary: true },
+    queries: {
+      // The retries will have exponential delay.
+      // See https://tanstack.com/query/v4/docs/guides/query-retries#retry-delay
+      // delay = Math.min(1000 * 2 ** attemptIndex, 30000)
+      retry: true,
+      useErrorBoundary: true
+    },
     mutations: {
       onError: (error) => {
         // Use a format string to convert the error object to a proper string without much hassle.

--- a/web/src/components/data-table/Cells.tsx
+++ b/web/src/components/data-table/Cells.tsx
@@ -12,7 +12,7 @@ interface CellProps {
 
 export const AgeCell = ({ value }: CellProps) => (
   <div className="text-sm text-gray-500" title={value}>
-    {formatDistanceToNowStrict(new Date(value), { addSuffix: true })}
+    {formatDistanceToNowStrict(new Date(value), { addSuffix: false })}
   </div>
 );
 


### PR DESCRIPTION
- infinitely retry web queries so we avoid the "failed to fetch" error when the web server is unavailable
- remove the "ago" suffix from age cells (closes #497)