### PR TITLE
fix(config): lxc container detection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,7 +107,13 @@ func writeConfig(configPath string, configFile string) error {
 			// docker creates a .dockerenv file at the root
 			// of the directory tree inside the container.
 			// if this file exists then the viewer is running
-			// from inside a container so return true
+			// from inside a docker container so return true
+			host = "0.0.0.0"
+		} else if _, err := os.Stat("/dev/.lxc-boot-id"); err == nil {
+			// lxc creates this file containing the uuid
+			// of the container in every boot.
+			// if this file exists then the viewer is running
+			// from inside a lxc container so return true
 			host = "0.0.0.0"
 		} else if pd, _ := os.Open("/proc/1/cgroup"); pd != nil {
 			defer pd.Close()


### PR DESCRIPTION
The current method to detect lxc and start the config file with host 0.0.0.0 does not work because linux kernel have moved to namespaces and also only root have permissions to access some proc files.

I have checked within all my containers and also with a friend that runs lxc on a different plataform, both of us have this file with same permissions 444.

I also have checked against [lxc source code](https://github.com/lxc/lxc/blob/master/src/lxc/conf.c#L4024).

I would assume its safe to assume this file should exists on every boot.