### PR TITLE
enhancement(database): improve log messages

### DIFF
--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -51,15 +51,16 @@ func (db *DB) migratePostgres() error {
 	var version int
 	err = tx.QueryRow(`SELECT version FROM schema_migrations`).Scan(&version)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return errors.Wrap(err, "no rows")
+		return errors.Wrap(err, "failed to query schema version")
 	}
 
 	if version == len(postgresMigrations) {
 		return nil
+	} else if version > len(postgresMigrations) {
+		return errors.New("autobrr (version %d) older than schema (version: %d)", len(postgresMigrations), version)
 	}
-	if version > len(postgresMigrations) {
-		return errors.New("old")
-	}
+
+	db.log.Info().Msgf("Beginning database schema upgrade from version %v to version: %v", version, len(postgresMigrations))
 
 	if version == 0 {
 		if _, err := tx.Exec(postgresSchema); err != nil {
@@ -67,6 +68,7 @@ func (db *DB) migratePostgres() error {
 		}
 	} else {
 		for i := version; i < len(postgresMigrations); i++ {
+			db.log.Info().Msgf("Upgrading Database schema to version: %v", i)
 			if _, err := tx.Exec(postgresMigrations[i]); err != nil {
 				return errors.Wrap(err, "failed to execute migration #%v", i)
 			}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -65,6 +65,8 @@ func (db *DB) migrateSQLite() error {
 		return errors.New("autobrr (version %d) older than schema (version: %d)", len(sqliteMigrations), version)
 	}
 
+	db.log.Info().Msgf("Beginning database schema upgrade from version %v to version: %v", version, len(sqliteMigrations))
+
 	tx, err := db.handler.Begin()
 	if err != nil {
 		return err
@@ -77,6 +79,7 @@ func (db *DB) migrateSQLite() error {
 		}
 	} else {
 		for i := version; i < len(sqliteMigrations); i++ {
+			db.log.Info().Msgf("Upgrading Database schema to version: %v", i)
 			if _, err := tx.Exec(sqliteMigrations[i]); err != nil {
 				return errors.Wrap(err, "failed to execute migration #%v", i)
 			}


### PR DESCRIPTION
Presently when a schema migration happens, nothing is printed until the migration completes (the application has no output until then). This is ok for a computer, however humans can get quite anxious seeing an application appear to hang for seconds, to minutes, to tens of minutes on startup. These printouts are in an effort to help reduce that anxious moment, and let the end-user know that the application is doing good work for them.