### PR TITLE
fix(indexers): ncore irc server change

### DIFF
--- a/internal/indexer/definitions/ncore.yaml
+++ b/internal/indexer/definitions/ncore.yaml
@@ -19,8 +19,8 @@ settings:
     help: "Check a torrent download link. key='value' is your passkey."
 
 irc:
-  network: nCore
-  server: irc.ncore.pro
+  network: P2P-Network
+  server: irc.p2p-network.net
   port: 6697
   tls: true
   channels:
@@ -46,12 +46,12 @@ irc:
       label: NickServ Password
       help: NickServ password
 
-    - name: invite_command
-      type: secret
-      default: "NBOT !invite IRCKEY"
-      required: true
-      label: Invite command
-      help: Invite auth with the key from https://ncore.pro/irc.php. Replace IRCKEY
+    #- name: invite_command
+    #  type: secret
+    #  default: "NBOT !invite IRCKEY"
+    #  required: true
+    #  label: Invite command
+    #  help: Invite auth with the key from https://ncore.pro/irc.php. Replace IRCKEY
 
   parse:
     type: single


### PR DESCRIPTION
nCore IRC has moved to `irc.p2p-network.net`, and their announce channel no longer requires an invitation. This was reported by qmayer in #dev-general yesterday, and I have confirmed it through TheLounge.

I left the invite part commented out instead of removing it, as it is uncertain whether they will re-implement it at some point.