### PR TITLE
enhancement(web): reduce tooltip icon contrast

### DIFF
--- a/web/src/components/tooltips/CustomTooltip.tsx
+++ b/web/src/components/tooltips/CustomTooltip.tsx
@@ -18,7 +18,7 @@ export const CustomTooltip = ({
   const id = `${anchorId}-tooltip`;
   return (
     <div className="flex items-center">
-      <svg id={id} className="ml-1 w-4 h-4" viewBox="0 0 72 72"><path d="M32 2C15.432 2 2 15.432 2 32s13.432 30 30 30s30-13.432 30-30S48.568 2 32 2m5 49.75H27v-24h10v24m-5-29.5a5 5 0 1 1 0-10a5 5 0 0 1 0 10" fill="currentcolor"/></svg>
+      <svg id={id} className="ml-1 w-4 h-4 text-gray-500 dark:text-gray-400 fill-current" viewBox="0 0 72 72"><path d="M32 2C15.432 2 2 15.432 2 32s13.432 30 30 30s30-13.432 30-30S48.568 2 32 2m5 49.75H27v-24h10v24m-5-29.5a5 5 0 1 1 0-10a5 5 0 0 1 0 10"/></svg>
       <Tooltip style= {{ maxWidth: "350px", fontSize: "12px", textTransform: "none", fontWeight: "normal", borderRadius: "0.375rem", backgroundColor: "#34343A", color: "#fff", opacity: "1" }} delayShow={100} delayHide={150} place={place} anchorId={id} data-html={true} clickable={clickable}>
         {children}
       </Tooltip>

--- a/web/src/domain/routes.tsx
+++ b/web/src/domain/routes.tsx
@@ -19,7 +19,7 @@ import {
   LogSettings,
   NotificationSettings,
   ReleaseSettings
-} from "../screens/settings";
+} from "../screens/settings/";
 import { RegexPlayground } from "../screens/settings/RegexPlayground";
 
 import { baseUrl } from "../utils";

--- a/web/src/screens/Base.tsx
+++ b/web/src/screens/Base.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { Link, NavLink, Outlet } from "react-router-dom";
 import { Disclosure, Menu, Transition } from "@headlessui/react";
-import { BookOpenIcon, UserIcon } from "@heroicons/react/24/solid";
+import { ArrowTopRightOnSquareIcon, UserIcon } from "@heroicons/react/24/solid";
 import { Bars3Icon, XMarkIcon, MegaphoneIcon } from "@heroicons/react/24/outline";
 
 import { AuthContext } from "../utils/Context";
@@ -96,7 +96,7 @@ export default function Base() {
                           )}
                         >
                           Docs
-                          <BookOpenIcon
+                          <ArrowTopRightOnSquareIcon
                             className="inline ml-1 h-5 w-5"
                             aria-hidden="true"
                           />

--- a/web/src/screens/auth/login.tsx
+++ b/web/src/screens/auth/login.tsx
@@ -87,7 +87,7 @@ export const Login = () => {
               </button>
               <div>
                 <p className="flex float-right items-center mt-3 text-xs font-bold text-gray-700 dark:text-gray-200 uppercase tracking-wide cursor-pointer" id="forgot">
-                  Forgot?<svg className="ml-1 w-3 h-3" viewBox="0 0 72 72"><path d="M32 2C15.432 2 2 15.432 2 32s13.432 30 30 30s30-13.432 30-30S48.568 2 32 2m5 49.75H27v-24h10v24m-5-29.5a5 5 0 1 1 0-10a5 5 0 0 1 0 10" fill="white"/></svg>
+                  Forgot?<svg className="ml-1 w-3 h-3 text-gray-500 dark:text-gray-400 fill-current" viewBox="0 0 72 72"><path d="M32 2C15.432 2 2 15.432 2 32s13.432 30 30 30s30-13.432 30-30S48.568 2 32 2m5 49.75H27v-24h10v24m-5-29.5a5 5 0 1 1 0-10a5 5 0 0 1 0 10"/></svg>
                   <Tooltip style={{ maxWidth: "350px", fontSize: "12px", textTransform: "none", fontWeight: "normal", borderRadius: "0.375rem", backgroundColor: "#34343A", color: "#fff", opacity: "1" }} place="bottom" delayShow={100} delayHide={150} anchorId="forgot" html="<p style='padding-top: 2px'>If you forget your password you can reset it via the terminal: <code>autobrrctl --config /home/username/.config/autobrr change-password <USERNAME></code></p>" clickable={true}/>
                 </p>
               </div>

--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -545,7 +545,7 @@ export function Advanced({ values }: AdvancedProps) {
 
       <CollapsableSection defaultOpen={true} title="Freeleech" subtitle="Match only freeleech and freeleech percent.">
         <div className="col-span-6">
-          <SwitchGroup name="freeleech" label="Freeleech" description="Enabling freeleech locks freeleech percent to 100. Use either." tooltip={<div><p>Comma separated list of uploaders to ignore (takes priority over Match releases).</p><a href='https://autobrr.com/filters#advanced' className='text-blue-400 visited:text-blue-400' target='_blank'>https://autobrr.com/filters#advanced</a></div>} />
+          <SwitchGroup name="freeleech" label="Freeleech" description="Enabling freeleech locks freeleech percent to 100. Use either." tooltip={<div><p>Not all indexers announce freeleech on IRC. Check with your indexer before enabling freeleech filtering.</p></div>} />
         </div>
 
         <TextField name="freeleech_percent" label="Freeleech percent" columns={6} placeholder="eg. 50,75-100" disabled={values.freeleech}/>


### PR DESCRIPTION
Ref proposals in #707 

- Reduced contrast on the tooltip icon. It should now be identical to description and subtitle texts in both dark mode and light mode.
- Reverted the Docs icon to the old one
- Fixed Freeleech tooltip text

Proposed change:

<img width="580" alt="image" src="https://user-images.githubusercontent.com/18177310/218300966-5c45dcc8-c527-466f-add3-849b5df09eff.png">
<img width="580" alt="image" src="https://user-images.githubusercontent.com/18177310/218300969-87040c34-f3db-400b-a698-774206654390.png">