### PR TITLE
feat(filters): use TextArea for webhook data field

### DIFF
--- a/web/src/screens/filters/action.tsx
+++ b/web/src/screens/filters/action.tsx
@@ -15,6 +15,7 @@ import { CollapsableSection } from "./details";
 import { CustomTooltip } from "../../components/tooltips/CustomTooltip";
 import { Link } from "react-router-dom";
 import { useFormikContext } from "formik";
+import { TextArea } from "../../components/inputs/input";
 
 interface FilterActionsProps {
   filter: Filter;
@@ -183,10 +184,11 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
           columns={6}
           placeholder="Host eg. http://localhost/webhook"
         />
-        <TextField
+        <TextArea
           name={`actions.${idx}.webhook_data`}
           label="Data (json)"
           columns={6}
+          rows={5}
           placeholder={"Request data: { \"key\": \"value\" }"}
         />
       </div>


### PR DESCRIPTION
Switched to the TextArea component for the webhook data input field as it makes more sense than using TextField in this case.

![image](https://user-images.githubusercontent.com/18177310/227526166-c5cce732-cc18-40ec-b536-2c65d1f945bf.png)