### PR TITLE
fix(indexers): fix AR and TS (GER) regex patterns

### DIFF
--- a/internal/indexer/definitions/alpharatio.yaml
+++ b/internal/indexer/definitions/alpharatio.yaml
@@ -66,7 +66,7 @@ irc:
     lines:
       - test:
           - "[new release]-[moviehd]-[that.movie.2017.internal.1080p.bluray.crf.x264-group]-[url]-[ https://alpharatio.cc/torrents.php?id=000000 ]-[ 000000 ]-[ uploaded 2 mins, 59 secs after pre. ]"
-        pattern: \[new release\]-\[(.*)\]-\[(.*)\]-\[url\]-\[ (https?://.+/).+id=\d+ \]-\[ (\d+) \](?:-\[ uploaded (.*) after pre. ])?
+        pattern: '\[.*\]-\[(.*)\]-\[(.*)\]-\[.*\]-\[ (https?://.+/).*]-\[ (\d+) \](?:-\[ \w* (.*) after .* ])?'
         vars:
           - category
           - torrentName
@@ -75,7 +75,7 @@ irc:
           - preTime
       - test:
           - "[AutoDL]-[MovieHD]-[000000]-[ 1 | 10659 | 1 | 1 ]-[That.Movie.2017.INTERNAL.1080p.BluRay.CRF.x264-GROUP]"
-        pattern: \[AutoDL\]-\[.*\]-\[.*\]-\[ ([01]) \| (\d+) \| ([01]) \| ([01]) \]-\[.+\]
+        pattern: '\[.*\]-\[.*\]-\[.*\]-\[ ([01]) \| (\d+) \| ([01]) \| ([01]) \]-\[.*\]'
         vars:
           - scene
           - torrentSize

--- a/internal/indexer/definitions/torrentsyndikat.yaml
+++ b/internal/indexer/definitions/torrentsyndikat.yaml
@@ -61,7 +61,7 @@ irc:
           - "NEU Welcome.to.the.N.H.K.S01E15.German.DL.AC3.720p.BluRay.x264-ABJ [Serien/720p] [P2P] [678.68 MB] -- https://torrent-syndikat.org/details.php?id=000000 | Animation, Anime, Comedy, Drama, Romance, Thriller, Encode, AVC, DL, PID:00000, tt0857297"
           - "NEU KLIM_Beats-FireFlies-WEB-2016-KNOWN [Audio/Musik/MP3] [O-SCENE] [59.82 MB] -- https://torrent-syndikat.org/details.php?id=000000 | Hip-Hop"
           - "NEU DarkSpar-DARKZER0 [Spiele/Windows] [O-SCENE] [54.46 MB] -- https://torrent-syndikat.org/details.php?id=000000 | "
-        pattern: 'NEU (.+) \[(.+)\] \[(.+)\] \[(.+)\] -- (https?\:\/\/.+\/).+id=(\d+) \| (.+)'
+        pattern: 'NEU (.*) \[(.*)\] \[(.*)\] \[(.*)\] -- (https?\:\/\/.*\/).*id=(\d+) \| (.*)'
         vars:
           - torrentName
           - category


### PR DESCRIPTION
The indexer definition for AR resulted in `line not matching expected regex pattern` for all announces for unknown reason.
Recreated the regex to a similar but much more rudimentary fashion.

The indexer definition for TS (GER) resulted in `line not matching expected regex pattern` when there were no tags existing in the announce. 

AR is successfully tested in a live env and in regex101 with 1069 multi-line announces and
TS (GER) got successfully tested through mock with an announce previously resulting in an error.