### PR TITLE
feat(logs): webhook sanitization

### DIFF
--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -95,8 +95,8 @@ var (
 		repl    string
 	}{
 		{
-			pattern: regexp.MustCompile(`("password":")[\p{L}0-9!#%&*+/:;<=>?@^_` + "`" + `{|}~]+`),
-			repl:    "${1}REDACTED",
+			pattern: regexp.MustCompile(`("host\\":\\"|"password\\":\\"|"user\\":\\"|ExternalWebhookHost:)(\S+)(\\"|\sExternalWebhookData:)`),
+			repl:    "${1}REDACTED${3}",
 		},
 		{
 			pattern: regexp.MustCompile(`(torrent_pass|passkey|authkey|auth|secret_key|api|apikey)=([a-zA-Z0-9]+)`),

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -95,7 +95,7 @@ var (
 		repl    string
 	}{
 		{
-			pattern: regexp.MustCompile(`("host\\":\\"|"password\\":\\"|"user\\":\\"|ExternalWebhookHost:)(\S+)(\\"|\sExternalWebhookData:)`),
+			pattern: regexp.MustCompile(`("apikey\\":\s\\"|"host\\":\\"|"password\\":\\"|"user\\":\\"|ExternalWebhookHost:)(\S+)(\\"|\sExternalWebhookData:)`),
 			repl:    "${1}REDACTED${3}",
 		},
 		{

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -170,7 +170,7 @@ func SanitizeLogFile(filePath string, output io.Writer) error {
 			strings.Contains(line, `"module":"action"`)
 
 		for i := 0; i < len(regexReplacements); i++ {
-			// Apply the first two patterns only if the line contains "module":"feed",
+			// Apply the first three patterns only if the line contains "module":"feed",
 			// "module":"filter", "repo":"release", or "module":"action"
 			if i < 3 {
 				if bFilter {

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -95,6 +95,10 @@ var (
 		repl    string
 	}{
 		{
+			pattern: regexp.MustCompile(`("password":")[\p{L}0-9!#%&*+/:;<=>?@^_` + "`" + `{|}~]+`),
+			repl:    "${1}REDACTED",
+		},
+		{
 			pattern: regexp.MustCompile(`(torrent_pass|passkey|authkey|auth|secret_key|api|apikey)=([a-zA-Z0-9]+)`),
 			repl:    "${1}=REDACTED",
 		},
@@ -168,7 +172,7 @@ func SanitizeLogFile(filePath string, output io.Writer) error {
 		for i := 0; i < len(regexReplacements); i++ {
 			// Apply the first two patterns only if the line contains "module":"feed",
 			// "module":"filter", "repo":"release", or "module":"action"
-			if i < 2 {
+			if i < 3 {
 				if bFilter {
 					line = regexReplacements[i].pattern.ReplaceAllString(line, regexReplacements[i].repl)
 				}

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -95,7 +95,7 @@ var (
 		repl    string
 	}{
 		{
-			pattern: regexp.MustCompile(`("apikey\\":\s\\"|"host\\":\\"|"password\\":\\"|"user\\":\\"|ExternalWebhookHost:)(\S+)(\\"|\sExternalWebhookData:)`),
+			pattern: regexp.MustCompile(`("apikey\\":\s?\\"|"host\\":\s?\\"|"password\\":\s?\\"|"user\\":\s?\\"|ExternalWebhookHost:)(\S+)(\\"|\sExternalWebhookData:)`),
 			repl:    "${1}REDACTED${3}",
 		},
 		{

--- a/internal/http/logs_sanitize_test.go
+++ b/internal/http/logs_sanitize_test.go
@@ -138,6 +138,11 @@ func TestSanitizeLogFile(t *testing.T) {
 			input:    "\"module\":\"irc\" PRIVMSG NickServ IDENTIFY zAPEJEA8ryYnpj3AiE3KJ",
 			expected: "\"module\":\"irc\" PRIVMSG NickServ IDENTIFY REDACTED",
 		},
+		{
+			name:     "json_passwords",
+			input:    "\"module\":\"action\" \"password\":\"p4s#sw0r!d",
+			expected: "\"module\":\"action\" \"password\":\"REDACTED",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/http/logs_sanitize_test.go
+++ b/internal/http/logs_sanitize_test.go
@@ -146,6 +146,10 @@ func TestSanitizeLogFile(t *testing.T) {
 			input:    "\"module\":\"action\" ExternalWebhookHost:http://127.0.0.1:6940/api/upgrade ExternalWebhookData:",
 			expected: "\"module\":\"action\" ExternalWebhookHost:REDACTED ExternalWebhookData:",
 		},
+		{
+			input:    "\"module\":\"filter\" \\\"id\\\": 3855,\\n  \\\"apikey\\\": \\\"ad789a9s8d.asdpoiasdpojads09sad809\\\",\\n  \\\"minratio\\\": 10.0\\n",
+			expected: "\"module\":\"filter\" \\\"id\\\": 3855,\\n  \\\"apikey\\\": \\\"REDACTED\\\",\\n  \\\"minratio\\\": 10.0\\n",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/http/logs_sanitize_test.go
+++ b/internal/http/logs_sanitize_test.go
@@ -139,9 +139,12 @@ func TestSanitizeLogFile(t *testing.T) {
 			expected: "\"module\":\"irc\" PRIVMSG NickServ IDENTIFY REDACTED",
 		},
 		{
-			name:     "json_passwords",
-			input:    "\"module\":\"action\" \"password\":\"p4s#sw0r!d",
-			expected: "\"module\":\"action\" \"password\":\"REDACTED",
+			input:    "\"module\":\"action\" \\\"host\\\":\\\"subdomain.domain.com:42069/subfolder\\\", \\n   \\\"user\\\":\\\"AUserName\\\", \\n   \\\"password\\\":\\\"p4ssw0!rd\\\", \\n",
+			expected: "\"module\":\"action\" \\\"host\\\":\\\"REDACTED\\\", \\n   \\\"user\\\":\\\"REDACTED\\\", \\n   \\\"password\\\":\\\"REDACTED\\\", \\n",
+		},
+		{
+			input:    "\"module\":\"action\" ExternalWebhookHost:http://127.0.0.1:6940/api/upgrade ExternalWebhookData:",
+			expected: "\"module\":\"action\" ExternalWebhookHost:REDACTED ExternalWebhookData:",
 		},
 	}
 


### PR DESCRIPTION
Closes #799 

This PR sanitizes the data from the `host`, `user` and `password` fields for `"level":"info","module":"action"` log entries when downloading the logs via the webinterface.
Additionally it also sanitizes the `ExternalWebhookHost` field.

Huge thank you to @s0up4200 for helping me get my troubles out of the way! 😄 