### PR TITLE
fix(indexers): bad ncore torrent URL

### DIFF
--- a/internal/indexer/definitions/ncore.yaml
+++ b/internal/indexer/definitions/ncore.yaml
@@ -69,4 +69,4 @@ irc:
 
     match:
       # https://ncore.pro/torrents.php?action=download&id=0000&key=00000
-      torrenturl: "/download&id={{ .torrentId }}&key={{ .passkey }}"
+      torrenturl: "/torrents.php?action=download&id={{ .torrentId }}&key={{ .passkey }}"


### PR DESCRIPTION
Fixed the URL change initially made in the [baseurl override commit](https://github.com/autobrr/autobrr/commit/25a165b764ace7937ee8b0786ecd9bcd4b86a939#diff-8f417b2cd8914a5cdbdf14faaae4938e7f50de76992015ca2512204d3d0871a4)
An ncore user reported getting 404s after upgrading to v1.12.0

Untested, but should be good. The guy reporting it checked and confirmed that the URL is correct.