### PR TITLE
fix(web): numberfield changing while scrolling

### DIFF
--- a/web/src/components/inputs/input.tsx
+++ b/web/src/components/inputs/input.tsx
@@ -376,6 +376,12 @@ export const NumberField = ({
               }
               form.setFieldValue(field.name, parseInt(event.target.value)); // Convert the input value to an integer using parseInt() to ensure that the backend can properly parse the numberfield as an integer.
             }}
+            onWheel={(event) => {
+              if (event.currentTarget === document.activeElement) {
+                event.currentTarget.blur();
+                setTimeout(() => event.currentTarget.focus(), 0);
+              }
+            }}
           />
           {meta.touched && meta.error && (
             <div className="error">{meta.error}</div>

--- a/web/src/components/inputs/input_wide.tsx
+++ b/web/src/components/inputs/input_wide.tsx
@@ -187,6 +187,12 @@ export const NumberFieldWide = ({
                 : "focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 border-gray-300 dark:border-gray-700",
               "block w-full shadow-sm dark:bg-gray-800 sm:text-sm dark:text-white rounded-md"
             )}
+            onWheel={(event) => {
+              if (event.currentTarget === document.activeElement) {
+                event.currentTarget.blur();
+                setTimeout(() => event.currentTarget.focus(), 0);
+              }
+            }}
             placeholder={placeholder}
           />
         )}


### PR DESCRIPTION
This PR addresses the issue where number input fields were changing their values when using the scroll wheel. The desired behavior is to prevent the scroll wheel from changing the input values while still allowing the page to scroll if field is selected.

~~Currently only tested in Firefox.~~