### PR TITLE
enhancement(web): disable freeleech percent field if freeleech is enabled

### DIFF
--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -546,7 +546,7 @@ export function Advanced({ values }: AdvancedProps) {
           <SwitchGroup name="freeleech" label="Freeleech" />
         </div>
 
-        <TextField name="freeleech_percent" label="Freeleech percent" columns={6} placeholder="eg. 50,75-100" />
+        <TextField name="freeleech_percent" label="Freeleech percent" columns={6} placeholder="eg. 50,75-100" disabled={values.freeleech}/>
       </CollapsableSection>
     </div>
   );


### PR DESCRIPTION
This should hopefully help avoid confusion on the users part since toggling the switch locks freeleech percent to 100. Seen it happen a few times where they enter 50-100 and then toggles the switch.