### PR TITLE
fix(web) reversed onChange for priority numberfield

### DIFF
--- a/web/src/components/inputs/input.tsx
+++ b/web/src/components/inputs/input.tsx
@@ -249,16 +249,6 @@ export const NumberField = ({
             )}
             placeholder={placeholder}
             disabled={disabled}
-            onChange={event => {
-              // safeguard and validation if user removes the number
-              // it will then set 0 by default. Formik can't handle this properly
-              if (event.target.value == "") {
-                form.setFieldValue(field.name, 0);
-                return;
-              }
-
-              form.setFieldValue(field.name, event.target.value);
-            }}
           />
           {meta.touched && meta.error && (
             <div className="error">{meta.error}</div>


### PR DESCRIPTION
Unable to adjust priority within filters with the following code present, so removed it for now.
```js
            onChange={event => {
              // safeguard and validation if user removes the number
              // it will then set 0 by default. Formik can't handle this properly
              if (event.target.value == "") {
                form.setFieldValue(field.name, 0);
                return;
              }

              form.setFieldValue(field.name, event.target.value);
            }}
          />
          {meta.touched && meta.error && (
            <div className="error">{meta.error}</div>
          )}
```
<img width="276" alt="image" src="https://user-images.githubusercontent.com/18177310/210277848-c67cf09b-3ae9-4d78-bbf5-ca809f168a04.png">