### PR TITLE
fix(indexers): SkipTheTrailers identifier

### DIFF
--- a/internal/indexer/definitions/skipthetrailers.yaml
+++ b/internal/indexer/definitions/skipthetrailers.yaml
@@ -1,7 +1,7 @@
 ---
 #id: skipthetrailers
 name: SkipTheTrailers
-identifier: stc
+identifier: stt
 description: SkipTheTrailers (STT) is a Private Torrent Tracker for Movies
 language: en-us
 urls:


### PR DESCRIPTION
Fix clashing identifier of stt to not use stc.