### PR TITLE
fix(indexers): subsplease baseurl

### DIFF
--- a/internal/indexer/definitions/subsplease.yaml
+++ b/internal/indexer/definitions/subsplease.yaml
@@ -5,7 +5,7 @@ identifier: subsplease
 description: SubsPlease is an indexer for Anime.
 language: en-us
 urls:
-  - https://subsplease.org/
+  - https://nyaa.si/
 privacy: public
 protocol: torrent
 supports:


### PR DESCRIPTION
This PR fixes the 404 HTTP Error for SubsPlease, since the baseURL was wrong.