### PR TITLE
fix(indexers): multiple definition regex pattern corrections

### DIFF
--- a/internal/indexer/definitions/fuzer.yaml
+++ b/internal/indexer/definitions/fuzer.yaml
@@ -57,7 +57,7 @@ irc:
           - "New Torrent: סדרה - עונה 4 פרק 5 | Show S04E05 2160p UHDTV x265-Release-Group Category: סדרות ישראליות HD By: Uploader1 Size: 2.88GB Link: http://fuzer.me/attachment.php?attachmentid=101010 [Show.S04E05.2160p.UHDTV.x265-Release-Group]"
           - "New Torrent: סדרה אפילו יותר טובה - עונה 1 פרק 7 - תרגום בצד | Even Better Show S01E07 1080p AMZN WEB-DL DDP5.1 H.264 Category: סדרות HD By: EvenBett3rUploader Size: 2.27GB Link: http://fuzer.me/attachment.php?attachmentid=222222 [Even.Better.Show.S01E07.14.45.1080p.AMZN.WEB-DL.DDP5.1.H.264]"
           - "New Torrent: הכי טובה - עונה 1 פרק 5 - תרגום בצד | The Best S01E05 1080p WEB H264-TEST Category: סדרות HD By: Uploader5 Size: 3.25GB Link: http://fuzer.me/attachment.php?attachmentid=616161 [The.Best.S01E05.1080p.WEB.H264-TEST]"
-        pattern: 'New Torrent: (.*) Category: (.*) By: (.*) Size: (.*) Link: https?\:\/\/([^\/]+)\/.*[&amp;\?]attachmentid=(\d+) \[(.*)\]'
+        pattern: 'New Torrent:.*\| .* Category:\s?.* (.*) By: (.*) Size: (.*) Link: (https?\:\/\/.*\/).*attachmentid=(\d+) \[(.*)\]'
         vars:
           - category
           - uploader

--- a/internal/indexer/definitions/fuzer.yaml
+++ b/internal/indexer/definitions/fuzer.yaml
@@ -59,7 +59,6 @@ irc:
           - "New Torrent: הכי טובה - עונה 1 פרק 5 - תרגום בצד | The Best S01E05 1080p WEB H264-TEST Category: סדרות HD By: Uploader5 Size: 3.25GB Link: http://fuzer.me/attachment.php?attachmentid=616161 [The.Best.S01E05.1080p.WEB.H264-TEST]"
         pattern: 'New Torrent: (.*) Category: (.*) By: (.*) Size: (.*) Link: https?\:\/\/([^\/]+)\/.*[&amp;\?]attachmentid=(\d+) \[(.*)\]'
         vars:
-          - name1
           - category
           - uploader
           - torrentSize

--- a/internal/indexer/definitions/hebits.yaml
+++ b/internal/indexer/definitions/hebits.yaml
@@ -65,14 +65,13 @@ irc:
           - "New: (מה שקורה בצללים - עונה 4, פרק 3 / What We Do in the Shadows - S04E03 *היידפנישן*) Category: סדרות - HD Size: 825.43 MiB Seeders: 0 Leechers: 0"
           - "New: (לגו מלחמת הכוכבים: חופשת קיץ / LEGO Star Wars Summer Vacation *היידפנישן*) Category: סרטים - HD Size: 1.02 GiB Seeders: 0 Leechers: 0"
           - "New: (תמונות מחיי נישואין - עונה 1 / Scenes from a Marriage (US) - S01 *היידפנישן מלא*) Category: סדרות - HD מלא Size: 18.61 GiB Seeders: 0 Leechers: 0"
-        pattern: '^New: \((.*)\) Category: (.*) Size: ([\d\.,]+ \w+) Seeders: .+ Leechers: .+'
+        pattern: '^New: .* Category: .* (.*) Size: (.*) Seeders: .+ Leechers: .+'
         vars:
-          - name1
           - category
           - torrentSize
       - test:
           - "Link: https://hebits.net/torrents.php?torrentid=80081"
-        pattern: '^Link: (https?\:\/\/?[w{3}.]*[^\/]+\/).+torrentid=(\d+)'
+        pattern: '^Link: (https://?.*/).*torrentid=(\d+)'
         vars:
           - baseUrl
           - torrentId

--- a/internal/indexer/definitions/iplay.yaml
+++ b/internal/indexer/definitions/iplay.yaml
@@ -53,7 +53,7 @@ irc:
       - test:
           - "New torrent: Artist-Album-2022-GROUP -- [Black Metal] -- https://metal.iplay.ro/details.php?id=000000 -- by Anonymous"
           - "New torrent: Artist-Album -[WEB | FLAC]- RMT -- [FreeLeech!] -- [-Discography/Album Pack] -- https://metal.iplay.ro/details.php?id=000000 -- by Anonymous"
-        pattern: 'New Torrent: (.*?) (?:-- \[(.*)!\] )?-- \[(.*)] -- (https?://.+/).*id=(.*) -- by (.*)'
+        pattern: 'New torrent: (.*?) (?:-- \[(.*)!\] )?-- \[(.*)] -- (https?://.+/).*id=(.*) -- by (.*)'
         vars:
           - torrentName
           - freeleech

--- a/internal/indexer/definitions/ncore.yaml
+++ b/internal/indexer/definitions/ncore.yaml
@@ -59,7 +59,7 @@ irc:
       - test:
           - "[NEW TORRENT in mp3] Artist name - Album name > 115.63 MiB in 17F > https://ncore.pro/torrents.php?action=details&id=0000000"
           - "[NEW TORRENT in xvidser_hun] Some.Show.S02E67.RTLM.WEB-DL.H264.HUN-GROUP > 269.31 MiB in 2F > https://ncore.pro/torrents.php?action=details&id=0000000"
-        pattern: '\[NEW TORRENT in (.*)\] (.*) > (.*) in .* > (https?://ncore.pro.*action=).*id=(.*)'
+        pattern: '\[NEW TORRENT in (.*)\] (.*) > (.*) in .* > (https?://.*/).*action=.*id=(.*)'
         vars:
           - category
           - torrentName

--- a/internal/indexer/definitions/retroflix.yaml
+++ b/internal/indexer/definitions/retroflix.yaml
@@ -56,7 +56,7 @@ irc:
       - test:
           - "New! (Movies) - [REQUESTED].French.Movie.(1978).(French.with.English.Subtitles) - (18.76 GB) - https://retroflix.club/browse/t/00000/french-movie-1978-french-with-english-subtitles"
           - "New! (Movies) - Old.Movie.1967.1080p.BluRay.x265.10bit-GROUP1 - (5.42 GB) - https://retroflix.club/browse/t/00000/old-movie-1967-1080p-bluray-x265-10bit-group1"
-        pattern: ^New! \((.*)\) - (.*) - \((.*)\) - (https?:\/\/.*\/)browse/t/(\d+).*
+        pattern: '^New! \((.*)\) - (?:\[REQUESTED\].)?(.*) - \((.*)\) - (https?:\/\/.*\/)browse/t/(\d+).*'
         vars:
           - category
           - torrentName

--- a/internal/indexer/definitions/speedapp.yaml
+++ b/internal/indexer/definitions/speedapp.yaml
@@ -52,7 +52,7 @@ irc:
       - test:
           - "New! (Movies HD-RO) - Some.File.2022.1080p.WEB-DL.DDP5.1.Atmos.H.264.mkv - (5.14 GB) - https://speedapp.io/browse/00000/t/some-file-2022-1080p-web-dl-ddp5-1-atmos-h-264-mkv"
           - "New! (XXX HD) - Some.XXX.21.05.19.famous.actress.XXX.1080p.MP4-WRB - (841.64 MB) - https://speedapp.io/browse/000000/t/some-xxx-21-05-19-famous-actress-xxx-1080p-mp4-wrb"
-        pattern: 'New! \((.+)\) - (.+) - \((.+)\) - (https?:\/\/.+\/)browse\/(\d+)\/t\/(.+)'
+        pattern: 'New! \((.+)\) - (.+) - \((.+)\) - (https?:\/\/.+\/)browse\/(\d+)\/t\/.+'
         vars:
           - category
           - torrentName

--- a/internal/indexer/definitions/torrentbytes.yaml
+++ b/internal/indexer/definitions/torrentbytes.yaml
@@ -59,7 +59,7 @@ irc:
     lines:
       - test:
           - "[TB-RLS] .:. [ The.New.Game-GROUP ] .:. [ https://www.torrentbytes.net/download.php?id=0000000 ] .:. [ https://www.torrentbytes.net/details.php?id=0000000 ] .:. [ Uploaded 2 minutes, 12 seconds after pre ]"
-        pattern: '^\[TB-RLS\] \.:\. \[ (.*) \] \.:\. \[ https?\:\/\/([^\/]+\/).*id=(\d+).*https?\:\/\/(?:.*\[ Uploaded (.*)\])?'
+        pattern: '^\[TB-RLS\] \.:\. \[ (.*) \] \.:\. \[ (https?\:\/\/.*\/).*id=(\d+).*https?\:\/\/(?:.*\[ Uploaded (.*)\])?'
         vars:
           - torrentName
           - baseUrl


### PR DESCRIPTION
### Fuzer:
New: https://regex101.com/r/YxtVT7/1
Old: https://regex101.com/r/pmyFOX/1
Removed `name1` var and capture group.

### Hebits: 
New: https://regex101.com/r/AuJPRg/1
Old: https://regex101.com/r/66kpcT/1
Removed `name1` var and capture group.

### iPlay: 
New: https://regex101.com/r/9Qpe6k/1
Old: https://regex101.com/r/kLzNrI/1
Case sensitive start made it fail everything(?)

### nCore:
New: https://regex101.com/r/hTkcT8/1
Old: https://regex101.com/r/Pj0y6X/1
Bad baseurl capture.

### Retroflix:
New: https://regex101.com/r/qIS6i5/1
Old: https://regex101.com/r/WY5qPu/1
Removed [REQUESTED] from torrentName capture.

### Speedapp: 
New: https://regex101.com/r/Fzv6Cq/1
Old: https://regex101.com/r/1v0T3j/1
Removed unused capture group.

### TorrentBytes:
New: https://regex101.com/r/ozIu3F/1
Old: https://regex101.com/r/n5iJr6/1
Bad baseurl capture.