### PR TITLE
feat(filters): Double Upload

### DIFF
--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -190,6 +190,7 @@ func (r *FilterRepo) FindByID(ctx context.Context, filterID int) (*domain.Filter
 			"scene",
 			"freeleech",
 			"freeleech_percent",
+			"double_upload",
 			"smart_episode",
 			"shows",
 			"seasons",
@@ -249,10 +250,10 @@ func (r *FilterRepo) FindByID(ctx context.Context, filterID int) (*domain.Filter
 
 	var f domain.Filter
 	var minSize, maxSize, maxDownloadsUnit, matchReleases, exceptReleases, matchReleaseGroups, exceptReleaseGroups, matchReleaseTags, exceptReleaseTags, freeleechPercent, shows, seasons, episodes, years, artists, albums, matchCategories, exceptCategories, matchUploaders, exceptUploaders, tags, exceptTags, extScriptCmd, extScriptArgs, extWebhookHost, extWebhookData sql.NullString
-	var useRegex, scene, freeleech, hasLog, hasCue, perfectFlac, extScriptEnabled, extWebhookEnabled sql.NullBool
+	var useRegex, scene, doubleUpload, freeleech, hasLog, hasCue, perfectFlac, extScriptEnabled, extWebhookEnabled sql.NullBool
 	var delay, maxDownloads, logScore, extWebhookStatus, extScriptStatus sql.NullInt32
 
-	if err := row.Scan(&f.ID, &f.Enabled, &f.Name, &minSize, &maxSize, &delay, &f.Priority, &maxDownloads, &maxDownloadsUnit, &matchReleases, &exceptReleases, &useRegex, &matchReleaseGroups, &exceptReleaseGroups, &matchReleaseTags, &exceptReleaseTags, &f.UseRegexReleaseTags, &scene, &freeleech, &freeleechPercent, &f.SmartEpisode, &shows, &seasons, &episodes, pq.Array(&f.Resolutions), pq.Array(&f.Codecs), pq.Array(&f.Sources), pq.Array(&f.Containers), pq.Array(&f.MatchHDR), pq.Array(&f.ExceptHDR), pq.Array(&f.MatchOther), pq.Array(&f.ExceptOther), &years, &artists, &albums, pq.Array(&f.MatchReleaseTypes), pq.Array(&f.Formats), pq.Array(&f.Quality), pq.Array(&f.Media), &logScore, &hasLog, &hasCue, &perfectFlac, &matchCategories, &exceptCategories, &matchUploaders, &exceptUploaders, pq.Array(&f.MatchLanguage), pq.Array(&f.ExceptLanguage), &tags, &exceptTags, pq.Array(&f.Origins), pq.Array(&f.ExceptOrigins), &extScriptEnabled, &extScriptCmd, &extScriptArgs, &extScriptStatus, &extWebhookEnabled, &extWebhookHost, &extWebhookData, &extWebhookStatus, &f.CreatedAt, &f.UpdatedAt); err != nil {
+	if err := row.Scan(&f.ID, &f.Enabled, &f.Name, &minSize, &maxSize, &delay, &f.Priority, &maxDownloads, &maxDownloadsUnit, &matchReleases, &exceptReleases, &useRegex, &matchReleaseGroups, &exceptReleaseGroups, &matchReleaseTags, &exceptReleaseTags, &f.UseRegexReleaseTags, &scene, &freeleech, &freeleechPercent, &doubleUpload, &f.SmartEpisode, &shows, &seasons, &episodes, pq.Array(&f.Resolutions), pq.Array(&f.Codecs), pq.Array(&f.Sources), pq.Array(&f.Containers), pq.Array(&f.MatchHDR), pq.Array(&f.ExceptHDR), pq.Array(&f.MatchOther), pq.Array(&f.ExceptOther), &years, &artists, &albums, pq.Array(&f.MatchReleaseTypes), pq.Array(&f.Formats), pq.Array(&f.Quality), pq.Array(&f.Media), &logScore, &hasLog, &hasCue, &perfectFlac, &matchCategories, &exceptCategories, &matchUploaders, &exceptUploaders, pq.Array(&f.MatchLanguage), pq.Array(&f.ExceptLanguage), &tags, &exceptTags, pq.Array(&f.Origins), pq.Array(&f.ExceptOrigins), &extScriptEnabled, &extScriptCmd, &extScriptArgs, &extScriptStatus, &extWebhookEnabled, &extWebhookHost, &extWebhookData, &extWebhookStatus, &f.CreatedAt, &f.UpdatedAt); err != nil {
 		return nil, errors.Wrap(err, "error scanning row")
 	}
 
@@ -287,6 +288,7 @@ func (r *FilterRepo) FindByID(ctx context.Context, filterID int) (*domain.Filter
 	f.UseRegex = useRegex.Bool
 	f.Scene = scene.Bool
 	f.Freeleech = freeleech.Bool
+	f.DoubleUpload = doubleUpload.Bool
 
 	f.ExternalScriptEnabled = extScriptEnabled.Bool
 	f.ExternalScriptCmd = extScriptCmd.String
@@ -353,6 +355,7 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, tx *Tx, indexe
 			"f.scene",
 			"f.freeleech",
 			"f.freeleech_percent",
+			"f.double_upload",
 			"f.smart_episode",
 			"f.shows",
 			"f.seasons",
@@ -422,10 +425,10 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, tx *Tx, indexe
 		var f domain.Filter
 
 		var minSize, maxSize, maxDownloadsUnit, matchReleases, exceptReleases, matchReleaseGroups, exceptReleaseGroups, matchReleaseTags, exceptReleaseTags, freeleechPercent, shows, seasons, episodes, years, artists, albums, matchCategories, exceptCategories, matchUploaders, exceptUploaders, tags, exceptTags, extScriptCmd, extScriptArgs, extWebhookHost, extWebhookData sql.NullString
-		var useRegex, scene, freeleech, hasLog, hasCue, perfectFlac, extScriptEnabled, extWebhookEnabled sql.NullBool
+		var doubleUpload, useRegex, scene, freeleech, hasLog, hasCue, perfectFlac, extScriptEnabled, extWebhookEnabled sql.NullBool
 		var delay, maxDownloads, logScore, extWebhookStatus, extScriptStatus sql.NullInt32
 
-		if err := rows.Scan(&f.ID, &f.Enabled, &f.Name, &minSize, &maxSize, &delay, &f.Priority, &maxDownloads, &maxDownloadsUnit, &matchReleases, &exceptReleases, &useRegex, &matchReleaseGroups, &exceptReleaseGroups, &matchReleaseTags, &exceptReleaseTags, &f.UseRegexReleaseTags, &scene, &freeleech, &freeleechPercent, &f.SmartEpisode, &shows, &seasons, &episodes, pq.Array(&f.Resolutions), pq.Array(&f.Codecs), pq.Array(&f.Sources), pq.Array(&f.Containers), pq.Array(&f.MatchHDR), pq.Array(&f.ExceptHDR), pq.Array(&f.MatchOther), pq.Array(&f.ExceptOther), &years, &artists, &albums, pq.Array(&f.MatchReleaseTypes), pq.Array(&f.Formats), pq.Array(&f.Quality), pq.Array(&f.Media), &logScore, &hasLog, &hasCue, &perfectFlac, &matchCategories, &exceptCategories, &matchUploaders, &exceptUploaders, pq.Array(&f.MatchLanguage), pq.Array(&f.ExceptLanguage), &tags, &exceptTags, pq.Array(&f.Origins), pq.Array(&f.ExceptOrigins), &extScriptEnabled, &extScriptCmd, &extScriptArgs, &extScriptStatus, &extWebhookEnabled, &extWebhookHost, &extWebhookData, &extWebhookStatus, &f.CreatedAt, &f.UpdatedAt); err != nil {
+		if err := rows.Scan(&f.ID, &f.Enabled, &f.Name, &minSize, &maxSize, &delay, &f.Priority, &maxDownloads, &maxDownloadsUnit, &matchReleases, &exceptReleases, &useRegex, &matchReleaseGroups, &exceptReleaseGroups, &matchReleaseTags, &exceptReleaseTags, &f.UseRegexReleaseTags, &scene, &freeleech, &freeleechPercent, &doubleUpload, &f.SmartEpisode, &shows, &seasons, &episodes, pq.Array(&f.Resolutions), pq.Array(&f.Codecs), pq.Array(&f.Sources), pq.Array(&f.Containers), pq.Array(&f.MatchHDR), pq.Array(&f.ExceptHDR), pq.Array(&f.MatchOther), pq.Array(&f.ExceptOther), &years, &artists, &albums, pq.Array(&f.MatchReleaseTypes), pq.Array(&f.Formats), pq.Array(&f.Quality), pq.Array(&f.Media), &logScore, &hasLog, &hasCue, &perfectFlac, &matchCategories, &exceptCategories, &matchUploaders, &exceptUploaders, pq.Array(&f.MatchLanguage), pq.Array(&f.ExceptLanguage), &tags, &exceptTags, pq.Array(&f.Origins), pq.Array(&f.ExceptOrigins), &extScriptEnabled, &extScriptCmd, &extScriptArgs, &extScriptStatus, &extWebhookEnabled, &extWebhookHost, &extWebhookData, &extWebhookStatus, &f.CreatedAt, &f.UpdatedAt); err != nil {
 			return nil, errors.Wrap(err, "error scanning row")
 		}
 
@@ -460,6 +463,7 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, tx *Tx, indexe
 		f.UseRegex = useRegex.Bool
 		f.Scene = scene.Bool
 		f.Freeleech = freeleech.Bool
+		f.DoubleUpload = doubleUpload.Bool
 
 		f.ExternalScriptEnabled = extScriptEnabled.Bool
 		f.ExternalScriptCmd = extScriptCmd.String
@@ -500,6 +504,7 @@ func (r *FilterRepo) Store(ctx context.Context, filter domain.Filter) (*domain.F
 			"scene",
 			"freeleech",
 			"freeleech_percent",
+			"double_upload",
 			"smart_episode",
 			"shows",
 			"seasons",
@@ -562,6 +567,7 @@ func (r *FilterRepo) Store(ctx context.Context, filter domain.Filter) (*domain.F
 			filter.Scene,
 			filter.Freeleech,
 			filter.FreeleechPercent,
+			filter.DoubleUpload,
 			filter.SmartEpisode,
 			filter.Shows,
 			filter.Seasons,
@@ -643,6 +649,7 @@ func (r *FilterRepo) Update(ctx context.Context, filter domain.Filter) (*domain.
 		Set("scene", filter.Scene).
 		Set("freeleech", filter.Freeleech).
 		Set("freeleech_percent", filter.FreeleechPercent).
+		Set("double_upload", filter.DoubleUpload).
 		Set("smart_episode", filter.SmartEpisode).
 		Set("shows", filter.Shows).
 		Set("seasons", filter.Seasons).
@@ -761,6 +768,9 @@ func (r *FilterRepo) UpdatePartial(ctx context.Context, filter domain.FilterUpda
 	}
 	if filter.FreeleechPercent != nil {
 		q = q.Set("freeleech_percent", filter.FreeleechPercent)
+	}
+	if filter.DoubleUpload != nil {
+		q = q.Set("double_upload", filter.DoubleUpload)
 	}
 	if filter.SmartEpisode != nil {
 		q = q.Set("smart_episode", filter.SmartEpisode)

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -83,7 +83,7 @@ CREATE TABLE filter
     scene                          BOOLEAN,
     freeleech                      BOOLEAN,
     freeleech_percent              TEXT,
-	double_upload                  BOOLEAN,
+    double_upload                  BOOLEAN,
     smart_episode                  BOOLEAN DEFAULT FALSE,
     shows                          TEXT,
     seasons                        TEXT,
@@ -237,7 +237,7 @@ CREATE TABLE "release"
     tags              TEXT []   DEFAULT '{}' NOT NULL,
     freeleech         BOOLEAN,
     freeleech_percent INTEGER,
-	double_upload     BOOLEAN,
+    double_upload     BOOLEAN,
     uploader          TEXT,
 	pre_time          TEXT,
     filter_id         INTEGER
@@ -453,8 +453,8 @@ var postgresMigrations = []string{
 	ALTER TABLE release
 		DROP COLUMN freeleech_percent;
 
-	ALTER TABLE release
-		DROP COLUMN double_upload;
+    ALTER TABLE release
+        DROP COLUMN double_upload;
 
 	ALTER TABLE "filter"
 		ADD COLUMN origins TEXT []   DEFAULT '{}';

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -83,6 +83,7 @@ CREATE TABLE filter
     scene                          BOOLEAN,
     freeleech                      BOOLEAN,
     freeleech_percent              TEXT,
+	double_upload                  BOOLEAN,
     smart_episode                  BOOLEAN DEFAULT FALSE,
     shows                          TEXT,
     seasons                        TEXT,
@@ -236,6 +237,7 @@ CREATE TABLE "release"
     tags              TEXT []   DEFAULT '{}' NOT NULL,
     freeleech         BOOLEAN,
     freeleech_percent INTEGER,
+	double_upload     BOOLEAN,
     uploader          TEXT,
 	pre_time          TEXT,
     filter_id         INTEGER
@@ -450,6 +452,9 @@ var postgresMigrations = []string{
 
 	ALTER TABLE release
 		DROP COLUMN freeleech_percent;
+
+	ALTER TABLE release
+		DROP COLUMN double_upload;
 
 	ALTER TABLE "filter"
 		ADD COLUMN origins TEXT []   DEFAULT '{}';

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -69,6 +69,7 @@ CREATE TABLE filter
     min_size                       TEXT,
     max_size                       TEXT,
     delay                          INTEGER,
+    double_upload                  BOOLEAN,
     priority                       INTEGER   DEFAULT 0 NOT NULL,
     max_downloads                  INTEGER   DEFAULT 0,
     max_downloads_unit             TEXT,
@@ -384,6 +385,7 @@ var sqliteMigrations = []string{
 		tags              TEXT []   DEFAULT '{}' NOT NULL,
 		freeleech         BOOLEAN,
 		freeleech_percent INTEGER,
+        double_upload     BOOLEAN,
 		uploader          TEXT,
 		pre_time          TEXT
 	);
@@ -708,6 +710,9 @@ ALTER TABLE release_action_status_dg_tmp
 
 	ALTER TABLE "release"
 		DROP COLUMN freeleech_percent;
+
+    ALTER TABLE "release"
+	    DROP COLUMN double_upload;
 
 	ALTER TABLE "filter"
 		ADD COLUMN origins TEXT []   DEFAULT '{}';

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -385,7 +385,7 @@ var sqliteMigrations = []string{
 		tags              TEXT []   DEFAULT '{}' NOT NULL,
 		freeleech         BOOLEAN,
 		freeleech_percent INTEGER,
-        double_upload     BOOLEAN,
+		double_upload     BOOLEAN,
 		uploader          TEXT,
 		pre_time          TEXT
 	);

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -67,6 +67,7 @@ type Filter struct {
 	MinSize                     string                 `json:"min_size,omitempty"`
 	MaxSize                     string                 `json:"max_size,omitempty"`
 	Delay                       int                    `json:"delay,omitempty"`
+	DoubleUpload                bool                   `json:"double_upload,omitempty"`
 	Priority                    int32                  `json:"priority"`
 	MaxDownloads                int                    `json:"max_downloads,omitempty"`
 	MaxDownloadsUnit            FilterMaxDownloadsUnit `json:"max_downloads_unit,omitempty"`
@@ -140,6 +141,7 @@ type FilterUpdate struct {
 	MaxSize                     *string                 `json:"max_size,omitempty"`
 	Delay                       *int                    `json:"delay,omitempty"`
 	Priority                    *int32                  `json:"priority,omitempty"`
+	DoubleUpload                *bool                   `json:"double_upload,omitempty"`
 	MaxDownloads                *int                    `json:"max_downloads,omitempty"`
 	MaxDownloadsUnit            *FilterMaxDownloadsUnit `json:"max_downloads_unit,omitempty"`
 	MatchReleases               *string                 `json:"match_releases,omitempty"`
@@ -222,6 +224,10 @@ func (f Filter) CheckFilter(r *Release) ([]string, bool) {
 
 	if f.FreeleechPercent != "" && !checkFreeleechPercent(r.FreeleechPercent, f.FreeleechPercent) {
 		r.addRejectionF("freeleech percent not matching. got: %v want: %v", r.FreeleechPercent, f.FreeleechPercent)
+	}
+
+	if f.DoubleUpload && r.DoubleUpload != f.DoubleUpload {
+		r.addRejection("wanted: double upload")
 	}
 
 	if len(f.Origins) > 0 && !containsSlice(r.Origin, f.Origins) {

--- a/internal/domain/filter_test.go
+++ b/internal/domain/filter_test.go
@@ -1700,6 +1700,7 @@ func TestFilter_CheckFilter1(t *testing.T) {
 				ExceptOrigins:       tt.fields.ExceptOrigins,
 				Freeleech:           tt.fields.Freeleech,
 				FreeleechPercent:    tt.fields.FreeleechPercent,
+				DoubleUpload:        tt.fields.DoubleUpload,
 				Shows:               tt.fields.Shows,
 				Seasons:             tt.fields.Seasons,
 				Episodes:            tt.fields.Episodes,

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -80,6 +80,7 @@ type Release struct {
 	ReleaseTags                 string                `json:"-"`
 	Freeleech                   bool                  `json:"-"`
 	FreeleechPercent            int                   `json:"-"`
+	DoubleUpload                bool                  `json:"-"`
 	Bonus                       []string              `json:"-"`
 	Uploader                    string                `json:"uploader"`
 	PreTime                     string                `json:"pre_time"`
@@ -423,6 +424,10 @@ func (r *Release) MapVars(def *IndexerDefinition, varMap map[string]string) erro
 
 	if category, err := getStringMapValue(varMap, "category"); err == nil {
 		r.Category = category
+	}
+
+	if doubleUpload, err := getStringMapValue(varMap, "doubleUpload"); err == nil {
+		r.DoubleUpload = StringEqualFoldMulti(doubleUpload, "true", "yes")
 	}
 
 	if freeleech, err := getStringMapValue(varMap, "freeleech"); err == nil {

--- a/internal/indexer/definitions/aither.yaml
+++ b/internal/indexer/definitions/aither.yaml
@@ -55,7 +55,7 @@ irc:
           - resolution
           - freeleechPercent
           - internal
-          - tags
+          - doubleUpload
           - torrentSize
           - uploader
           - baseUrl

--- a/internal/indexer/definitions/skipthecommericals.yaml
+++ b/internal/indexer/definitions/skipthecommericals.yaml
@@ -58,7 +58,7 @@ irc:
           - releaseTags
           - torrentName
           - freeleechPercent
-          - tags
+          - doubleUpload
           - torrentSize
           - uploader
           - baseUrl

--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -542,12 +542,15 @@ export function Advanced({ values }: AdvancedProps) {
         </div>
       </CollapsableSection>
 
-      <CollapsableSection defaultOpen={true} title="Freeleech" subtitle="Match only freeleech, freeleech percent and double upload.">
+      <CollapsableSection defaultOpen={true} title="Freeleech" subtitle="Match only freeleech and freeleech percent.">
         <div className="col-span-6">
           <SwitchGroup name="freeleech" label="Freeleech" />
         </div>
 
         <TextField name="freeleech_percent" label="Freeleech percent" columns={6} placeholder="eg. 50,75-100" />
+      </CollapsableSection>
+
+      <CollapsableSection defaultOpen={true} title="Double Upload" subtitle="Match torrents with double upload only.">
         <div className="col-span-6">
           <SwitchGroup name="double_upload" label="Double upload" />
         </div>

--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -268,6 +268,7 @@ export default function FilterDetails() {
                 except_uploaders: filter.except_uploaders,
                 match_language: filter.match_language || [],
                 except_language: filter.except_language || [],
+                double_upload: filter.double_upload,
                 freeleech: filter.freeleech,
                 freeleech_percent: filter.freeleech_percent,
                 formats: filter.formats || [],
@@ -541,12 +542,16 @@ export function Advanced({ values }: AdvancedProps) {
         </div>
       </CollapsableSection>
 
-      <CollapsableSection defaultOpen={true} title="Freeleech" subtitle="Match only freeleech and freeleech percent.">
+      <CollapsableSection defaultOpen={true} title="Freeleech" subtitle="Match only freeleech, freeleech percent and double upload.">
         <div className="col-span-6">
           <SwitchGroup name="freeleech" label="Freeleech" />
         </div>
 
         <TextField name="freeleech_percent" label="Freeleech percent" columns={6} placeholder="eg. 50,75-100" />
+        <div className="col-span-6">
+          <SwitchGroup name="double_upload" label="Double upload" />
+        </div>
+
       </CollapsableSection>
     </div>
   );

--- a/web/src/types/Filter.d.ts
+++ b/web/src/types/Filter.d.ts
@@ -23,6 +23,7 @@ interface Filter {
   except_origins: string[];
   freeleech: boolean;
   freeleech_percent: string;
+  double_upload: boolean;
   shows: string;
   seasons: string;
   episodes: string;


### PR DESCRIPTION
### Add check for double upload

As of right now, Aither and Skipthecomericals announce double upload. There are a lot of indexers with RSS/Torznab support that has this as well.

Tested fine with mockindexer, waiting for real world examples to be announced with Aither. Will update this when that is confirmed working.