### PR TITLE
feat(macros): add sprig functions to macros

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/autobrr/autobrr/pkg/errors"
+
+	"github.com/Masterminds/sprig/v3"
 )
 
 type Macro struct {
@@ -70,7 +72,7 @@ func (m Macro) Parse(text string) (string, error) {
 	}
 
 	// setup template
-	tmpl, err := template.New("macro").Parse(text)
+	tmpl, err := template.New("macro").Funcs(sprig.TxtFuncMap()).Parse(text)
 	if err != nil {
 		return "", errors.Wrap(err, "could parse macro template")
 	}
@@ -91,7 +93,7 @@ func (m Macro) MustParse(text string) string {
 	}
 
 	// setup template
-	tmpl, err := template.New("macro").Parse(text)
+	tmpl, err := template.New("macro").Funcs(sprig.TxtFuncMap()).Parse(text)
 	if err != nil {
 		return ""
 	}

--- a/internal/domain/macros_test.go
+++ b/internal/domain/macros_test.go
@@ -166,6 +166,24 @@ func TestMacros_Parse(t *testing.T) {
 			want:    "movies-2021",
 			wantErr: false,
 		},
+		{
+			name: "test_size_formating",
+			release: Release{
+				Size: 3834225472,
+			},
+			args:    args{text: "{{printf \"%.2f GB\" (divf .Size 1073741824)}}"},
+			want:    "3.57 GB",
+			wantErr: false,
+		},
+		{
+			name: "test_text_manipulation",
+			release: Release{
+				TorrentName: "Title Name 2 - Keyword [Blu-ray][MKV][h264 10-bit][1080p][FLAC 2.0][Dual Audio][Softsubs (Sub Group)][Freeleech]",
+			},
+			args:    args{text: "{{join \"\" (regexSplit \"^.+- Keyword \" .TorrentName -1)}}"},
+			want:    "[Blu-ray][MKV][h264 10-bit][1080p][FLAC 2.0][Dual Audio][Softsubs (Sub Group)][Freeleech]",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Adds [sprig functions](http://masterminds.github.io/sprig/) to Macros.

Fixes #732 