### PR TITLE
fix(filters): match `dv hdr`

### DIFF
--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -326,12 +326,12 @@ func (f Filter) CheckFilter(r *Release) ([]string, bool) {
 	}
 
 	// HDR is parsed into the Codec slice from rls
-	if len(f.MatchHDR) > 0 && !sliceContainsSlice(r.HDR, f.MatchHDR) {
+	if len(f.MatchHDR) > 0 && !matchHDR(r.HDR, f.MatchHDR) {
 		r.addRejectionF("hdr not matching. got: %v want: %v", r.HDR, f.MatchHDR)
 	}
 
 	// HDR is parsed into the Codec slice from rls
-	if len(f.ExceptHDR) > 0 && sliceContainsSlice(r.HDR, f.ExceptHDR) {
+	if len(f.ExceptHDR) > 0 && matchHDR(r.HDR, f.ExceptHDR) {
 		r.addRejectionF("hdr unwanted. got: %v want: %v", r.HDR, f.ExceptHDR)
 	}
 
@@ -777,6 +777,48 @@ func checkFreeleechPercent(announcePercent int, filterPercent string) bool {
 
 		if int(filterPercentInt) == announcePercent {
 			return true
+		}
+	}
+
+	return false
+}
+
+func matchHDR(releaseValues []string, filterValues []string) bool {
+
+	for _, filter := range filterValues {
+		if filter == "" {
+			continue
+		}
+		filter = strings.ToLower(filter)
+		filter = strings.Trim(filter, " ")
+
+		parts := strings.Split(filter, " ")
+		if len(parts) == 2 {
+			partsMatched := 0
+			for _, part := range parts {
+				for _, tag := range releaseValues {
+					if tag == "" {
+						continue
+					}
+					tag = strings.ToLower(tag)
+					if tag == part {
+						partsMatched++
+					}
+					if len(parts) == partsMatched {
+						return true
+					}
+				}
+			}
+		} else {
+			for _, tag := range releaseValues {
+				if tag == "" {
+					continue
+				}
+				tag = strings.ToLower(tag)
+				if tag == filter {
+					return true
+				}
+			}
 		}
 	}
 

--- a/internal/domain/filter_test.go
+++ b/internal/domain/filter_test.go
@@ -932,6 +932,47 @@ func TestFilter_CheckFilter(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "match_hdr_9",
+			fields: &Release{
+				TorrentName: "Good show shift S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HDR HEVC-GROUP",
+			},
+			args: args{
+				filter: Filter{
+					Enabled:  true,
+					MatchHDR: []string{"DV HDR"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "match_hdr_10",
+			fields: &Release{
+				TorrentName: "Good show shift S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HDR10 HEVC-GROUP",
+			},
+			args: args{
+				filter: Filter{
+					Enabled:  true,
+					MatchHDR: []string{"DV HDR"},
+				},
+				rejections: []string{"hdr not matching. got: [DV HDR10] want: [DV HDR]"},
+			},
+			want: false,
+		},
+		{
+			name: "match_hdr_11",
+			fields: &Release{
+				TorrentName: "Good show shift S02 2160p ATVP WEB-DL DDP 5.1 Atmos HDR10 HEVC-GROUP",
+			},
+			args: args{
+				filter: Filter{
+					Enabled:  true,
+					MatchHDR: []string{"DV", "HDR"},
+				},
+				rejections: []string{"hdr not matching. got: [HDR10] want: [DV HDR]"},
+			},
+			want: false,
+		},
+		{
 			name: "match_music_1",
 			fields: &Release{
 				TorrentName: "Artist - Albumname FLAC CD",


### PR DESCRIPTION
An update in the `rls` parsing library broke the previous implementation.

The matching for HDR now checks if there's a space in the filter, like `dv hdr` and then does extra checks to make sure all parts exists in the release.