### PR TITLE
build(ci): move back to hosted-runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   web:
     name: Build web
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
   goreleaserbuild:
     name: Build Go binaries
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: web
     steps:
       - name: Checkout
@@ -82,7 +82,7 @@ jobs:
   goreleaser:
     name: Build & publish binaries and images
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: web
     steps:
       - name: Checkout
@@ -119,7 +119,7 @@ jobs:
 
   docker:
     name: Build and publish Docker images
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: web
     steps:
       - name: Checkout
@@ -159,7 +159,7 @@ jobs:
           context: .
           file: ./Dockerfile.ci
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
-          push: true
+          push: ${{ github.repository_owner == 'autobrr' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
The self-hosted runners are a bit buggy and sometimes hangs for hours and hours.