### PR TITLE
fix(filters): max downloads per filter check

### DIFF
--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -87,6 +87,7 @@ func (s *service) RunAction(ctx context.Context, action *domain.Action, release 
 		Type:       action.Type,
 		Client:     action.Client.Name,
 		Filter:     release.Filter.Name,
+		FilterID:   int64(release.Filter.ID),
 		Rejections: []string{},
 		Timestamp:  time.Now(),
 	}

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -264,12 +264,14 @@ CREATE TABLE release_action_status
 	type          TEXT NOT NULL,
 	client        TEXT,
 	filter        TEXT,
+	filter_id     INTEGER,
 	rejections    TEXT []   DEFAULT '{}' NOT NULL,
 	timestamp     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	raw           TEXT,
 	log           TEXT,
 	release_id    INTEGER NOT NULL,
-	FOREIGN KEY (release_id) REFERENCES "release"(id) ON DELETE CASCADE
+	FOREIGN KEY (release_id) REFERENCES "release"(id) ON DELETE CASCADE,
+	FOREIGN KEY (filter_id) REFERENCES "filter"(id) ON DELETE SET NULL
 );
 
 CREATE INDEX release_action_status_release_id_index
@@ -630,5 +632,19 @@ CREATE INDEX indexer_identifier_index
 
 	ALTER TABLE "filter"
 		ADD COLUMN except_language TEXT []   DEFAULT '{}';
+	`,
+	`ALTER TABLE release_action_status
+    ADD filter_id INTEGER;
+
+CREATE INDEX release_action_status_filter_id_index
+    ON release_action_status (filter_id);
+
+ALTER TABLE release_action_status
+    ADD CONSTRAINT release_action_status_filter_id_fk
+        FOREIGN KEY (filter_id) REFERENCES filter;
+
+UPDATE release_action_status
+SET filter_id = (SELECT f.id
+FROM filter f WHERE f.name = release_action_status.filter);
 	`,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -247,16 +247,27 @@ CREATE TABLE release_action_status
 	type          TEXT NOT NULL,
 	client        TEXT,
 	filter        TEXT,
+    filter_id     INTEGER
+        CONSTRAINT release_action_status_filter_id_fk
+            REFERENCES filter,
 	rejections    TEXT []   DEFAULT '{}' NOT NULL,
 	timestamp     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	raw           TEXT,
 	log           TEXT,
-	release_id    INTEGER NOT NULL,
-	FOREIGN KEY (release_id) REFERENCES "release"(id) ON DELETE CASCADE
+    release_id    INTEGER NOT NULL
+        CONSTRAINT release_action_status_release_id_fkey
+            REFERENCES "release"
+            ON DELETE CASCADE
 );
+
+CREATE INDEX release_action_status_status_index
+    ON release_action_status (status);
 
 CREATE INDEX release_action_status_release_id_index
     ON release_action_status (release_id);
+
+CREATE INDEX release_action_status_filter_id_index
+    ON release_action_status (filter_id);
 
 CREATE TABLE notification
 (
@@ -974,5 +985,59 @@ ALTER TABLE irc_network_dg_tmp
 
 	ALTER TABLE "filter"
 		ADD COLUMN except_language TEXT []   DEFAULT '{}';
+	`,
+	`CREATE TABLE release_action_status_dg_tmp
+(
+    id         INTEGER
+        PRIMARY KEY,
+    status     TEXT,
+    action     TEXT                   NOT NULL,
+    type       TEXT                   NOT NULL,
+    rejections TEXT      DEFAULT '{}' NOT NULL,
+    timestamp  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    raw        TEXT,
+    log        TEXT,
+    release_id INTEGER                NOT NULL
+        constraint release_action_status_release_id_fkey
+            references "release"
+            on delete cascade,
+    client     TEXT,
+    filter     TEXT,
+    filter_id  INTEGER
+        CONSTRAINT release_action_status_filter_id_fk
+            REFERENCES filter
+);
+
+INSERT INTO release_action_status_dg_tmp(id, status, action, type, rejections, timestamp, raw, log, release_id, client, filter)
+SELECT id,
+       status,
+       action,
+       type,
+       rejections,
+       timestamp,
+       raw,
+       log,
+       release_id,
+       client,
+       filter
+FROM release_action_status;
+
+DROP TABLE release_action_status;
+
+ALTER TABLE release_action_status_dg_tmp
+    RENAME TO release_action_status;
+
+CREATE INDEX release_action_status_filter_id_index
+    ON release_action_status (filter_id);
+
+CREATE INDEX release_action_status_release_id_index
+    ON release_action_status (release_id);
+
+CREATE INDEX release_action_status_status_index
+    ON release_action_status (status);
+
+UPDATE release_action_status
+SET filter_id = (SELECT f.id
+FROM filter f WHERE f.name = release_action_status.filter);
 	`,
 }

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -98,6 +98,7 @@ type ReleaseActionStatus struct {
 	Type       ActionType        `json:"type"`
 	Client     string            `json:"client"`
 	Filter     string            `json:"filter"`
+	FilterID   int64             `json:"-"`
 	Rejections []string          `json:"rejections"`
 	Timestamp  time.Time         `json:"timestamp"`
 	ReleaseID  int64             `json:"-"`


### PR DESCRIPTION
## What

This should finally fix the core issue of the filter Max Downloads per Time issues.

However, it is still susceptible to race conditions when a lot of announces are being handled within less than seconds between them due to the handling of announces, filters, and actions.

## Why

Announces are processed in parallel and the filter checks for a single announce is done sequentially and so are actions on that particular filter. The status `PUSH_APPROVED|PUSH_REJECTED|PUSH_ERROR` is only set at the end of the `RunAction` function. It will therefore wait on re-announce to complete which might take up to 30 seconds sometimes.

If another announce is being handled in that same time it will not see that something else is processing at the same time.

One solution to this could be to add a new status like `PUSH_PENDING` or `PUSH_PROCESSING` which is set before the action runs it's checks, and then afterwards set the Approved or Rejected status. Then in the function that checks the downloads per filter it can include that status in the check.

Fixes #643 #546 