### PR TITLE
fix(releases): check for duplicate tags

### DIFF
--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -233,8 +233,29 @@ func (r *Release) ParseReleaseTagsString(tags string) {
 
 	t := ParseReleaseTagString(cleanTags)
 
+	f := func(target *[]string, source []string) {
+		toappend := make([]string, 0, len(source))
+		for _, t := range *target {
+			found := false
+			t = rls.MustNormalize(t)
+
+			for _, s := range source {
+				if len(s) == 0 || rls.MustNormalize(s) == t {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				toappend = append(toappend, t)
+			}
+		}
+
+		*target = append(*target, toappend...)
+	}
+
 	if len(t.Audio) > 0 {
-		r.Audio = append(r.Audio, t.Audio...)
+		f(&r.Audio, t.Audio)
 	}
 	if len(t.Bonus) > 0 {
 		if sliceContainsSlice([]string{"Freeleech"}, t.Bonus) {
@@ -245,10 +266,10 @@ func (r *Release) ParseReleaseTagsString(tags string) {
 		r.Bonus = append(r.Bonus, t.Bonus...)
 	}
 	if len(t.Codec) > 0 {
-		r.Codec = append(r.Codec, t.Codec)
+		f(&r.Codec, append(make([]string, 0, 1), t.Codec))
 	}
 	if len(t.Other) > 0 {
-		r.Other = append(r.Other, t.Other...)
+		f(&r.Other, t.Other)
 	}
 	if r.Origin == "" && t.Origin != "" {
 		r.Origin = t.Origin

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -237,10 +237,10 @@ func (r *Release) ParseReleaseTagsString(tags string) {
 		toappend := make([]string, 0, len(source))
 		for _, t := range *target {
 			found := false
-			t = rls.MustNormalize(t)
+			norm := rls.MustNormalize(t)
 
 			for _, s := range source {
-				if len(s) == 0 || rls.MustNormalize(s) == t {
+				if rls.MustNormalize(s) == norm {
 					found = true
 					break
 				}


### PR DESCRIPTION
Presently Audio, Codec, and Other can contain duplicate information if it's present in the announced tags. This results in a not great situation where we're not only storing duplicate information, but filtering on it as well.