### PR TITLE
feat(web): added missing placeholder to r(u)Torrent action label

### DIFF
--- a/web/src/screens/filters/action.tsx
+++ b/web/src/screens/filters/action.tsx
@@ -341,7 +341,7 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
               name={`actions.${idx}.label`}
               label="Label"
               columns={6}
-              placeholder="eg. label1,label2"
+              placeholder="eg. label1 (must exist in rTorrent to work)"
             />
           </div>
 

--- a/web/src/screens/filters/action.tsx
+++ b/web/src/screens/filters/action.tsx
@@ -341,7 +341,7 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
               name={`actions.${idx}.label`}
               label="Label"
               columns={6}
-              placeholder="eg. label1 (must exist in rTorrent to work)"
+              placeholder="eg. label1 (must exist in ruTorrent to work)"
             />
           </div>
 


### PR DESCRIPTION
Turns out ruTorrent labels need to exist for autobrr to use it.
Same as with Deluge labels basically.