### PR TITLE
fix(indexers): TS regex

### DIFF
--- a/internal/indexer/definitions/torrentseeds.yaml
+++ b/internal/indexer/definitions/torrentseeds.yaml
@@ -59,7 +59,7 @@ irc:
     lines:
       - test:
           - "New: This.Is.A.New.show.S00E00.720p.WEB.H264-Test .:. Category: TV/HD .:. Size: 364.82 MB .:. URL:  https://www.torrentseeds.org/details.php?id=000000 .:. Uploaded by: George."
-        pattern: 'New: (.+) \.:\. Category: (.+) \.:\. Size: (.+) \.:\. URL:  (https?\:\/\/.+\/).+id=(\d+) \.:\. Uploaded by: (.*)\.'
+        pattern: 'New: (.+) \.:\. Category: (.+) \.:\. Size: (.+) \.:\. URL:  (https?\:\/\/.+\/).+/(\d+) \.:\. Uploaded by: (.*)\.'
         vars:
           - torrentName
           - category

--- a/internal/indexer/definitions/torrentseeds.yaml
+++ b/internal/indexer/definitions/torrentseeds.yaml
@@ -58,7 +58,7 @@ irc:
     type: single
     lines:
       - test:
-          - "New: This.Is.A.New.show.S00E00.720p.WEB.H264-Test .:. Category: TV/HD .:. Size: 364.82 MB .:. URL:  https://www.torrentseeds.org/details.php?id=000000 .:. Uploaded by: George."
+          - "New: This.Is.A.New.show.S00E00.720p.WEB.H264-Test .:. Category: TV/HD .:. Size: 706.15 MiB .:. URL:  https://www.torrentseeds.org/torrents/0000000 .:. Uploaded by: George."
         pattern: 'New: (.+) \.:\. Category: (.+) \.:\. Size: (.+) \.:\. URL:  (https?\:\/\/.+\/).+/(\d+) \.:\. Uploaded by: (.*)\.'
         vars:
           - torrentName


### PR DESCRIPTION
Adjusted our regex with capturing the ID after `/` instead of `id=`. 
Tested this the new expression with 1180 announces of which all resulted in a match.

EDIT:
Tested this PR with a snapshot build aswell. Successfully fetching files now again.