### PR TITLE
fix(indexers): subsplease regex

### DIFF
--- a/internal/indexer/definitions/subsplease.yaml
+++ b/internal/indexer/definitions/subsplease.yaml
@@ -44,7 +44,7 @@ irc:
   parse:
     type: single
     lines:
-      - pattern: '\[Release\] (.*(SubsPlease).*.(mkv)) \((.*)\) - .* - (.*)'
+      - pattern: '\[Release\] (.*(SubsPlease).*?)\.?(mkv)? \((\d+.?\d*[KMGTP]?B)\) - .* - (.*)'
         vars:
           - torrentName
           - releaseGroup


### PR DESCRIPTION
A user on discord found an issue with the SubsPlease regex not matching batches.
To fix the issue the releaseTags capture group is now optional.

Making the releaseTags group optional proposed another issue,
where the torrentName capture group would consume the content of the releaseTags group aswell.
This got fixed by setting the quantifier of the torrentName capture group lazy/ungreedy.

After setting this quantifier lazy/ungreedy the torrentName capture group got ended early by the torrentSize capture group.
That issue got fixed by creating a more specific regex for the torrentSize group.

Additionally I decided to move the releaseTags capture group out of the torrentName group in order to create more exact matches from the names of nyaa and the SubsPlease site itself.

Unfortunately i only had 4 announces to test this.
Should there be any concerns about the new regex you can leave it open
and I will check the regex from time to time after having gathered more announces.

https://regex101.com/r/M8nlhM/2