### PR TITLE
enhancement(config): clarify logPath usage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,7 @@ port = 7474
 
 # autobrr logs file
 # If not defined, logs to stdout
+# Make sure to use forward slashes and include the filename with extension. eg: "log/autobrr.log", "C:/autobrr/log/autobrr.log"
 #
 # Optional
 #


### PR DESCRIPTION
Windows uses backslashes `\` which doesn't work instead they should use forwardslashes `/` for the logPath .
To help clarify this issue and assist users in understanding how to properly set the logPath I have added example and warning.