### PR TITLE
fix(indexers): TorrentNetwork settings crash

### DIFF
--- a/internal/indexer/definitions/torrentnetwork.yaml
+++ b/internal/indexer/definitions/torrentnetwork.yaml
@@ -8,7 +8,7 @@ urls:
   - https://tntracker.org/
 privacy: private
 protocol: torrent
-suppports:
+supports:
   - irc
   - rss
 source: unknown


### PR DESCRIPTION
Fixes #878 

There was a misspelling in the TorrentNetwork definition which caused an error due for not finding the field required.
Will pull this on prod and report back if the fix has been successful.