### PR TITLE
feat(downloadclients): qBit add rule UploadSpeedThreshold

### DIFF
--- a/internal/action/qbittorrent.go
+++ b/internal/action/qbittorrent.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
@@ -125,18 +126,30 @@ func (s *service) qbittorrentCheckRulesCanDownload(ctx context.Context, action *
 					// if current transfer speed is more than threshold return out and skip
 					// DlInfoSpeed is in bytes so lets convert to KB to match DownloadSpeedThreshold
 					if info.DlInfoSpeed/1024 >= client.Settings.Rules.DownloadSpeedThreshold {
-						s.log.Debug().Msg("max active downloads reached, skipping")
+						rejection := fmt.Sprintf("max active downloads reached and total download speed above threshold: %d, skipping", client.Settings.Rules.DownloadSpeedThreshold)
 
-						rejections := []string{"max active downloads reached, skipping"}
-						return rejections, nil
+						s.log.Debug().Msg(rejection)
+
+						return []string{rejection}, nil
+					}
+
+					// if current transfer speed is more than threshold return out and skip
+					// UpInfoSpeed is in bytes so lets convert to KB to match UploadSpeedThreshold
+					if info.UpInfoSpeed/1024 >= client.Settings.Rules.UploadSpeedThreshold {
+						rejection := fmt.Sprintf("max active downloads reached and total upload speed above threshold: %d, skipping", client.Settings.Rules.UploadSpeedThreshold)
+
+						s.log.Debug().Msg(rejection)
+
+						return []string{rejection}, nil
 					}
 
 					s.log.Debug().Msg("active downloads are slower than set limit, lets add it")
 				} else {
-					s.log.Debug().Msg("max active downloads reached, skipping")
+					rejection := "max active downloads reached, skipping"
 
-					rejections := []string{"max active downloads reached, skipping"}
-					return rejections, nil
+					s.log.Debug().Msg(rejection)
+
+					return []string{rejection}, nil
 				}
 			}
 		}

--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -48,6 +48,7 @@ type DownloadClientRules struct {
 	MaxActiveDownloads     int   `json:"max_active_downloads"`
 	IgnoreSlowTorrents     bool  `json:"ignore_slow_torrents"`
 	DownloadSpeedThreshold int64 `json:"download_speed_threshold"`
+	UploadSpeedThreshold   int64 `json:"upload_speed_threshold"`
 }
 
 type BasicAuth struct {

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -269,12 +269,20 @@ function FormFieldsRules() {
           />
 
           {settings.rules?.ignore_slow_torrents === true && (
-            <NumberFieldWide
-              name="settings.rules.download_speed_threshold"
-              label="Download speed threshold"
-              placeholder="in KB/s"
-              help="If download speed is below this when max active downloads is hit, download anyways. KB/s"
-            />
+            <>
+              <NumberFieldWide
+                name="settings.rules.download_speed_threshold"
+                label="Download speed threshold"
+                placeholder="in KB/s"
+                help="If download speed is below this when max active downloads is hit, download anyways. KB/s"
+              />
+              <NumberFieldWide
+                name="settings.rules.upload_speed_threshold"
+                label="Upload speed threshold"
+                placeholder="in KB/s"
+                help="If upload speed is below this when max active downloads is hit, download anyways. KB/s"
+              />
+            </>
           )}
         </>
       )}

--- a/web/src/types/Download.d.ts
+++ b/web/src/types/Download.d.ts
@@ -25,6 +25,7 @@ interface DownloadClientRules {
   max_active_downloads: number;
   ignore_slow_torrents: boolean;
   download_speed_threshold: number;
+  upload_speed_threshold: number;
 }
 
 interface DownloadClientBasicAuth {


### PR DESCRIPTION
Add new rule check for qBittorrent to check if the total transfer speed is below set threshold.

It works the same way as the Download Speed Threshold but upload instead.

Example: Upload speed threshhold set to 90000 (90MB/s)

If total transfer speed of client is less than 90000 it will add a new torrent if "ignore slow torrents" is enabled in the download client settings in autobrr.

If it's above 90000 then it will reject and skip adding.

Resolves #574