### PR TITLE
chore(deps): update Go to 1.20

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@ node_modules/
 config.toml
 .goreleaser.yml
 Dockerfile
-Dockerfile.ci
+ci.Dockerfile
 docker-compose.yml
 README.md
 bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: ./Dockerfile.ci
+          file: ./ci.Dockerfile
           platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
           push: ${{ github.repository_owner == 'autobrr' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,11 @@ jobs:
           name: web-build
           path: web/build
 
+#     1.20 is the last version to support Windows < 10, Server < 2016, and MacOS < 1.15.
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.2'
+          go-version: '1.20.1'
           cache: true
 
       - name: Run GoReleaser build
@@ -96,10 +97,11 @@ jobs:
           name: web-build
           path: web/build
 
+#     1.20 is the last version to support Windows < 10, Server < 2016, and MacOS < 1.15.
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.2'
+          go-version: '1.20.1'
           cache: true
 
       - name: Run GoReleaser build and publish tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY web .
 RUN yarn build
 
 # build app
-FROM golang:1.19-alpine3.16 AS app-builder
+FROM golang:1.20-alpine3.16 AS app-builder
 
 ARG VERSION=dev
 ARG REVISION=dev

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM golang:1.19-alpine3.16 AS app-builder
+FROM golang:1.20-alpine3.16 AS app-builder
 
 ARG VERSION=dev
 ARG REVISION=dev

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/autobrr
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2


### PR DESCRIPTION
https://go.dev/blog/go1.20

`
The new function [errors.Join](https://go.dev/pkg/errors#Join) returns an error wrapping a list of errors which may be obtained again if the error type implements the Unwrap() []error method.
`

`When [building a Go release from source](https://go.dev/doc/install/source), Go 1.20 requires a Go 1.17.13 or newer release. In the future, we plan to move the bootstrap toolchain forward approximately once a year. Also, starting with Go 1.21, some older operating systems will no longer be supported: this includes Windows 7, 8, Server 2008 and Server 2012, macOS 10.13 High Sierra, and 10.14 Mojave. On the other hand, Go 1.20 adds experimental support for FreeBSD on RISC-V.`
