### PR TITLE
fix(web): reverted freeleech lock mechanism

### DIFF
--- a/web/src/screens/filters/details.tsx
+++ b/web/src/screens/filters/details.tsx
@@ -548,7 +548,7 @@ export function Advanced({ values }: AdvancedProps) {
           <SwitchGroup name="freeleech" label="Freeleech" description="Enabling freeleech locks freeleech percent to 100. Use either." tooltip={<div><p>Not all indexers announce freeleech on IRC. Check with your indexer before enabling freeleech filtering.</p></div>} />
         </div>
 
-        <TextField name="freeleech_percent" label="Freeleech percent" columns={6} placeholder="eg. 50,75-100" disabled={values.freeleech}/>
+        <TextField name="freeleech_percent" label="Freeleech percent" columns={6} placeholder="eg. 50,75-100" />
       </CollapsableSection>
     </div>
   );


### PR DESCRIPTION
Reverted locking mechanism for the Freeleech toggle as it doesn't set `freeleechPercent` to 100 when doing so.