### PR TITLE
enhancement(web): specify error message when not choosing a client

### DIFF
--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -38,6 +38,10 @@ export async function HttpClient<T>(
           return Promise.reject(new Error("Not found"));
         }
 
+        if (JSON.stringify(await response.json()) === JSON.stringify({ message: "json: cannot unmarshal string into Go struct field Action.actions.client_id of type int32" })) {
+          return Promise.reject(new Error("Please select a client from the dropdown menu before saving."));
+        }
+
         return Promise.reject(new Error(await response.text()));
       }
 


### PR DESCRIPTION
Every now an then we get questions about following error message:
`{"message":"json: cannot unmarshal string into Go struct field Action.actions.client_id of type int32"}`
So i went ahead and caught the error to replace it with a understandable one:

![image](https://user-images.githubusercontent.com/35452459/235326032-44fa295c-051a-4712-980c-79b0869e18a9.png)