### PR TITLE
fix(indexers): TorrentBytes broken tracker use non-SSL link

### DIFF
--- a/internal/indexer/definitions/torrentbytes.yaml
+++ b/internal/indexer/definitions/torrentbytes.yaml
@@ -68,7 +68,7 @@ irc:
 
     match:
       infourl: "/details.php?id={{ .torrentId }}"
-      torrenturl: "/download.php?id={{ .torrentId }}&SSL=1&name={{ .torrentName }}.torrent"
+      torrenturl: "/download.php?id={{ .torrentId }}&name={{ .torrentName }}.torrent"
       cookie: true
       encode:
         - torrentName


### PR DESCRIPTION
TorrentBytes tracker have broken SSL so until they fix it lets change to download of .torrent with just http trackers.