### PR TITLE
fix(downloadclients): remove from filter actions on delete

### DIFF
--- a/internal/database/download_client.go
+++ b/internal/database/download_client.go
@@ -254,6 +254,31 @@ func (r *DownloadClientRepo) Update(ctx context.Context, client domain.DownloadC
 }
 
 func (r *DownloadClientRepo) Delete(ctx context.Context, clientID int) error {
+	tx, err := r.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelWriteCommitted})
+	if err != nil {
+		return err
+	}
+
+	defer tx.Rollback()
+
+	if err := r.delete(ctx, tx, clientID); err != nil {
+		return errors.Wrap(err, "error deleting download client: %d", clientID)
+	}
+
+	if err := r.deleteClientFromAction(ctx, tx, clientID); err != nil {
+		return errors.Wrap(err, "error deleting download client: %d", clientID)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "error deleting download client: %d", clientID)
+	}
+
+	r.log.Info().Msgf("delete download client: %d", clientID)
+
+	return nil
+}
+
+func (r *DownloadClientRepo) delete(ctx context.Context, tx *Tx, clientID int) error {
 	queryBuilder := r.db.squirrel.
 		Delete("client").
 		Where(sq.Eq{"id": clientID})
@@ -263,7 +288,7 @@ func (r *DownloadClientRepo) Delete(ctx context.Context, clientID int) error {
 		return errors.Wrap(err, "error building query")
 	}
 
-	res, err := r.db.handler.ExecContext(ctx, query, args...)
+	res, err := tx.ExecContext(ctx, query, args...)
 	if err != nil {
 		return errors.Wrap(err, "error executing query")
 	}
@@ -276,7 +301,29 @@ func (r *DownloadClientRepo) Delete(ctx context.Context, clientID int) error {
 		return errors.New("no rows affected")
 	}
 
-	r.log.Info().Msgf("delete download client: %d", clientID)
+	r.log.Debug().Msgf("delete download client: %d", clientID)
+
+	return nil
+}
+
+func (r *DownloadClientRepo) deleteClientFromAction(ctx context.Context, tx *Tx, clientID int) error {
+	var err error
+
+	queryBuilder := r.db.squirrel.
+		Update("action").
+		Set("enabled", false).
+		Set("client_id", 0).
+		Where(sq.Eq{"client_id": clientID}).
+		Suffix("RETURNING filter_id").RunWith(tx)
+
+	// return values
+	var filterID int
+
+	if err = queryBuilder.QueryRowContext(ctx).Scan(&filterID); err != nil {
+		return errors.Wrap(err, "error executing query")
+	}
+
+	r.log.Debug().Msgf("deleting download client %d from action for filter %d", clientID, filterID)
 
 	return nil
 }

--- a/internal/domain/action.go
+++ b/internal/domain/action.go
@@ -49,7 +49,7 @@ type Action struct {
 	WebhookHeaders        []string            `json:"webhook_headers,omitempty"`
 	FilterID              int                 `json:"filter_id,omitempty"`
 	ClientID              int32               `json:"client_id,omitempty"`
-	Client                DownloadClient      `json:"client,omitempty"`
+	Client                *DownloadClient     `json:"client,omitempty"`
 }
 
 // ParseMacros parse all macros on action


### PR DESCRIPTION
Properly remove from filter actions on delete.

The best solution would have been to use SQL foreign key constraints, but that might have unintended consequences for users who have been running autobrr for a long time.

Fixes #856