### PR TITLE
fix(releases): improve load time by 47x

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -125,7 +125,7 @@ func (repo *ReleaseRepo) Find(ctx context.Context, params domain.ReleaseQueryPar
 
 func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain.ReleaseQueryParams) ([]*domain.Release, int64, int64, error) {
 	queryBuilder := repo.db.squirrel.
-		Select("r.id", "r.filter_status", "r.rejections", "r.indexer", "r.filter", "r.protocol", "r.title", "r.torrent_name", "r.size", "r.timestamp", "(SELECT COUNT(*) FROM release) AS total_count").
+		Select("r.id", "r.filter_status", "r.rejections", "r.indexer", "r.filter", "r.protocol", "r.title", "r.torrent_name", "r.size", "r.timestamp", "(SELECT COUNT() FROM release) AS total_count").
 		From("release r").
 		OrderBy("r.id DESC")
 

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -237,7 +237,7 @@ func (repo *ReleaseRepo) findRecentReleases(ctx context.Context, tx *Tx) ([]*dom
 	queryBuilder := repo.db.squirrel.
 		Select("r.id", "r.filter_status", "r.rejections", "r.indexer", "r.filter", "r.protocol", "r.title", "r.torrent_name", "r.size", "r.timestamp").
 		From("release r").
-		OrderBy("r.timestamp DESC").
+		OrderBy("r.id DESC").
 		Limit(10)
 
 	query, args, err := queryBuilder.ToSql()

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -125,9 +125,9 @@ func (repo *ReleaseRepo) Find(ctx context.Context, params domain.ReleaseQueryPar
 
 func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain.ReleaseQueryParams) ([]*domain.Release, int64, int64, error) {
 	queryBuilder := repo.db.squirrel.
-		Select("r.id", "r.filter_status", "r.rejections", "r.indexer", "r.filter", "r.protocol", "r.title", "r.torrent_name", "r.size", "r.timestamp", "COUNT(*) OVER() AS total_count").
+		Select("r.id", "r.filter_status", "r.rejections", "r.indexer", "r.filter", "r.protocol", "r.title", "r.torrent_name", "r.size", "r.timestamp", "(SELECT COUNT(*) FROM release) AS total_count").
 		From("release r").
-		OrderBy("r.timestamp DESC")
+		OrderBy("r.id DESC")
 
 	if params.Limit > 0 {
 		queryBuilder = queryBuilder.Limit(params.Limit)

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -400,16 +400,17 @@ func (repo *ReleaseRepo) attachActionStatus(ctx context.Context, tx *Tx, release
 func (repo *ReleaseRepo) Stats(ctx context.Context) (*domain.ReleaseStats, error) {
 
 	query := `SELECT *
-FROM (SELECT
+FROM (
+	SELECT
 	COUNT() AS total,
-	COUNT(CASE WHEN filter_status = 'FILTER_APPROVED' THEN '' END) AS filtered_count,
-	COUNT(CASE WHEN filter_status = 'FILTER_REJECTED' THEN '' END) AS filter_rejected_count
+	COUNT(CASE WHEN filter_status = 'FILTER_APPROVED' THEN 0 END) AS filtered_count,
+	COUNT(CASE WHEN filter_status = 'FILTER_REJECTED' THEN 0 END) AS filter_rejected_count
 	FROM release
 )
 CROSS JOIN (
 	SELECT
-	COUNT(CASE WHEN status = 'PUSH_APPROVED' THEN '' END) AS push_approved_count,
-	COUNT(CASE WHEN status = 'PUSH_REJECTED' THEN '' END) AS push_rejected_count
+	COUNT(CASE WHEN status = 'PUSH_APPROVED' THEN 0 END) AS push_approved_count,
+	COUNT(CASE WHEN status = 'PUSH_REJECTED' THEN 0 END) AS push_rejected_count
 	FROM release_action_status
 )`
 

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -126,7 +126,7 @@ func (repo *ReleaseRepo) Find(ctx context.Context, params domain.ReleaseQueryPar
 
 func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain.ReleaseQueryParams) ([]*domain.Release, int64, int64, error) {
 	queryBuilder := repo.db.squirrel.
-		Select("r.id", "r.filter_status", "r.rejections", "r.indexer", "r.filter", "r.protocol", "r.title", "r.torrent_name", "r.size", "r.timestamp", "(SELECT COUNT() FROM release) AS total_count").
+		Select("r.id", "r.filter_status", "r.rejections", "r.indexer", "r.filter", "r.protocol", "r.title", "r.torrent_name", "r.size", "r.timestamp", "(SELECT COUNT(*) FROM release) AS total_count").
 		From("release r").
 		OrderBy("r.id DESC")
 

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -146,17 +146,17 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 
 	if params.Search != "" {
 		reserved := map[string]string{
-			"title": "r.title",
-			"group": "r.release_group",
-			"category": "r.category",
-			"season": "r.season",
-			"episode": "r.episode",
-			"year": "r.year",
+			"title":      "r.title",
+			"group":      "r.release_group",
+			"category":   "r.category",
+			"season":     "r.season",
+			"episode":    "r.episode",
+			"year":       "r.year",
 			"resolution": "r.resolution",
-			"source": "r.source",
-			"codec": "r.codec",
-			"hdr": "r.hdr",
-			"filter": "r.filter",
+			"source":     "r.source",
+			"codec":      "r.codec",
+			"hdr":        "r.hdr",
+			"filter":     "r.filter",
 		}
 
 		search := strings.TrimSpace(params.Search)
@@ -433,17 +433,17 @@ func (repo *ReleaseRepo) Stats(ctx context.Context) (*domain.ReleaseStats, error
 	query := `SELECT *
 FROM (
 	SELECT
-	COUNT() AS total,
+	COUNT(*) AS total,
 	COUNT(CASE WHEN filter_status = 'FILTER_APPROVED' THEN 0 END) AS filtered_count,
 	COUNT(CASE WHEN filter_status = 'FILTER_REJECTED' THEN 0 END) AS filter_rejected_count
 	FROM release
-)
+) AS zoo
 CROSS JOIN (
 	SELECT
 	COUNT(CASE WHEN status = 'PUSH_APPROVED' THEN 0 END) AS push_approved_count,
 	COUNT(CASE WHEN status = 'PUSH_REJECTED' THEN 0 END) AS push_rejected_count
 	FROM release_action_status
-)`
+) AS foo`
 
 	row := repo.db.handler.QueryRowContext(ctx, query)
 	if err := row.Err(); err != nil {


### PR DESCRIPTION
Presently we scan the entire DB on each line item returned by the database engine, in an effort to populate the single "total releases" counter on the bottom of the page. This results in a 47x slowdown on my system as the calculation is done for every line item returned. While it's more appropriate to break this out into another query entirely, changing the query to work on the static set of data in memory results in a massive speedup (47x on a classic SSD, much more on rotational systems).

EDIT: Removed one of the subqueries on stats, the speedup is only 40% (100ms savings), but I'm sure that's better than it was. Using Group By as opposed to renaming the fields like this is also faster, but would break the webui.

https://www.youtube.com/watch?v=yK0P1Bk8Cx4