### PR TITLE
refactor(database): clean-up queries

### DIFF
--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -29,7 +29,7 @@ func NewActionRepo(log logger.Logger, db *DB, clientRepo domain.DownloadClientRe
 
 func (r *ActionRepo) FindByFilterID(ctx context.Context, filterID int) ([]*domain.Action, error) {
 
-	tx, err := r.db.BeginTx(ctx, nil)
+	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -51,6 +51,10 @@ func (r *ActionRepo) FindByFilterID(ctx context.Context, filterID int) ([]*domai
 		}
 	}
 
+	if err = tx.Commit(); err != nil {
+		return nil, errors.Wrap(err, "error finding filter by id")
+	}
+
 	return actions, nil
 }
 

--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -87,7 +87,7 @@ func (r *ActionRepo) findByFilterID(ctx context.Context, tx *Tx, filterID int) (
 			"client_id",
 		).
 		From("action").
-		Where("filter_id = ?", filterID)
+		Where(sq.Eq{"filter_id": filterID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -165,7 +165,7 @@ func (r *ActionRepo) attachDownloadClient(ctx context.Context, tx *Tx, clientID 
 			"settings",
 		).
 		From("client").
-		Where("id = ?", clientID)
+		Where(sq.Eq{"id": clientID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -282,7 +282,7 @@ func (r *ActionRepo) List(ctx context.Context) ([]domain.Action, error) {
 func (r *ActionRepo) Delete(actionID int) error {
 	queryBuilder := r.db.squirrel.
 		Delete("action").
-		Where("id = ?", actionID)
+		Where(sq.Eq{"id": actionID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -302,7 +302,7 @@ func (r *ActionRepo) Delete(actionID int) error {
 func (r *ActionRepo) DeleteByFilterID(ctx context.Context, filterID int) error {
 	queryBuilder := r.db.squirrel.
 		Delete("action").
-		Where("filter_id = ?", filterID)
+		Where(sq.Eq{"filter_id": filterID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -472,7 +472,7 @@ func (r *ActionRepo) Update(ctx context.Context, action domain.Action) (*domain.
 		Set("webhook_data", webhookData).
 		Set("client_id", clientID).
 		Set("filter_id", filterID).
-		Where("id = ?", action.ID)
+		Where(sq.Eq{"id": action.ID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -499,7 +499,7 @@ func (r *ActionRepo) StoreFilterActions(ctx context.Context, actions []*domain.A
 
 	deleteQueryBuilder := r.db.squirrel.
 		Delete("action").
-		Where("filter_id = ?", filterID)
+		Where(sq.Eq{"filter_id": filterID})
 
 	deleteQuery, deleteArgs, err := deleteQueryBuilder.ToSql()
 	if err != nil {
@@ -622,7 +622,7 @@ func (r *ActionRepo) ToggleEnabled(actionID int) error {
 	queryBuilder := r.db.squirrel.
 		Update("action").
 		Set("enabled", sq.Expr("NOT enabled")).
-		Where("id = ?", actionID)
+		Where(sq.Eq{"id": actionID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/api.go
+++ b/internal/database/api.go
@@ -9,7 +9,6 @@ import (
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/pkg/errors"
 
-
 	sq "github.com/Masterminds/squirrel"
 	"github.com/lib/pq"
 	"github.com/rs/zerolog"

--- a/internal/database/api.go
+++ b/internal/database/api.go
@@ -9,6 +9,8 @@ import (
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/pkg/errors"
 
+
+	sq "github.com/Masterminds/squirrel"
 	"github.com/lib/pq"
 	"github.com/rs/zerolog"
 )
@@ -55,7 +57,7 @@ func (r *APIRepo) Store(ctx context.Context, key *domain.APIKey) error {
 func (r *APIRepo) Delete(ctx context.Context, key string) error {
 	queryBuilder := r.db.squirrel.
 		Delete("api_key").
-		Where("key = ?", key)
+		Where(sq.Eq{"key": key})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/download_client.go
+++ b/internal/database/download_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/pkg/errors"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/rs/zerolog"
 )
 
@@ -136,7 +137,7 @@ func (r *DownloadClientRepo) FindByID(ctx context.Context, id int32) (*domain.Do
 			"settings",
 		).
 		From("client").
-		Where("id = ?", id)
+		Where(sq.Eq{"id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -232,7 +233,7 @@ func (r *DownloadClientRepo) Update(ctx context.Context, client domain.DownloadC
 		Set("username", client.Username).
 		Set("password", client.Password).
 		Set("settings", string(settingsJson)).
-		Where("id = ?", client.ID)
+		Where(sq.Eq{"id": client.ID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -255,7 +256,7 @@ func (r *DownloadClientRepo) Update(ctx context.Context, client domain.DownloadC
 func (r *DownloadClientRepo) Delete(ctx context.Context, clientID int) error {
 	queryBuilder := r.db.squirrel.
 		Delete("client").
-		Where("id = ?", clientID)
+		Where(sq.Eq{"id": clientID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/feed.go
+++ b/internal/database/feed.go
@@ -43,7 +43,7 @@ func (r *FeedRepo) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
 		).
 		From("feed f").
 		Join("indexer i ON f.indexer_id = i.id").
-		Where("f.id = ?", id)
+		Where(sq.Eq{"f.id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -89,7 +89,7 @@ func (r *FeedRepo) FindByIndexerIdentifier(ctx context.Context, indexer string) 
 		).
 		From("feed f").
 		Join("indexer i ON f.indexer_id = i.id").
-		Where("i.name = ?", indexer)
+		Where(sq.Eq{"i.name": indexer})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -221,7 +221,7 @@ func (r *FeedRepo) Update(ctx context.Context, feed *domain.Feed) error {
 		Set("api_key", feed.ApiKey).
 		Set("cookie", feed.Cookie).
 		Set("updated_at", sq.Expr("CURRENT_TIMESTAMP")).
-		Where("id = ?", feed.ID)
+		Where(sq.Eq{"id": feed.ID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -240,7 +240,7 @@ func (r *FeedRepo) UpdateLastRun(ctx context.Context, feedID int) error {
 	queryBuilder := r.db.squirrel.
 		Update("feed").
 		Set("last_run", sq.Expr("CURRENT_TIMESTAMP")).
-		Where("id = ?", feedID)
+		Where(sq.Eq{"id": feedID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -260,7 +260,7 @@ func (r *FeedRepo) UpdateLastRunWithData(ctx context.Context, feedID int, data s
 		Update("feed").
 		Set("last_run", sq.Expr("CURRENT_TIMESTAMP")).
 		Set("last_run_data", data).
-		Where("id = ?", feedID)
+		Where(sq.Eq{"id": feedID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -282,7 +282,7 @@ func (r *FeedRepo) ToggleEnabled(ctx context.Context, id int, enabled bool) erro
 		Update("feed").
 		Set("enabled", enabled).
 		Set("updated_at", sq.Expr("CURRENT_TIMESTAMP")).
-		Where("id = ?", id)
+		Where(sq.Eq{"id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -299,7 +299,7 @@ func (r *FeedRepo) ToggleEnabled(ctx context.Context, id int, enabled bool) erro
 func (r *FeedRepo) Delete(ctx context.Context, id int) error {
 	queryBuilder := r.db.squirrel.
 		Delete("feed").
-		Where("id = ?", id)
+		Where(sq.Eq{"id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/feed_cache.go
+++ b/internal/database/feed_cache.go
@@ -8,6 +8,7 @@ import (
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/pkg/errors"
+	sq "github.com/Masterminds/squirrel"
 
 	"github.com/rs/zerolog"
 )
@@ -31,9 +32,9 @@ func (r *FeedCacheRepo) Get(bucket string, key string) ([]byte, error) {
 			"ttl",
 		).
 		From("feed_cache").
-		Where("bucket = ?", bucket).
-		Where("key = ?", key).
-		Where("ttl > ?", time.Now())
+		Where(sq.Eq{"bucket": bucket}).
+		Where(sq.Eq{"key": key}).
+		Where(sq.Gt{"ttl": time.Now()})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -64,7 +65,7 @@ func (r *FeedCacheRepo) GetByBucket(ctx context.Context, bucket string) ([]domai
 			"ttl",
 		).
 		From("feed_cache").
-		Where("bucket = ?", bucket)
+		Where(sq.Eq{"bucket": bucket})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -102,7 +103,7 @@ func (r *FeedCacheRepo) GetCountByBucket(ctx context.Context, bucket string) (in
 	queryBuilder := r.db.squirrel.
 		Select("COUNT(*)").
 		From("feed_cache").
-		Where("bucket = ?", bucket)
+		Where(sq.Eq{"bucket": bucket})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -128,8 +129,8 @@ func (r *FeedCacheRepo) Exists(bucket string, key string) (bool, error) {
 		Select("1").
 		Prefix("SELECT EXISTS (").
 		From("feed_cache").
-		Where("bucket = ?", bucket).
-		Where("key = ?", key).
+		Where(sq.Eq{"bucket": bucket}).
+		Where(sq.Eq{"key": key}).
 		Suffix(")")
 
 	query, args, err := queryBuilder.ToSql()
@@ -167,8 +168,8 @@ func (r *FeedCacheRepo) Put(bucket string, key string, val []byte, ttl time.Time
 func (r *FeedCacheRepo) Delete(ctx context.Context, bucket string, key string) error {
 	queryBuilder := r.db.squirrel.
 		Delete("feed_cache").
-		Where("bucket = ?", bucket).
-		Where("key = ?", key)
+		Where(sq.Eq{"bucket": bucket}).
+		Where(sq.Eq{"key": key})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -186,7 +187,7 @@ func (r *FeedCacheRepo) Delete(ctx context.Context, bucket string, key string) e
 func (r *FeedCacheRepo) DeleteBucket(ctx context.Context, bucket string) error {
 	queryBuilder := r.db.squirrel.
 		Delete("feed_cache").
-		Where("bucket = ?", bucket)
+		Where(sq.Eq{"bucket": bucket})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -40,7 +40,7 @@ func (r *FilterRepo) Find(ctx context.Context, params domain.FilterQueryParams) 
 		return nil, err
 	}
 
-	if err = tx.Commit(); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, errors.Wrap(err, "error commit transaction find releases")
 	}
 
@@ -319,6 +319,10 @@ func (r *FilterRepo) FindByIndexerIdentifier(indexer string) ([]domain.Filter, e
 			continue
 		}
 		filters[i].Downloads = downloads
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, errors.Wrap(err, "error finding filter by identifier")
 	}
 
 	return filters, nil
@@ -949,8 +953,7 @@ func (r *FilterRepo) StoreIndexerConnections(ctx context.Context, filterID int, 
 		r.log.Debug().Msgf("filter.StoreIndexerConnections: store '%v' on filter: %v", indexer.Name, filterID)
 	}
 
-	err = tx.Commit()
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		return errors.Wrap(err, "error store indexers for filter: %v", filterID)
 	}
 

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -29,7 +29,7 @@ func NewFilterRepo(log logger.Logger, db *DB) domain.FilterRepo {
 }
 
 func (r *FilterRepo) Find(ctx context.Context, params domain.FilterQueryParams) ([]domain.Filter, error) {
-	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{})
+	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return nil, errors.Wrap(err, "error begin transaction")
 	}

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -233,7 +233,7 @@ func (r *FilterRepo) FindByID(ctx context.Context, filterID int) (*domain.Filter
 			"updated_at",
 		).
 		From("filter").
-		Where("id = ?", filterID)
+		Where(sq.Eq{"id": filterID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -392,9 +392,9 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, tx *Tx, indexe
 		From("filter f").
 		Join("filter_indexer fi ON f.id = fi.filter_id").
 		Join("indexer i ON i.id = fi.indexer_id").
-		Where("i.identifier = ?", indexer).
-		Where("i.enabled = ?", true).
-		Where("f.enabled = ?", true).
+		Where(sq.Eq{"i.identifier": indexer}).
+		Where(sq.Eq{"i.enabled": true}).
+		Where(sq.Eq{"f.enabled": true}).
 		OrderBy("f.priority DESC")
 
 	query, args, err := queryBuilder.ToSql()
@@ -671,7 +671,7 @@ func (r *FilterRepo) Update(ctx context.Context, filter domain.Filter) (*domain.
 		Set("external_webhook_data", filter.ExternalWebhookData).
 		Set("external_webhook_expect_status", filter.ExternalWebhookExpectStatus).
 		Set("updated_at", time.Now().Format(time.RFC3339)).
-		Where("id = ?", filter.ID)
+		Where(sq.Eq{"id": filter.ID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -866,7 +866,7 @@ func (r *FilterRepo) UpdatePartial(ctx context.Context, filter domain.FilterUpda
 		q = q.Set("external_webhook_expect_status", filter.ExternalWebhookExpectStatus)
 	}
 
-	q = q.Where("id = ?", filter.ID)
+	q = q.Where(sq.Eq{"id": filter.ID})
 
 	query, args, err := q.ToSql()
 	if err != nil {
@@ -897,7 +897,7 @@ func (r *FilterRepo) ToggleEnabled(ctx context.Context, filterID int, enabled bo
 		Update("filter").
 		Set("enabled", enabled).
 		Set("updated_at", sq.Expr("CURRENT_TIMESTAMP")).
-		Where("id = ?", filterID)
+		Where(sq.Eq{"id": filterID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -921,7 +921,7 @@ func (r *FilterRepo) StoreIndexerConnections(ctx context.Context, filterID int, 
 
 	deleteQueryBuilder := r.db.squirrel.
 		Delete("filter_indexer").
-		Where("filter_id = ?", filterID)
+		Where(sq.Eq{"filter_id": filterID})
 
 	deleteQuery, deleteArgs, err := deleteQueryBuilder.ToSql()
 	if err != nil {
@@ -978,7 +978,7 @@ func (r *FilterRepo) StoreIndexerConnection(ctx context.Context, filterID int, i
 func (r *FilterRepo) DeleteIndexerConnections(ctx context.Context, filterID int) error {
 	queryBuilder := r.db.squirrel.
 		Delete("filter_indexer").
-		Where("filter_id = ?", filterID)
+		Where(sq.Eq{"filter_id": filterID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -996,7 +996,7 @@ func (r *FilterRepo) DeleteIndexerConnections(ctx context.Context, filterID int)
 func (r *FilterRepo) Delete(ctx context.Context, filterID int) error {
 	queryBuilder := r.db.squirrel.
 		Delete("filter").
-		Where("id = ?", filterID)
+		Where(sq.Eq{"id": filterID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -52,7 +52,7 @@ func (r *FilterRepo) find(ctx context.Context, tx *Tx, params domain.FilterQuery
 	actionCountQuery := r.db.squirrel.
 		Select("COUNT(*)").
 		From("action a").
-		Where("a.filter_id = f.id")
+		Where(sq.Eq{"a.filter_id": "f.id"})
 
 	queryBuilder := r.db.squirrel.
 		Select(
@@ -70,7 +70,7 @@ func (r *FilterRepo) find(ctx context.Context, tx *Tx, params domain.FilterQuery
 		From("filter f")
 
 	if params.Search != "" {
-		queryBuilder = queryBuilder.Where("f.name LIKE ?", fmt.Sprint("%", params.Search, "%"))
+		queryBuilder = queryBuilder.Where(sq.Like{"f.name": params.Search + "%"})
 	}
 
 	if len(params.Sort) > 0 {
@@ -123,7 +123,7 @@ func (r *FilterRepo) ListFilters(ctx context.Context) ([]domain.Filter, error) {
 	actionCountQuery := r.db.squirrel.
 		Select("COUNT(*)").
 		From("action a").
-		Where("a.filter_id = f.id")
+		Where(sq.Eq{"a.filter_id": "f.id"})
 
 	queryBuilder := r.db.squirrel.
 		Select(

--- a/internal/database/indexer.go
+++ b/internal/database/indexer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/pkg/errors"
+	sq "github.com/Masterminds/squirrel"
 
 	"github.com/rs/zerolog"
 )
@@ -61,7 +62,7 @@ func (r *IndexerRepo) Update(ctx context.Context, indexer domain.Indexer) (*doma
 		Set("base_url", indexer.BaseURL).
 		Set("settings", settings).
 		Set("updated_at", time.Now().Format(time.RFC3339)).
-		Where("id = ?", indexer.ID)
+		Where(sq.Eq{"id": indexer.ID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -117,7 +118,7 @@ func (r *IndexerRepo) FindByID(ctx context.Context, id int) (*domain.Indexer, er
 	queryBuilder := r.db.squirrel.
 		Select("id", "enabled", "name", "identifier", "implementation", "base_url", "settings").
 		From("indexer").
-		Where("id = ?", id)
+		Where(sq.Eq{"id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -156,7 +157,7 @@ func (r *IndexerRepo) FindByFilterID(ctx context.Context, id int) ([]domain.Inde
 		Select("id", "enabled", "name", "identifier", "base_url", "settings").
 		From("indexer").
 		Join("filter_indexer ON indexer.id = filter_indexer.indexer_id").
-		Where("filter_indexer.filter_id = ?", id)
+		Where(sq.Eq{"filter_indexer.filter_id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -202,7 +203,7 @@ func (r *IndexerRepo) FindByFilterID(ctx context.Context, id int) ([]domain.Inde
 func (r *IndexerRepo) Delete(ctx context.Context, id int) error {
 	queryBuilder := r.db.squirrel.
 		Delete("indexer").
-		Where("id = ?", id)
+		Where(sq.Eq{"id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/irc.go
+++ b/internal/database/irc.go
@@ -94,10 +94,8 @@ func (r *IrcRepo) DeleteNetwork(ctx context.Context, id int64) error {
 		return errors.Wrap(err, "error executing query")
 	}
 
-	err = tx.Commit()
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		return errors.Wrap(err, "error commit deleting network")
-
 	}
 
 	return nil
@@ -439,8 +437,7 @@ func (r *IrcRepo) StoreNetworkChannels(ctx context.Context, networkID int64, cha
 		//channel.ID, err = res.LastInsertId()
 	}
 
-	err = tx.Commit()
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		return errors.Wrap(err, "error commit transaction store network")
 	}
 

--- a/internal/database/irc.go
+++ b/internal/database/irc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/pkg/errors"
+	sq "github.com/Masterminds/squirrel"
 
 	"github.com/rs/zerolog"
 )
@@ -28,7 +29,7 @@ func (r *IrcRepo) GetNetworkByID(ctx context.Context, id int64) (*domain.IrcNetw
 	queryBuilder := r.db.squirrel.
 		Select("id", "enabled", "name", "server", "port", "tls", "pass", "nick", "auth_mechanism", "auth_account", "auth_password", "invite_command").
 		From("irc_network").
-		Where("id = ?", id)
+		Where(sq.Eq{"id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -67,7 +68,7 @@ func (r *IrcRepo) DeleteNetwork(ctx context.Context, id int64) error {
 
 	queryBuilder := r.db.squirrel.
 		Delete("irc_channel").
-		Where("network_id = ?", id)
+		Where(sq.Eq{"network_id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -81,7 +82,7 @@ func (r *IrcRepo) DeleteNetwork(ctx context.Context, id int64) error {
 
 	netQueryBuilder := r.db.squirrel.
 		Delete("irc_network").
-		Where("id = ?", id)
+		Where(sq.Eq{"id": id})
 
 	netQuery, netArgs, err := netQueryBuilder.ToSql()
 	if err != nil {
@@ -106,7 +107,7 @@ func (r *IrcRepo) FindActiveNetworks(ctx context.Context) ([]domain.IrcNetwork, 
 	queryBuilder := r.db.squirrel.
 		Select("id", "enabled", "name", "server", "port", "tls", "pass", "nick", "auth_mechanism", "auth_account", "auth_password", "invite_command").
 		From("irc_network").
-		Where("enabled = ?", true)
+		Where(sq.Eq{"enabled": true})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -200,7 +201,7 @@ func (r *IrcRepo) ListChannels(networkID int64) ([]domain.IrcChannel, error) {
 	queryBuilder := r.db.squirrel.
 		Select("id", "name", "enabled", "password").
 		From("irc_channel").
-		Where("network_id = ?", networkID)
+		Where(sq.Eq{"network_id": networkID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -237,8 +238,8 @@ func (r *IrcRepo) CheckExistingNetwork(ctx context.Context, network *domain.IrcN
 	queryBuilder := r.db.squirrel.
 		Select("id", "enabled", "name", "server", "port", "tls", "pass", "nick", "auth_mechanism", "auth_account", "auth_password", "invite_command").
 		From("irc_network").
-		Where("server = ?", network.Server).
-		Where("auth_account = ?", network.Auth.Account)
+		Where(sq.Eq{"server": network.Server}).
+		Where(sq.Eq{"auth_account": network.Auth.Account})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -350,7 +351,7 @@ func (r *IrcRepo) UpdateNetwork(ctx context.Context, network *domain.IrcNetwork)
 		Set("auth_password", password).
 		Set("invite_command", inviteCmd).
 		Set("updated_at", time.Now().Format(time.RFC3339)).
-		Where("id = ?", network.ID)
+		Where(sq.Eq{"id": network.ID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -378,7 +379,7 @@ func (r *IrcRepo) StoreNetworkChannels(ctx context.Context, networkID int64, cha
 
 	queryBuilder := r.db.squirrel.
 		Delete("irc_channel").
-		Where("network_id = ?", networkID)
+		Where(sq.Eq{"network_id": networkID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -458,7 +459,7 @@ func (r *IrcRepo) StoreChannel(networkID int64, channel *domain.IrcChannel) erro
 			Set("detached", channel.Detached).
 			Set("name", channel.Name).
 			Set("pass", pass).
-			Where("id = ?", channel.ID)
+			Where(sq.Eq{"id": channel.ID})
 
 		query, args, err := channelQueryBuilder.ToSql()
 		if err != nil {
@@ -528,7 +529,7 @@ func (r *IrcRepo) UpdateChannel(channel *domain.IrcChannel) error {
 		Set("detached", channel.Detached).
 		Set("name", channel.Name).
 		Set("pass", pass).
-		Where("id = ?", channel.ID)
+		Where(sq.Eq{"id": channel.ID})
 
 	query, args, err := channelQueryBuilder.ToSql()
 	if err != nil {
@@ -549,7 +550,7 @@ func (r *IrcRepo) UpdateInviteCommand(networkID int64, invite string) error {
 	channelQueryBuilder := r.db.squirrel.
 		Update("irc_network").
 		Set("invite_command", invite).
-		Where("id = ?", networkID)
+		Where(sq.Eq{"id": networkID})
 
 	query, args, err := channelQueryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/notification.go
+++ b/internal/database/notification.go
@@ -144,7 +144,7 @@ func (r *NotificationRepo) FindByID(ctx context.Context, id int) (*domain.Notifi
 			"updated_at",
 		).
 		From("notification").
-		Where("id = ?", id)
+		Where(sq.Eq{"id": id})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -240,7 +240,7 @@ func (r *NotificationRepo) Update(ctx context.Context, notification domain.Notif
 		Set("api_key", apiKey).
 		Set("channel", channel).
 		Set("updated_at", sq.Expr("CURRENT_TIMESTAMP")).
-		Where("id = ?", notification.ID)
+		Where(sq.Eq{"id": notification.ID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -260,7 +260,7 @@ func (r *NotificationRepo) Update(ctx context.Context, notification domain.Notif
 func (r *NotificationRepo) Delete(ctx context.Context, notificationID int) error {
 	queryBuilder := r.db.squirrel.
 		Delete("notification").
-		Where("id = ?", notificationID)
+		Where(sq.Eq{"id": notificationID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -61,8 +61,8 @@ func (repo *ReleaseRepo) StoreReleaseActionStatus(ctx context.Context, a *domain
 			Set("status", a.Status).
 			Set("rejections", pq.Array(a.Rejections)).
 			Set("timestamp", a.Timestamp).
-			Where("id = ?", a.ID).
-			Where("release_id = ?", a.ReleaseID)
+			Where(sq.Eq{"id": a.ID}).
+			Where(sq.Eq{"release_id": a.ReleaseID})
 
 		query, args, err := queryBuilder.ToSql()
 		if err != nil {
@@ -346,7 +346,7 @@ func (repo *ReleaseRepo) GetActionStatusByReleaseID(ctx context.Context, release
 	queryBuilder := repo.db.squirrel.
 		Select("id", "status", "action", "type", "client", "filter", "rejections", "timestamp").
 		From("release_action_status").
-		Where("release_id = ?", releaseID)
+		Where(sq.Eq{"release_id": releaseID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -390,7 +390,7 @@ func (repo *ReleaseRepo) attachActionStatus(ctx context.Context, tx *Tx, release
 	queryBuilder := repo.db.squirrel.
 		Select("id", "status", "action", "type", "client", "filter", "rejections", "timestamp").
 		From("release_action_status").
-		Where("release_id = ?", releaseID)
+		Where(sq.Eq{"release_id": releaseID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -166,7 +166,7 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 			if reskey := r.FindAllStringSubmatch(search, -1); len(reskey) != 0 {
 				filter := sq.Or{}
 				for _, found := range reskey {
-					filter = append(filter, sq.Like{v: strings.ReplaceAll(strings.Trim(strings.Trim(found[1], `"`), `'`), ".", "_") + "%"})
+					filter = append(filter, ILike(v, strings.ReplaceAll(strings.Trim(strings.Trim(found[1], `"`), `'`), ".", "_")+"%"))
 				}
 
 				queryBuilder = queryBuilder.Where(filter)
@@ -175,7 +175,7 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 		}
 
 		if len(search) != 0 {
-			queryBuilder = queryBuilder.Where(sq.Like{"r.torrent_name": search + "%"})
+			queryBuilder = queryBuilder.Where(ILike("r.torrent_name", search+"%"))
 		}
 	}
 
@@ -480,7 +480,7 @@ func (repo *ReleaseRepo) CanDownloadShow(ctx context.Context, title string, seas
 	queryBuilder := repo.db.squirrel.
 		Select("COUNT(*)").
 		From("release").
-		Where(sq.Like{"title": title + "%"})
+		Where(ILike("title", title+"%"))
 
 	if season > 0 && episode > 0 {
 		queryBuilder = queryBuilder.Where(sq.Or{

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -98,7 +98,7 @@ func (repo *ReleaseRepo) StoreReleaseActionStatus(ctx context.Context, a *domain
 }
 
 func (repo *ReleaseRepo) Find(ctx context.Context, params domain.ReleaseQueryParams) ([]*domain.Release, int64, int64, error) {
-	tx, err := repo.db.BeginTx(ctx, &sql.TxOptions{})
+	tx, err := repo.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return nil, 0, 0, errors.Wrap(err, "error begin transaction")
 	}
@@ -238,7 +238,7 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 }
 
 func (repo *ReleaseRepo) FindRecent(ctx context.Context) ([]*domain.Release, error) {
-	tx, err := repo.db.BeginTx(ctx, &sql.TxOptions{})
+	tx, err := repo.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return nil, errors.Wrap(err, "error begin transaction")
 	}

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -511,7 +511,7 @@ func (repo *ReleaseRepo) CanDownloadShow(ctx context.Context, title string, seas
 	queryBuilder := repo.db.squirrel.
 		Select("COUNT(*)").
 		From("release").
-		Where("title LIKE ?", fmt.Sprint("%", title, "%"))
+		Where(sq.Like{"title": title + "%"})
 
 	if season > 0 && episode > 0 {
 		queryBuilder = queryBuilder.Where(sq.Or{

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -6,6 +6,7 @@ import (
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/pkg/errors"
+	sq "github.com/Masterminds/squirrel"
 
 	"github.com/rs/zerolog"
 )
@@ -48,7 +49,7 @@ func (r *UserRepo) FindByUsername(ctx context.Context, username string) (*domain
 	queryBuilder := r.db.squirrel.
 		Select("id", "username", "password").
 		From("users").
-		Where("username = ?", username)
+		Where(sq.Eq{"username": username})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -99,7 +100,7 @@ func (r *UserRepo) Update(ctx context.Context, user domain.User) error {
 		Update("users").
 		Set("username", user.Username).
 		Set("password", user.Password).
-		Where("username = ?", user.Username)
+		Where(sq.Eq{"username": user.Username})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {


### PR DESCRIPTION
SQLite defaults to sql.LevelSerializable, which takes a full atomic lock during the transaction. MSSQL defaults to sql.LevelReadCommitted, which seems like a reasonable compromise. Presently untested.

Documentation: https://www.sqlite.org/isolation.html
https://pkg.go.dev/database/sql#IsolationLevel