### PR TITLE
feat(feeds): add allow_empty to ignore empty feed caches

### DIFF
--- a/internal/database/feed.go
+++ b/internal/database/feed.go
@@ -37,6 +37,7 @@ func (r *FeedRepo) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
 			"f.interval",
 			"f.timeout",
 			"f.max_age",
+			"f.allow_empty",
 			"f.api_key",
 			"f.cookie",
 			"f.settings",
@@ -61,7 +62,7 @@ func (r *FeedRepo) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
 
 	var apiKey, cookie, settings sql.NullString
 
-	if err := row.Scan(&f.ID, &f.Indexer, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, &apiKey, &cookie, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
+	if err := row.Scan(&f.ID, &f.Indexer, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, &f.AllowEmpty, &apiKey, &cookie, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
 		return nil, errors.Wrap(err, "error scanning row")
 	}
 
@@ -92,6 +93,7 @@ func (r *FeedRepo) FindByIndexerIdentifier(ctx context.Context, indexer string) 
 			"f.interval",
 			"f.timeout",
 			"f.max_age",
+			"f.allow_empty",
 			"f.api_key",
 			"f.cookie",
 			"f.settings",
@@ -116,7 +118,7 @@ func (r *FeedRepo) FindByIndexerIdentifier(ctx context.Context, indexer string) 
 
 	var apiKey, cookie, settings sql.NullString
 
-	if err := row.Scan(&f.ID, &f.Indexer, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, &apiKey, &cookie, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
+	if err := row.Scan(&f.ID, &f.Indexer, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, &f.AllowEmpty, &apiKey, &cookie, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
 		return nil, errors.Wrap(err, "error scanning row")
 	}
 
@@ -145,6 +147,7 @@ func (r *FeedRepo) Find(ctx context.Context) ([]domain.Feed, error) {
 			"f.interval",
 			"f.timeout",
 			"f.max_age",
+			"f.allow_empty",
 			"f.api_key",
 			"f.cookie",
 			"f.last_run",
@@ -176,7 +179,7 @@ func (r *FeedRepo) Find(ctx context.Context) ([]domain.Feed, error) {
 		var apiKey, cookie, lastRunData, settings sql.NullString
 		var lastRun sql.NullTime
 
-		if err := rows.Scan(&f.ID, &f.Indexer, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, &apiKey, &cookie, &lastRun, &lastRunData, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
+		if err := rows.Scan(&f.ID, &f.Indexer, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, &f.AllowEmpty, &apiKey, &cookie, &lastRun, &lastRunData, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
 			return nil, errors.Wrap(err, "error scanning row")
 		}
 
@@ -289,6 +292,7 @@ func (r *FeedRepo) Update(ctx context.Context, feed *domain.Feed) error {
 		Set("interval", feed.Interval).
 		Set("timeout", feed.Timeout).
 		Set("max_age", feed.MaxAge).
+		Set("allow_empty", feed.AllowEmpty).
 		Set("api_key", feed.ApiKey).
 		Set("cookie", feed.Cookie).
 		Set("settings", settings).

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -671,4 +671,7 @@ ADD COLUMN download_url TEXT;
 	SET except_tags_match_logic = 'ANY'
 	WHERE except_tags IS NOT NULL;
 	`,
+	`ALTER TABLE feed
+			ADD COLUMN allow_empty BOOLEAN DEFAULT FALSE;
+	`,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -1064,4 +1064,7 @@ ADD COLUMN download_url TEXT;
     SET except_tags_match_logic = 'ANY'
     WHERE except_tags IS NOT NULL;
 	`,
+	`ALTER TABLE feed
+			ADD COLUMN allow_empty BOOLEAN DEFAULT FALSE;
+	`,
 }

--- a/internal/domain/feed.go
+++ b/internal/domain/feed.go
@@ -48,6 +48,7 @@ type Feed struct {
 	Indexerr     FeedIndexer       `json:"-"`
 	LastRun      time.Time         `json:"last_run"`
 	LastRunData  string            `json:"last_run_data"`
+	AllowEmpty   bool              `json:"allow_empty"`
 }
 
 type FeedSettingsJSON struct {

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -263,7 +263,7 @@ func (j *RSSJob) getFeed(ctx context.Context) (items []*gofeed.Item, err error) 
 
 		// first time we fetch the feed the cached bucket count will be 0
 		// only append to items if it's bigger than 0, so we get new items only
-		if bucketCount > 0 {
+		if bucketCount > 0 || j.Feed.AllowEmpty {
 			items = append(items, item)
 		}
 	}

--- a/web/src/forms/settings/FeedForms.tsx
+++ b/web/src/forms/settings/FeedForms.tsx
@@ -32,6 +32,7 @@ interface InitialValues {
   interval: number;
   timeout: number;
   max_age: number;
+  allow_empty: boolean;
   settings: FeedSettings;
 }
 
@@ -107,6 +108,7 @@ export function FeedUpdateForm({ isOpen, toggle, feed }: UpdateProps) {
     interval: feed.interval,
     timeout: feed.timeout,
     max_age: feed.max_age,
+    allow_empty: feed.allow_empty || false,
     settings: feed.settings
   };
 
@@ -239,6 +241,7 @@ function FormFieldsRSS() {
       <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban."/>
       <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh."/>
       <NumberFieldWide name="max_age" label="Max age" help="Seconds. Will not grab older than this value."/>
+      <SwitchGroupWide name="allow_empty" label="Allow Empty" description="Directly start interpreting the result"/>
 
       <PasswordFieldWide name="cookie" label="Cookie" help="Not commonly used" />
     </div>

--- a/web/src/types/Feed.d.ts
+++ b/web/src/types/Feed.d.ts
@@ -8,6 +8,7 @@ interface Feed {
   interval: number;
   timeout: number;
   max_age: number;
+  allow_empty: boolean;
   api_key: string;
   cookie: string;
   last_run: string;


### PR DESCRIPTION
This is required to allow people to fetch bookmark feeds that dont contain anything except their bookmarks