### PR TITLE
feat(filters): navigate to edit page on filter creation

### DIFF
--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -112,7 +112,7 @@ export const APIClient = {
       return appClient.Get<Filter[]>(`api/filters${q}`);
     },
     getByID: (id: number) => appClient.Get<Filter>(`api/filters/${id}`),
-    create: (filter: Filter) => appClient.Post("api/filters", filter),
+    create: (filter: Filter) => appClient.Post<Filter>("api/filters", filter),
     update: (filter: Filter) => appClient.Put(`api/filters/${filter.id}`, filter),
     duplicate: (id: number) => appClient.Get<Filter>(`api/filters/${id}/duplicate`),
     toggleEnable: (id: number, enabled: boolean) => appClient.Put(`api/filters/${id}/enabled`, { enabled }),

--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -10,6 +10,7 @@ import { queryClient } from "../../App";
 import { APIClient } from "../../api/APIClient";
 import DEBUG from "../../components/debug";
 import Toast from "../../components/notifications/Toast";
+import { useNavigate } from "react-router-dom";
 
 interface filterAddFormProps {
     isOpen: boolean;
@@ -17,14 +18,18 @@ interface filterAddFormProps {
 }
 
 function FilterAddForm({ isOpen, toggle }: filterAddFormProps) {
+  const navigate = useNavigate();
   const mutation = useMutation(
     (filter: Filter) => APIClient.filters.create(filter),
     {
-      onSuccess: (_, filter) => {
+      onSuccess: (filter) => {
         queryClient.invalidateQueries("filters");
         toast.custom((t) => <Toast type="success" body={`Filter ${filter.name} was added`} t={t} />);
 
         toggle();
+        if (filter.id) {
+          navigate(filter.id.toString());
+        }
       }
     }
   );


### PR DESCRIPTION
i'm not certain if there is an explict reason for the current behavior, but personally I always want to edit a filter immediately after creation.

i can adjust the commit message if needed, i wasn't sure if this was a fix or a feature /shrug