### PR TITLE
fix(feeds): RSS improve torrent size parsing

### DIFF
--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -185,7 +185,7 @@ func NewRelease(indexer string) *Release {
 		Implementation: ReleaseImplementationIRC,
 		Timestamp:      time.Now(),
 		Tags:           []string{},
-		Size:		0,
+		Size:           0,
 	}
 
 	return r
@@ -273,7 +273,7 @@ func (r *Release) ParseReleaseTagsString(tags string) {
 	}
 }
 
-// If there are parsing errors, then it keeps the original (or default size 0)
+// ParseSizeBytesString If there are parsing errors, then it keeps the original (or default size 0)
 // Otherwise, it will update the size only if the new size is bigger than the previous one.
 func (r *Release) ParseSizeBytesString(size string) {
 	s, err := humanize.ParseBytes(size)

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -185,6 +185,7 @@ func NewRelease(indexer string) *Release {
 		Implementation: ReleaseImplementationIRC,
 		Timestamp:      time.Now(),
 		Tags:           []string{},
+		Size:		0,
 	}
 
 	return r
@@ -272,13 +273,13 @@ func (r *Release) ParseReleaseTagsString(tags string) {
 	}
 }
 
+// If there are parsing errors, then it keeps the original (or default size 0)
+// Otherwise, it will update the size only if the new size is bigger than the previous one.
 func (r *Release) ParseSizeBytesString(size string) {
 	s, err := humanize.ParseBytes(size)
-	if err != nil {
-		// log could not parse into bytes
-		r.Size = 0
+	if err == nil && s > r.Size {
+		r.Size = s
 	}
-	r.Size = s
 }
 
 func (r *Release) DownloadTorrentFileCtx(ctx context.Context) error {

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -154,11 +154,11 @@ func (j *RSSJob) processItem(item *gofeed.Item) *domain.Release {
 		rls.Uploader += v.Name
 	}
 
-	if rls.Size == 0 {
-		// parse size bytes string
-		if sz, ok := item.Custom["size"]; ok {
-			rls.ParseSizeBytesString(sz)
-		}
+	// Enclosure->length can be 0, a fixed size (see next additional parsing required), or the actual torrent size.
+	// Therefore when Custom->Size is defined it should be picked as the size. Otherwise we use Enclosure->Length
+	// This solves the issue of torrent size parsing of trackers like Lat-Team
+	if size, ok := item.Custom["size"]; ok {
+		rls.ParseSizeBytesString(size)
 	}
 
 	// additional size parsing

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -155,9 +155,8 @@ func (j *RSSJob) processItem(item *gofeed.Item) *domain.Release {
 		rls.Uploader += v.Name
 	}
 
-	// Enclosure->length can be 0, a fixed size (see next additional parsing required), or the actual torrent size.
-	// Therefore when Custom->Size is defined it should be picked as the size. Otherwise we use Enclosure->Length
-	// This solves the issue of torrent size parsing of trackers like Lat-Team
+	
+	// When custom->size and enclosures->size differ, pick the largest one.
 	if size, ok := item.Custom["size"]; ok {
 		s, err := humanize.ParseBytes(size)
 		if err != nil && s > rls.Size {

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -113,7 +113,7 @@ func (j *RSSJob) processItem(item *gofeed.Item) *domain.Release {
 		if e.Type == "application/x-bittorrent" && e.URL != "" {
 			rls.TorrentURL = e.URL
 		}
-		if e.Length != "" {
+		if e.Length != "" && e.Length != "39399" {
 			rls.ParseSizeBytesString(e.Length)
 		}
 	}
@@ -154,7 +154,6 @@ func (j *RSSJob) processItem(item *gofeed.Item) *domain.Release {
 		rls.Uploader += v.Name
 	}
 
-	
 	// When custom->size and enclosures->size differ, `ParseSizeBytesString` will pick the largest one.
 	if size, ok := item.Custom["size"]; ok {
 		rls.ParseSizeBytesString(size)

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -12,6 +12,7 @@ import (
 	"github.com/autobrr/autobrr/internal/release"
 	"github.com/autobrr/autobrr/pkg/errors"
 
+	"github.com/dustin/go-humanize"
 	"github.com/mmcdole/gofeed"
 	"github.com/rs/zerolog"
 )
@@ -158,7 +159,10 @@ func (j *RSSJob) processItem(item *gofeed.Item) *domain.Release {
 	// Therefore when Custom->Size is defined it should be picked as the size. Otherwise we use Enclosure->Length
 	// This solves the issue of torrent size parsing of trackers like Lat-Team
 	if size, ok := item.Custom["size"]; ok {
-		rls.ParseSizeBytesString(size)
+		s, err := humanize.ParseBytes(size)
+		if err != nil && s > rls.Size {
+			rls.Size = s
+		}
 	}
 
 	// additional size parsing

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -12,7 +12,6 @@ import (
 	"github.com/autobrr/autobrr/internal/release"
 	"github.com/autobrr/autobrr/pkg/errors"
 
-	"github.com/dustin/go-humanize"
 	"github.com/mmcdole/gofeed"
 	"github.com/rs/zerolog"
 )
@@ -156,12 +155,9 @@ func (j *RSSJob) processItem(item *gofeed.Item) *domain.Release {
 	}
 
 	
-	// When custom->size and enclosures->size differ, pick the largest one.
+	// When custom->size and enclosures->size differ, `ParseSizeBytesString` will pick the largest one.
 	if size, ok := item.Custom["size"]; ok {
-		s, err := humanize.ParseBytes(size)
-		if err != nil && s > rls.Size {
-			rls.Size = s
-		}
+		rls.ParseSizeBytesString(size)
 	}
 
 	// additional size parsing


### PR DESCRIPTION
When some RSS feeds have `Enclosure->Length` fixed size, autobrr fails to retrieve the size that's included in `Custom->Size`.

The previous logic used `custom->size` when `enclosure->length` was 0. But as stated in a previous issue, this `enclosure->length` can be a fixed length unrelated to the torrent. Therefore this value can be 0, fixed length, or the real one.

This modification will pick `custom->size` whenever is defined and it's bigger than `enclosures->length`.

https://github.com/autobrr/autobrr/issues/636