### PR TITLE
fix(database): fix filter regression from clean-up

### DIFF
--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -28,7 +28,6 @@ func NewActionRepo(log logger.Logger, db *DB, clientRepo domain.DownloadClientRe
 }
 
 func (r *ActionRepo) FindByFilterID(ctx context.Context, filterID int) ([]*domain.Action, error) {
-
 	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 	if err != nil {
 		return nil, err
@@ -49,10 +48,6 @@ func (r *ActionRepo) FindByFilterID(ctx context.Context, filterID int) ([]*domai
 			}
 			action.Client = *client
 		}
-	}
-
-	if err = tx.Commit(); err != nil {
-		return nil, errors.Wrap(err, "error finding filter by id")
 	}
 
 	return actions, nil
@@ -611,8 +606,7 @@ func (r *ActionRepo) StoreFilterActions(ctx context.Context, actions []*domain.A
 		r.log.Debug().Msgf("action.StoreFilterActions: store '%v' type: '%v' on filter: %v", action.Name, action.Type, filterID)
 	}
 
-	err = tx.Commit()
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, errors.Wrap(err, "error updating filter actions")
 
 	}

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -52,7 +52,7 @@ func (r *FilterRepo) find(ctx context.Context, tx *Tx, params domain.FilterQuery
 	actionCountQuery := r.db.squirrel.
 		Select("COUNT(*)").
 		From("action a").
-		Where(sq.Eq{"a.filter_id": "f.id"})
+		Where("a.filter_id = f.id")
 
 	queryBuilder := r.db.squirrel.
 		Select(

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -123,7 +123,7 @@ func (r *FilterRepo) ListFilters(ctx context.Context) ([]domain.Filter, error) {
 	actionCountQuery := r.db.squirrel.
 		Select("COUNT(*)").
 		From("action a").
-		Where(sq.Eq{"a.filter_id": "f.id"})
+		Where("a.filter_id = f.id")
 
 	queryBuilder := r.db.squirrel.
 		Select(

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -109,10 +109,6 @@ func (repo *ReleaseRepo) Find(ctx context.Context, params domain.ReleaseQueryPar
 		return nil, nextCursor, total, err
 	}
 
-	if err = tx.Commit(); err != nil {
-		return nil, 0, 0, errors.Wrap(err, "error commit transaction find releases")
-	}
-
 	return releases, nextCursor, total, nil
 }
 
@@ -313,10 +309,6 @@ func (repo *ReleaseRepo) FindRecent(ctx context.Context) ([]*domain.Release, err
 		return nil, err
 	}
 
-	if err = tx.Commit(); err != nil {
-		return nil, errors.Wrap(err, "error transaction commit")
-	}
-
 	return releases, nil
 }
 
@@ -487,8 +479,7 @@ func (repo *ReleaseRepo) Delete(ctx context.Context) error {
 		return errors.Wrap(err, "error executing query")
 	}
 
-	err = tx.Commit()
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		return errors.Wrap(err, "error commit transaction delete")
 	}
 


### PR DESCRIPTION
So, as we're now painfully aware from https://github.com/autobrr/autobrr/pull/569 squirrel does not support subqueries as well as one would expect. There's some support, if you use an Alias on a column to provide a window, but this only supports params in either the window, another window, or a parent function, otherwise squirrel will misplace them. As squirrel is now in "maintenance" mode, I don't expect this situation to improve unfortunately.

So, lets revert this (hopefully) one regression.