### PR TITLE
fix(autobrrctl): use brr-api instead of github directly for version check

### DIFF
--- a/cmd/autobrrctl/main.go
+++ b/cmd/autobrrctl/main.go
@@ -56,15 +56,25 @@ func main() {
 
 		// get the latest release tag from brr-api
 		resp, err := http.Get(fmt.Sprintf("https://api.autobrr.com/repos/%s/%s/releases/latest", owner, repo))
-		if err == nil && resp.StatusCode == http.StatusOK {
-			defer resp.Body.Close()
-			var rel struct {
-				TagName string `json:"tag_name"`
-			}
-			if err := json.NewDecoder(resp.Body).Decode(&rel); err == nil {
-				fmt.Fprintf(flag.CommandLine.Output(), "Latest release: %v\n", rel.TagName)
-			}
+		if err != nil {
+			fmt.Fprintf(flag.CommandLine.Output(), "Failed to fetch latest release from api: %v\n", err)
+			return
 		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusNotFound {
+			fmt.Fprintf(flag.CommandLine.Output(), "No release found for %s/%s\n", owner, repo)
+			return
+		}
+
+		var rel struct {
+			TagName string `json:"tag_name"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+			fmt.Fprintf(flag.CommandLine.Output(), "Failed to decode response from api: %v\n", err)
+			return
+		}
+		fmt.Fprintf(flag.CommandLine.Output(), "Latest release: %v\n", rel.TagName)
 
 	case "create-user":
 

--- a/cmd/autobrrctl/main.go
+++ b/cmd/autobrrctl/main.go
@@ -54,7 +54,7 @@ func main() {
 	case "version":
 		fmt.Fprintf(flag.CommandLine.Output(), "Version: %v\nCommit: %v\nBuild: %v\n", version, commit, date)
 
-		// get the latest release tag from Github
+		// get the latest release tag from brr-api
 		resp, err := http.Get(fmt.Sprintf("https://api.autobrr.com/repos/%s/%s/releases/latest", owner, repo))
 		if err == nil && resp.StatusCode == http.StatusOK {
 			defer resp.Body.Close()

--- a/cmd/autobrrctl/main.go
+++ b/cmd/autobrrctl/main.go
@@ -52,18 +52,18 @@ func main() {
 
 	switch cmd := flag.Arg(0); cmd {
 	case "version":
-		fmt.Fprintf(flag.CommandLine.Output(), "Version: %v\nCommit: %v\nBuild: %v\n", version, commit, date)
+		fmt.Printf("Version: %v\nCommit: %v\nBuild: %v\n", version, commit, date)
 
 		// get the latest release tag from brr-api
 		resp, err := http.Get(fmt.Sprintf("https://api.autobrr.com/repos/%s/%s/releases/latest", owner, repo))
 		if err != nil {
-			fmt.Fprintf(flag.CommandLine.Output(), "Failed to fetch latest release from api: %v\n", err)
+			fmt.Printf("Failed to fetch latest release from api: %v\n", err)
 			return
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusNotFound {
-			fmt.Fprintf(flag.CommandLine.Output(), "No release found for %s/%s\n", owner, repo)
+			fmt.Printf("No release found for %s/%s\n", owner, repo)
 			return
 		}
 
@@ -71,10 +71,10 @@ func main() {
 			TagName string `json:"tag_name"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
-			fmt.Fprintf(flag.CommandLine.Output(), "Failed to decode response from api: %v\n", err)
+			fmt.Printf("Failed to decode response from api: %v\n", err)
 			return
 		}
-		fmt.Fprintf(flag.CommandLine.Output(), "Latest release: %v\n", rel.TagName)
+		fmt.Printf("Latest release: %v\n", rel.TagName)
 
 	case "create-user":
 

--- a/cmd/autobrrctl/main.go
+++ b/cmd/autobrrctl/main.go
@@ -55,7 +55,7 @@ func main() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Version: %v\nCommit: %v\nBuild: %v\n", version, commit, date)
 
 		// get the latest release tag from Github
-		resp, err := http.Get(fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo))
+		resp, err := http.Get(fmt.Sprintf("https://api.autobrr.com/repos/%s/%s/releases/latest", owner, repo))
 		if err == nil && resp.StatusCode == http.StatusOK {
 			defer resp.Body.Close()
 			var rel struct {


### PR DESCRIPTION
`autobrrctl version` is contacting Github directly right now. Using brr-api makes more sense.

Added some error handling after recommendations from Kyle.