### PR TITLE
feat(actions): add "don't start" option for rtorrent

### DIFF
--- a/internal/action/rtorrent.go
+++ b/internal/action/rtorrent.go
@@ -54,7 +54,14 @@ func (s *service) rtorrent(ctx context.Context, action *domain.Action, release d
 			}
 		}
 
-		if err := rt.Add(release.MagnetURI, args...); err != nil {
+		var addTorrentMagnet func(string, ...*rtorrent.FieldValue) error
+		if action.Paused {
+			addTorrentMagnet = rt.AddStopped
+		} else {
+			addTorrentMagnet = rt.Add
+		}
+
+		if err := addTorrentMagnet(release.MagnetURI, args...); err != nil {
 			return nil, errors.Wrap(err, "could not add torrent from magnet: %s", release.MagnetURI)
 		}
 
@@ -97,7 +104,14 @@ func (s *service) rtorrent(ctx context.Context, action *domain.Action, release d
 			}
 		}
 
-		if err := rt.AddTorrent(tmpFile, args...); err != nil {
+		var addTorrentFile func([]byte, ...*rtorrent.FieldValue) error
+		if action.Paused {
+			addTorrentFile = rt.AddTorrentStopped
+		} else {
+			addTorrentFile = rt.AddTorrent
+		}
+
+		if err := addTorrentFile(tmpFile, args...); err != nil {
 			return nil, errors.Wrap(err, "could not add torrent file: %s", release.TorrentTmpFile)
 		}
 

--- a/web/src/screens/filters/action.tsx
+++ b/web/src/screens/filters/action.tsx
@@ -400,6 +400,14 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
               />
             </div>
           </div>
+          <div className="col-span-12 sm:col-span-6">
+            <div className="col-span-6">
+              <SwitchGroup
+                name={`actions.${idx}.paused`}
+                label="Don't start download automatically"
+              />
+            </div>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
Someone in the discord asked for it* so here it is

*they said paused, but you can't do that on rtorrent from my understanding so i went with stopped

![image](https://user-images.githubusercontent.com/127705169/227143716-42eacb34-41df-4b43-b4d7-0662bde0f81f.png)

this matches the option in rutorrent's add dialog
![image](https://user-images.githubusercontent.com/127705169/227144002-3c17d851-574d-4145-a64c-1c96fb8759d7.png)


