### PR TITLE
feat(macros): add TorrentID to list of supported macros

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -15,6 +15,7 @@ type Macro struct {
 	TorrentName         string
 	TorrentPathName     string
 	TorrentHash         string
+	TorrentID           string
 	TorrentUrl          string
 	TorrentDataRawBytes []byte
 	MagnetURI           string
@@ -45,6 +46,7 @@ func NewMacro(release Release) Macro {
 		TorrentPathName:     release.TorrentTmpFile,
 		TorrentDataRawBytes: release.TorrentDataRawBytes,
 		TorrentHash:         release.TorrentHash,
+		TorrentID:           release.TorrentID,
 		MagnetURI:           release.MagnetURI,
 		Indexer:             release.Indexer,
 		Title:               release.Title,


### PR DESCRIPTION
To be able to pass {{.TorrentID}} to an external webhook.
You need the TorrentID to fetch the name of the uploader on RED for example.

```json
{
  "id": "{{.TorrentID}}",
  "apikey": "ie960v12.08sf8098sdffsd098sd",
  "uploaders": "kyles,smarty"
}
