### PR TITLE
fix(indexers): immortalseed regex

### DIFF
--- a/internal/indexer/definitions/immortalseed.yaml
+++ b/internal/indexer/definitions/immortalseed.yaml
@@ -62,7 +62,7 @@ parse:
         - "ImmortalSeed - Category: ( TV - High Definition ) Torrent: ( The.Show.S07E02.Lunch.At.Sea.720p.WEBRip.X264-GROUP1 ) Size: ( 457.07 MB ) Link: ( https://immortalseed.me/details.php?id=0000000 )"
         - "ImmortalSeed - Category: ( TV - High Definition ) Torrent: ( Other.Show.S01E02.1080p.WEB.H264-GROUP2 ) Size: ( 3.66 GB ) Link: ( https://immortalseed.me/details.php?id=0000000 )"
         - "ImmortalSeed - Category: ( Anime ) Torrent: ( Some.Anime.Show.S01E04.1080p.WEB.H264-GROUP3 ) Size: ( 1.34 GB ) Link: ( https://immortalseed.me/details.php?id=0000000 )"
-      pattern: '\s*ImmortalSeed - Category: \( ([^)]*) \) Torrent: \( ([^)]*) \) Size: \( ([^)]*) \) Link: \( (https?\:\/\/[^\/]+\/).*[&\?]id=(\d+) \)'
+      pattern: '\s*ImmortalSeed - Category: \( ([^)]*) \) Torrent: \( ([^)]*) \) Size: \( ([^)]*) \)\s+Link: \( (https?\:\/\/[^\/]+\/).*[&\?]id=(\d+) \)'
       vars:
         - category
         - torrentName

--- a/internal/indexer/definitions/immortalseed.yaml
+++ b/internal/indexer/definitions/immortalseed.yaml
@@ -62,7 +62,7 @@ parse:
         - "ImmortalSeed - Category: ( TV - High Definition ) Torrent: ( The.Show.S07E02.Lunch.At.Sea.720p.WEBRip.X264-GROUP1 ) Size: ( 457.07 MB ) Link: ( https://immortalseed.me/details.php?id=0000000 )"
         - "ImmortalSeed - Category: ( TV - High Definition ) Torrent: ( Other.Show.S01E02.1080p.WEB.H264-GROUP2 ) Size: ( 3.66 GB ) Link: ( https://immortalseed.me/details.php?id=0000000 )"
         - "ImmortalSeed - Category: ( Anime ) Torrent: ( Some.Anime.Show.S01E04.1080p.WEB.H264-GROUP3 ) Size: ( 1.34 GB ) Link: ( https://immortalseed.me/details.php?id=0000000 )"
-      pattern: '\s*ImmortalSeed - Category: \( ([^)]*) \) Torrent: \( ([^)]*) \) Size: \( ([^)]*) \)\s+Link: \( (https?\:\/\/[^\/]+\/).*[&\?]id=(\d+) \)'
+      pattern: '\s*ImmortalSeed - Category: \( (.*) \) Torrent: \( (.*) \) Size: \( (.*) \)\s+Link: \( (https?:\/\/.*\/).*id=(\d+) \)'
       vars:
         - category
         - torrentName

--- a/internal/indexer/definitions/immortalseed.yaml
+++ b/internal/indexer/definitions/immortalseed.yaml
@@ -23,8 +23,8 @@ settings:
 irc:
   network: ImmortalSeed
   server: irc.immortalseed.me
-  port: 6667
-  tls: false
+  port: 7000
+  tls: true
   channels:
     - "#immortal"
   announcers:
@@ -50,10 +50,10 @@ irc:
 
     - name: invite_command
       type: secret
-      default: "immortal invite USERNAME IRCKEY"
+      default: "immortal invite USERNAME PASSKEY"
       required: true
       label: Invite command
-      help: Invite auth with immortal. Replace USERNAME and IRCKEY.
+      help: Invite auth with immortal. Replace USERNAME and PASSKEY.
 
 parse:
   type: single


### PR DESCRIPTION
fix(indexers): immortalseed regex
Fixed issue where the regex for matching the announce line from immortalseed only had 1 whitespace in front of "Link:"
but the announce line had 2 whitespaces in front of "Link:"

Added "\s+" (instead of " ") in front of "Link:" to match one or more whitespaces and simplified regex.

Other changes:
change IRC port to 7000
set TLS to true
replace "IRCKEY" in placeholder and help test with "PASSKEY" for invite_command field.

Tested with a sample size of 50 of which 50 matched. Before none of these announces matched.
Will report back again when i tested this regex with a bigger sample size.