### PR TITLE
feat(web): preserve sort order on Filters list

### DIFF
--- a/web/src/screens/filters/list.tsx
+++ b/web/src/screens/filters/list.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, FC, Fragment, MouseEventHandler, useReducer, useRef, useState } from "react";
+import { Dispatch, FC, Fragment, MouseEventHandler, useReducer, useRef, useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "react-hot-toast";
 import { Listbox, Menu, Switch, Transition } from "@headlessui/react";
@@ -122,15 +122,30 @@ function filteredData(data: Filter[], status: string) {
   };
 }
 
+function getStoredSortOrder() {
+  return localStorage.getItem("sortOrder") || "default";
+}
+
+function setStoredSortOrder(sortOrder: string) {
+  localStorage.setItem("sortOrder", sortOrder);
+}
+
 function FilterList({ toggleCreateFilter }: any) {
   const [{ indexerFilter, sortOrder, status }, dispatchFilter] =
-    useReducer(FilterListReducer, initialState);
+    useReducer(FilterListReducer, {
+      ...initialState,
+      sortOrder: getStoredSortOrder()
+    });
 
   const { error, data } = useQuery(
     ["filters", indexerFilter, sortOrder],
     () => APIClient.filters.find(indexerFilter, sortOrder),
     { refetchOnWindowFocus: false }
   );
+
+  useEffect(() => {
+    setStoredSortOrder(sortOrder);
+  }, [sortOrder]);
 
   if (error) {
     return (<p>An error has occurred: </p>);

--- a/web/src/screens/filters/list.tsx
+++ b/web/src/screens/filters/list.tsx
@@ -4,6 +4,8 @@ import { toast } from "react-hot-toast";
 import { Listbox, Menu, Switch, Transition } from "@headlessui/react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 
+import { FilterListContext, FilterListState } from "../../utils/Context";
+
 import {
   ArrowsRightLeftIcon,
   CheckIcon,
@@ -22,18 +24,6 @@ import { APIClient } from "../../api/APIClient";
 import Toast from "../../components/notifications/Toast";
 import { EmptyListState } from "../../components/emptystates";
 import { DeleteModal } from "../../components/modals";
-
-type FilterListState = {
-  indexerFilter: string[],
-  sortOrder: string;
-  status: string;
-};
-
-const initialState: FilterListState = {
-  indexerFilter: [],
-  sortOrder: "",
-  status: ""
-};
 
 enum ActionType {
   INDEXER_FILTER_CHANGE = "INDEXER_FILTER_CHANGE",
@@ -122,20 +112,13 @@ function filteredData(data: Filter[], status: string) {
   };
 }
 
-function getStoredSortOrder() {
-  return localStorage.getItem("sortOrder") || "default";
-}
-
-function setStoredSortOrder(sortOrder: string) {
-  localStorage.setItem("sortOrder", sortOrder);
-}
-
 function FilterList({ toggleCreateFilter }: any) {
-  const [{ indexerFilter, sortOrder, status }, dispatchFilter] =
-    useReducer(FilterListReducer, {
-      ...initialState,
-      sortOrder: getStoredSortOrder()
-    });
+  const filterListState = FilterListContext.useValue();
+
+  const [{ indexerFilter, sortOrder, status }, dispatchFilter] = useReducer(
+    FilterListReducer,
+    filterListState
+  );
 
   const { error, data } = useQuery(
     ["filters", indexerFilter, sortOrder],
@@ -144,11 +127,11 @@ function FilterList({ toggleCreateFilter }: any) {
   );
 
   useEffect(() => {
-    setStoredSortOrder(sortOrder);
-  }, [sortOrder]);
+    FilterListContext.set({ indexerFilter, sortOrder, status });
+  }, [indexerFilter, sortOrder, status]);
 
   if (error) {
-    return (<p>An error has occurred: </p>);
+    return <p>An error has occurred:</p>;
   }
 
   const filtered = filteredData(data ?? [], status);

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -19,8 +19,11 @@ export const InitializeGlobalContext = () => {
       )
     }));
   }
+  const filterList_ctx = localStorage.getItem("filterList");
+  if (filterList_ctx) {
+    FilterListContext.set(JSON.parse(filterList_ctx));
+  }
 };
-
 interface AuthInfo {
   username: string;
   isLoggedIn: boolean;
@@ -73,6 +76,30 @@ export const SettingsContext = newRidgeState<SettingsType>(
         localStorage.setItem("settings", JSON.stringify(new_state));
       } catch (e) {
         console.log("An error occurred while trying to modify the local settings context state.");
+        console.log("Error:", e);
+      }
+    }
+  }
+);
+
+export type FilterListState = {
+  indexerFilter: string[],
+  sortOrder: string;
+  status: string;
+};
+
+export const FilterListContext = newRidgeState<FilterListState>(
+  {
+    indexerFilter: [],
+    sortOrder: "",
+    status: ""
+  },
+  {
+    onSet: (new_state) => {
+      try {
+        localStorage.setItem("filterList", JSON.stringify(new_state));
+      } catch (e) {
+        console.log("An error occurred while trying to modify the local filter list context state.");
         console.log("Error:", e);
       }
     }


### PR DESCRIPTION
## Preserve sortOrder using localStorage on Filters page

Store the user's chosen sortOrder in the browser's localStorage to maintain their sorting preference even when the page is refreshed. Previously, the sortOrder would reset upon refreshing the Filters page.