### PR TITLE
fix(web): fixed baseurl for log downloads

### DIFF
--- a/web/src/screens/Logs.tsx
+++ b/web/src/screens/Logs.tsx
@@ -232,7 +232,7 @@ const LogFilesItem = ({ file }: LogFilesItemProps) => {
               "font-medium group flex rounded-md items-center px-2 py-2 text-sm"
             )}
             title="Download file"
-            to={`${baseUrl()}api/logs/files/${file.filename}`}
+            to={`/api/logs/files/${file.filename}`}
             target="_blank"
             download={true}
           >


### PR DESCRIPTION
Right now you can't download logs if you're on a subfolder reverse proxy setup. It only works on `/`.
Reason: the Link component does not require `${baseUrl()}`.

<img width="367" alt="image" src="https://user-images.githubusercontent.com/18177310/218547162-3a67d1f3-2f44-40ff-bb3a-e7a98fb03268.png">