### PR TITLE
feat(indexers): improve RED and OPS artist parsing

### DIFF
--- a/internal/action/lidarr.go
+++ b/internal/action/lidarr.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -51,12 +50,6 @@ func (s *service) lidarr(ctx context.Context, action *domain.Action, release dom
 		DownloadProtocol: "torrent",
 		Protocol:         "torrent",
 		PublishDate:      time.Now().Format(time.RFC3339),
-	}
-
-	// special handling for RED and OPS because their torrent names contain to little info
-	// "Artist - Album" is not enough for Lidarr to make a decision. It needs year like "Artist - Album 2022"
-	if release.Indexer == "redacted" || release.Indexer == "ops" {
-		r.Title = fmt.Sprintf("%v (%d)", release.TorrentName, release.Year)
 	}
 
 	rejections, err := arr.Push(ctx, r)

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -376,11 +376,11 @@ func (f Filter) CheckFilter(r *Release) ([]string, bool) {
 	}
 
 	if len(f.Artists) > 0 && !contains(r.Artists, f.Artists) {
-		r.addRejectionF("artists not matching. got: %v want: %v", r.TorrentName, f.Artists)
+		r.addRejectionF("artists not matching. got: %v want: %v", r.Artists, f.Artists)
 	}
 
 	if len(f.Albums) > 0 && !contains(r.Title, f.Albums) {
-		r.addRejectionF("albums not matching. got: %v want: %v", r.TorrentName, f.Albums)
+		r.addRejectionF("albums not matching. got: %v want: %v", r.Title, f.Albums)
 	}
 
 	// Perfect flac requires Cue, Log, Log Score 100, FLAC and 24bit Lossless

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -375,11 +375,11 @@ func (f Filter) CheckFilter(r *Release) ([]string, bool) {
 		r.addRejectionF("tags unwanted. got: %v want: %v", r.Tags, f.ExceptTags)
 	}
 
-	if len(f.Artists) > 0 && !containsFuzzy(r.TorrentName, f.Artists) {
+	if len(f.Artists) > 0 && !contains(r.Artists, f.Artists) {
 		r.addRejectionF("artists not matching. got: %v want: %v", r.TorrentName, f.Artists)
 	}
 
-	if len(f.Albums) > 0 && !containsFuzzy(r.TorrentName, f.Albums) {
+	if len(f.Albums) > 0 && !contains(r.Title, f.Albums) {
 		r.addRejectionF("albums not matching. got: %v want: %v", r.TorrentName, f.Albums)
 	}
 

--- a/internal/indexer/definitions/orpheus.yaml
+++ b/internal/indexer/definitions/orpheus.yaml
@@ -61,7 +61,7 @@ irc:
           - "TORRENT: That Artist - Albuum [2002] [Single] - FLAC / Lossless / WEB - 2000s,house,uk.garage,garage.house - https://orpheus.network/torrents.php?id=000000 / https://orpheus.network/torrents.php?action=download&id=0000000"
           - "TORRENT: Something [2021] [Album] - FLAC / Lossless / CD -  - https://orpheus.network/torrents.php?id=000000 / https://orpheus.network/torrents.php?action=download&id=0000000"
           - "TORRENT: Artist 1 & Artist 2 - Best album (subtitle) [2004] [Album] - FLAC / Lossless / Log (100%) / Cue / CD - experimental,ambient,downtempo - https://orpheus.network/torrents.php?id=000000 / https://orpheus.network/torrents.php?action=download&id=0000000"
-        pattern: 'TORRENT: (.*) \[(.+?)\] \[(.+?)\] - (.*) - \s*(.*) - https?:\/\/.* \/ (https?:\/\/.+\/).+id=(\d+)'
+        pattern: 'TORRENT: (.* \[(.*?)\] \[(.*?)\] - (.*)) - \s*(.*) - https?:\/\/.* \/ (https?:\/\/.*\/).*id=(\d+)'
         vars:
           - torrentName
           - year

--- a/internal/indexer/definitions/red.yaml
+++ b/internal/indexer/definitions/red.yaml
@@ -85,7 +85,7 @@ irc:
       - test:
           - "Artist - Albumname [2008] [Single] - FLAC / Lossless / Log / 100% / Cue / CD - https://redacted.ch/torrents.php?id=0000000 / https://redacted.ch/torrents.php?action=download&id=0000000 - hip.hop,rhythm.and.blues,2000s"
           - "A really long name here - Concertos 5 and 6, Suite No 2 [1991] [Album] - FLAC / Lossless / Log / 100% / Cue / CD - https://redacted.ch/torrents.php?id=0000000 / https://redacted.ch/torrents.php?action=download&id=0000000 - classical"
-        pattern: '(.* (?:\[(.*)\] \[(.*)\] - (.*))?) - .* \/ (https?\:\/\/.+\/).+id=(\d+) - (.+)'
+        pattern: '(.* (?:\[(.*)\] \[(.*)\] - (.*))?) - .* \/ (https?\:\/\/.+\/).+id=(\d+)[ -]*(.*)'
         vars:
           - torrentName
           - year

--- a/internal/indexer/definitions/red.yaml
+++ b/internal/indexer/definitions/red.yaml
@@ -85,7 +85,7 @@ irc:
       - test:
           - "Artist - Albumname [2008] [Single] - FLAC / Lossless / Log / 100% / Cue / CD - https://redacted.ch/torrents.php?id=0000000 / https://redacted.ch/torrents.php?action=download&id=0000000 - hip.hop,rhythm.and.blues,2000s"
           - "A really long name here - Concertos 5 and 6, Suite No 2 [1991] [Album] - FLAC / Lossless / Log / 100% / Cue / CD - https://redacted.ch/torrents.php?id=0000000 / https://redacted.ch/torrents.php?action=download&id=0000000 - classical"
-        pattern: '(.*) (?:\[(.*)\] \[(.*)\] - (.*))? .* \/ (https?\:\/\/.+\/).+id=(\d+) - (.+)'
+        pattern: '(.* (?:\[(.*)\] \[(.*)\] - (.*))?) - .* \/ (https?\:\/\/.+\/).+id=(\d+) - (.+)'
         vars:
           - torrentName
           - year


### PR DESCRIPTION
This PR should improve the artist parsing for RED and OPS.

From `Artist - Album name` to now catch the whole `Artist - Albumname [2008] [Single] - FLAC / Lossless / Log / 100% / Cue / CD`. This should properly parse artist and album name. The other values were working good already.

And with this change we remove the workaround for Lidarr where we added year to the basic release name.