### PR TITLE
fix(notifications): test handle unsupported type

### DIFF
--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -240,13 +240,14 @@ func (s *service) Test(ctx context.Context, notification domain.Notification) er
 
 	g, _ := errgroup.WithContext(ctx)
 
+	if agent == nil {
+		s.log.Error().Msgf("unsupported notification type: %v", notification.Type)
+		return errors.New("unsupported notification type")
+	}
+
 	for _, event := range events {
 		e := event
 		g.Go(func() error {
-			if agent == nil {
-				s.log.Error().Msgf("unsupported notification type: %v", notification.Type)
-				return errors.New("unsupported notification type")
-			}
 			return agent.Send(e.Event, e)
 		})
 

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
+	"github.com/autobrr/autobrr/pkg/errors"
 
 	"github.com/rs/zerolog"
 )
@@ -237,11 +238,15 @@ func (s *service) Test(ctx context.Context, notification domain.Notification) er
 		agent = NewTelegramSender(s.log, notification)
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	g, _ := errgroup.WithContext(ctx)
 
 	for _, event := range events {
 		e := event
 		g.Go(func() error {
+			if agent == nil {
+				s.log.Error().Msgf("unsupported notification type: %v", notification.Type)
+				return errors.New("unsupported notification type")
+			}
 			return agent.Send(e.Event, e)
 		})
 

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -236,14 +236,12 @@ func (s *service) Test(ctx context.Context, notification domain.Notification) er
 		agent = NewNotifiarrSender(s.log, notification)
 	case domain.NotificationTypeTelegram:
 		agent = NewTelegramSender(s.log, notification)
-	}
-
-	g, _ := errgroup.WithContext(ctx)
-
-	if agent == nil {
+	default:
 		s.log.Error().Msgf("unsupported notification type: %v", notification.Type)
 		return errors.New("unsupported notification type")
 	}
+
+	g, _ := errgroup.WithContext(ctx)
 
 	for _, event := range events {
 		e := event


### PR DESCRIPTION
If the agent variable is nil (This can happen if the `notification.Type` doesn't match any of the cases in the switch statement.) the server will crash.

On the frontend  when user test the notification without providing the type it will crash. Maybe we need to change the frontend as well, to make sure that the test button is disabled unless all the required field is filled, but this change at least will prevent the server from crashing.