### PR TITLE
fix(web): RegexField add padding

### DIFF
--- a/web/src/components/inputs/input.tsx
+++ b/web/src/components/inputs/input.tsx
@@ -158,6 +158,9 @@ export const RegexField = ({
                 disabled
                   ? "bg-gray-100 dark:bg-gray-700 cursor-not-allowed"
                   : "dark:bg-gray-800",
+                useRegex
+                  ? "pr-10"
+                  : "",
                 "mt-2 block w-full dark:text-gray-100 rounded-md"
               )}
               disabled={disabled}


### PR DESCRIPTION
Added a conditional pr-10 if useRegex=true to make the right side of the field remain visible when the icons are present.