### PR TITLE
feat(releases): implement keyword search

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -155,6 +155,8 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 			"resolution": "resolution",
 			"source": "source",
 			"codec": "codec",
+			"hdr": "hdr",
+			"filter": "filter",
 		}
 
 		search := strings.TrimSpace(params.Search)

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -161,11 +161,11 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 
 		search := strings.TrimSpace(params.Search)
 		for k, v := range reserved {
-			r := regexp.MustCompile(fmt.Sprintf("(?:%s:)(?P<value>[^\\s-]+)", k))
+			r := regexp.MustCompile(fmt.Sprintf(`(?:%s:)(?P<value>'.*?'|".*?"|\S+)`, k))
 			if reskey := r.FindAllStringSubmatch(search, -1); len(reskey) != 0 {
 				filter := sq.Or{}
 				for _, found := range reskey {
-					filter = append(filter, sq.Like{"r." + v: found[1] + "%"})
+					filter = append(filter, sq.Like{"r." + v: strings.Trim(strings.Trim(found[1], `"`), `'`) + "%"})
 				}
 
 				queryBuilder = queryBuilder.Where(filter)

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -146,17 +146,17 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 
 	if params.Search != "" {
 		reserved := map[string]string{
-			"title": "title",
-			"group": "release_group",
-			"category": "category",
-			"season": "season",
-			"episode": "episode",
-			"year": "year",
-			"resolution": "resolution",
-			"source": "source",
-			"codec": "codec",
-			"hdr": "hdr",
-			"filter": "filter",
+			"title": "r.title",
+			"group": "r.release_group",
+			"category": "r.category",
+			"season": "r.season",
+			"episode": "r.episode",
+			"year": "r.year",
+			"resolution": "r.resolution",
+			"source": "r.source",
+			"codec": "r.codec",
+			"hdr": "r.hdr",
+			"filter": "r.filter",
 		}
 
 		search := strings.TrimSpace(params.Search)
@@ -165,7 +165,7 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 			if reskey := r.FindAllStringSubmatch(search, -1); len(reskey) != 0 {
 				filter := sq.Or{}
 				for _, found := range reskey {
-					filter = append(filter, sq.Like{"r." + v: strings.ReplaceAll(strings.Trim(strings.Trim(found[1], `"`), `'`), ".", "_") + "%"})
+					filter = append(filter, sq.Like{v: strings.ReplaceAll(strings.Trim(strings.Trim(found[1], `"`), `'`), ".", "_") + "%"})
 				}
 
 				queryBuilder = queryBuilder.Where(filter)

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -165,7 +165,7 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 			if reskey := r.FindAllStringSubmatch(search, -1); len(reskey) != 0 {
 				filter := sq.Or{}
 				for _, found := range reskey {
-					filter = append(filter, sq.Like{"r." + v: strings.Trim(strings.Trim(found[1], `"`), `'`) + "%"})
+					filter = append(filter, sq.Like{"r." + v: strings.ReplaceAll(strings.Trim(strings.Trim(found[1], `"`), `'`), ".", "_") + "%"})
 				}
 
 				queryBuilder = queryBuilder.Where(filter)


### PR DESCRIPTION
This expands upon https://github.com/autobrr/autobrr/pull/302 by implementing keyword searching implementing a handful of what's immediately available. Multiple specifiers of the same type can be used, which does the right thing and implements an Or clause between them.

https://www.youtube.com/watch?v=MbXWrmQW-OE

## Available filters:

- `title`
- `group`
- `category`
- `season`
- `episode`
- `year`
- `resolution`
- `source`
- `codec`
- `hdr`
- `filter`

## Usage

In the search bar for releases do like `category:tv resolution:2160p`.