### PR TITLE
feat(indexers): add Tokyo Toshokan

### DIFF
--- a/internal/indexer/definitions/tokyotoshokan.yaml
+++ b/internal/indexer/definitions/tokyotoshokan.yaml
@@ -1,0 +1,63 @@
+---
+#id: tokyotosho
+name: Tokyo Toshokan
+identifier: tokyotosho
+description: A BitTorrent Library for Japanese Media
+language: en-us
+urls:
+  - https://
+privacy: public
+protocol: torrent
+supports:
+  - irc
+
+irc:
+  network: Rizon
+  server: irc.rizon.net
+  port: 6697
+  tls: true
+  channels:
+    - "#tokyotosho"
+  announcers:
+    - "TokyoTosho"
+  settings:
+    - name: nick
+      type: text
+      required: true
+      label: Nick
+      help: Bot nick. Eg. user_bot
+
+    - name: auth.account
+      type: text
+      required: false
+      label: NickServ Account
+      help: NickServ account. Make sure to group your main user and bot.
+
+    - name: auth.password
+      type: secret
+      required: false
+      label: NickServ Password
+      help: NickServ password
+  parse:
+    type: multi
+    lines:
+      - test:
+          - "Release 1748839: [Anime] SOMETITLE-007"
+        pattern: '^Release [0-9]*: \[(.*?)\] (.*)'
+        vars:
+          - category
+          - torrentName
+      - test:
+          - "Torrent: https://example.com/torrents/sha123/torrentname-007.torrent"
+        pattern: '^Torrent: (https:\/\/)(.*\.torrent)'
+        vars:
+          - baseUrl
+          - torrentId
+      - test:
+          - "Size: 7.21GB | Comment: A comment on the torrent left by the author"
+        pattern: '^Size: (\d+.?\d*[KMGTP]?B)( \| Comment: (.*))?'
+        vars:
+          - size
+
+    match:
+      torrenturl: "{{ .torrentId }}"

--- a/internal/indexer/definitions/tokyotoshokan.yaml
+++ b/internal/indexer/definitions/tokyotoshokan.yaml
@@ -49,9 +49,8 @@ irc:
           - torrentName
       - test:
           - "Torrent: https://example.com/torrents/sha123/torrentname-007.torrent"
-        pattern: '^Torrent: (https:\/\/)(.*\.torrent)'
+        pattern: '^Torrent: https:\/\/(.*)'
         vars:
-          - baseUrl
           - torrentId
       - test:
           - "Size: 7.21GB | Comment: A comment on the torrent left by the author"


### PR DESCRIPTION
Add support for Tokyo Toshokan indexer.
Closes https://github.com/autobrr/autobrr/issues/501

The only caveat is that this definition uses their main `#tokyotosho` channel on IRC instead of the `#tokyotosho-api` channel as specified in the issue (https://github.com/autobrr/autobrr/issues/501). This is because of the way they delimit their messages and is therefore not possible to use at the moment, as described in this related issue: https://github.com/autobrr/autobrr/issues/817.