### PR TITLE
feat(web): added missing placeholders

### DIFF
--- a/web/src/screens/filters/action.tsx
+++ b/web/src/screens/filters/action.tsx
@@ -291,6 +291,7 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
               name={`actions.${idx}.save_path`}
               label="Save path"
               columns={6}
+              placeholder="eg. /full/path/to/watch_folder"
             />
           </div>
         </div>
@@ -300,6 +301,7 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
             name={`actions.${idx}.label`}
             label="Label"
             columns={6}
+            placeholder="eg. label1 (must exist in Deluge to work)"
           />
         </div>
 
@@ -339,6 +341,7 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
               name={`actions.${idx}.label`}
               label="Label"
               columns={6}
+              placeholder="eg. label1,label2"
             />
           </div>
 
@@ -347,6 +350,7 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
               name={`actions.${idx}.save_path`}
               label="Save path"
               columns={6}
+              placeholder="eg. /full/path/to/watch_folder"
             />
           </div>
         </div>
@@ -367,6 +371,7 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
               name={`actions.${idx}.save_path`}
               label="Save path"
               columns={6}
+              placeholder="eg. /full/path/to/watch_folder"
             />
           </div>
         </div>

--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -343,12 +343,12 @@ export function General() {
         <TitleSubtitle title="Rules" subtitle="Specify rules on how torrents should be handled/selected" />
 
         <div className="mt-6 grid grid-cols-12 gap-6">
-          <TextField name="min_size" label="Min size" columns={6} placeholder="" />
-          <TextField name="max_size" label="Max size" columns={6} placeholder="" />
-          <NumberField name="delay" label="Delay" placeholder="" />
-          <NumberField name="priority" label="Priority" placeholder="" />
+          <TextField name="min_size" label="Min size" columns={6} placeholder="eg. 100MiB, 80GB" />
+          <TextField name="max_size" label="Max size" columns={6} placeholder="eg. 100MiB, 80GB" />
+          <NumberField name="delay" label="Delay" placeholder="Number of seconds to delay actions" />
+          <NumberField name="priority" label="Priority" placeholder="Higher number = higher prio" />
 
-          <NumberField name="max_downloads" label="Max downloads" placeholder="" />
+          <NumberField name="max_downloads" label="Max downloads" placeholder="Takes any number (0 is infinite)" />
           <Select name="max_downloads_unit" label="Max downloads per" options={downloadsPerUnitOptions}  optionDefaultText="Select unit" />
         </div>
       </div>
@@ -473,7 +473,7 @@ export function Advanced({ values }: AdvancedProps) {
           <WarningAlert text="autobrr has extensive filtering built-in - only use this if nothing else works. If you need help please ask." />
 
           <TextField name="match_releases" label="Match releases" columns={6} placeholder="eg. *some?movie*,*some?show*s01*" />
-          <TextField name="except_releases" label="Except releases" columns={6} placeholder="" />
+          <TextField name="except_releases" label="Except releases" columns={6} placeholder="eg. *bad?movie*,*bad?show*s03*" />
           {values.match_releases ? (
             <WarningAlert
               alert="Ask yourself:"
@@ -526,7 +526,7 @@ export function Advanced({ values }: AdvancedProps) {
           <WarningAlert text="These might not be what you think they are. For advanced users who know how things are parsed." />
 
           <TextField name="match_release_tags" label="Match release tags" columns={6} placeholder="eg. *mkv*,*foreign*" />
-          <TextField name="except_release_tags" label="Except release tags" columns={6} placeholder="" />
+          <TextField name="except_release_tags" label="Except release tags" columns={6} placeholder="eg. *mkv*,*foreign*" />
           <div className="col-span-6">
             <SwitchGroup name="use_regex_release_tags" label="Use Regex" />
           </div>
@@ -538,7 +538,7 @@ export function Advanced({ values }: AdvancedProps) {
           <SwitchGroup name="freeleech" label="Freeleech" />
         </div>
 
-        <TextField name="freeleech_percent" label="Freeleech percent" columns={6} />
+        <TextField name="freeleech_percent" label="Freeleech percent" columns={6} placeholder="eg. 50,75-100" />
       </CollapsableSection>
     </div>
   );


### PR DESCRIPTION
Added placeholders where there weren't any.

Some notable ones:

- Warn that label must exist in Deluge in order to work in `Deluge Label placeholder`.
- Higher number = higher prio in `Priority placeholder`.
- Emphasize that 0 is infinite in `Max downloads placeholder`.
- Emphasize the use of seconds in `Delay placeholder`.