### PR TITLE
enhancement(web): autobrr logo link to dashboard

### DIFF
--- a/web/src/screens/Base.tsx
+++ b/web/src/screens/Base.tsx
@@ -40,16 +40,18 @@ export default function Base() {
                 <div className="flex items-center justify-between h-16 px-4 sm:px-0">
                   <div className="flex items-center">
                     <div className="flex-shrink-0 flex items-center">
-                      <img
-                        className="block lg:hidden h-10 w-auto"
-                        src={logo}
-                        alt="Logo"
-                      />
-                      <img
-                        className="hidden lg:block h-10 w-auto"
-                        src={logo}
-                        alt="Logo"
-                      />
+                      <Link to="/">
+                        <img
+                          className="block lg:hidden h-10 w-auto"
+                          src={logo}
+                          alt="Logo"
+                        />
+                        <img
+                          className="hidden lg:block h-10 w-auto"
+                          src={logo}
+                          alt="Logo"
+                        />
+                      </Link>
                     </div>
                     <div className="sm:ml-3 hidden sm:block">
                       <div className="flex items-baseline space-x-4">

--- a/web/src/screens/dashboard/Stats.tsx
+++ b/web/src/screens/dashboard/Stats.tsx
@@ -33,9 +33,9 @@ export const Stats = () => {
 
   return (
     <div>
-      <h3 className="text-2xl font-medium leading-6 text-gray-900 dark:text-gray-200">
+      <h1 className="text-3xl font-bold text-black dark:text-white">
         Stats
-      </h3>
+      </h1>
 
       <dl className="grid grid-cols-1 gap-5 mt-5 sm:grid-cols-2 lg:grid-cols-3">
         <StatsItem name="Filtered Releases" value={data?.filtered_count} />


### PR DESCRIPTION
### The autobrr logo now links to Dashboard
Having the top left logo link to the front page is something you see on a lot of web pages. It's something you don't think about, because it's always like that. I've clicked that logo so many times expecting it to redirect me to the Dashboard that I've lost count.

### Changed the Stats header tag on Dashboard
The Stats header was a h3 tag. It is now an h1 tag with the same styling as the other h1 headers on other pages.

[Header change demonstration.](https://i.imgur.com/kwL0HoI.mp4)