### PR TITLE
enhancement(web): gray color for disabled checkboxes in dark mode

### DIFF
--- a/web/src/components/inputs/common.tsx
+++ b/web/src/components/inputs/common.tsx
@@ -37,7 +37,7 @@ const CheckboxField = ({
         type="checkbox" 
         className={classNames(
           "focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded", 
-          disabled ? "dark:bg-gray-700 dark:border-gray-700 bg-gray-200" : ""
+          disabled ? "bg-gray-200 dark:bg-gray-700 dark:border-gray-700" : ""
         )}
         disabled={disabled}
       />

--- a/web/src/components/inputs/common.tsx
+++ b/web/src/components/inputs/common.tsx
@@ -37,7 +37,7 @@ const CheckboxField = ({
         type="checkbox" 
         className={classNames(
           "focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded", 
-          disabled ? "bg-gray-700 border-gray-700" : "bg-gray-200"
+          disabled ? "dark:bg-gray-700 dark:border-gray-700 bg-gray-200" : ""
         )}
         disabled={disabled}
       />

--- a/web/src/components/inputs/common.tsx
+++ b/web/src/components/inputs/common.tsx
@@ -35,7 +35,10 @@ const CheckboxField = ({
         id={name}
         name={name}
         type="checkbox" 
-        className={classNames("focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded", disabled ? "bg-gray-200" : "")}
+        className={classNames(
+          "focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded", 
+          disabled ? "bg-gray-700 border-gray-700" : "bg-gray-200"
+        )}
         disabled={disabled}
       />
     </div>


### PR DESCRIPTION
Disabled checkboxes in dark mode are now the same color as disabled NumberFields in dark mode.

![image](https://user-images.githubusercontent.com/35452459/210186211-952187cc-3bf3-441a-a46d-a62f8f502d02.png)
