### PR TITLE
fix(actions): handle non download client actions

### DIFF
--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -97,21 +97,23 @@ func (s *service) RunAction(ctx context.Context, action *domain.Action, release 
 	}
 
 	payload := &domain.NotificationPayload{
-		Event:       domain.NotificationEventPushApproved,
-		ReleaseName: release.TorrentName,
-		Filter:      release.Filter.Name,
-		Indexer:     release.Indexer,
-		InfoHash:    release.TorrentHash,
-
+		Event:          domain.NotificationEventPushApproved,
+		ReleaseName:    release.TorrentName,
+		Filter:         release.Filter.Name,
+		Indexer:        release.Indexer,
+		InfoHash:       release.TorrentHash,
 		Size:           release.Size,
 		Status:         domain.ReleasePushStatusApproved,
 		Action:         action.Name,
 		ActionType:     action.Type,
-		ActionClient:   action.Client.Name,
 		Rejections:     []string{},
-		Protocol:       domain.ReleaseProtocolTorrent,
+		Protocol:       release.Protocol,
 		Implementation: release.Implementation,
 		Timestamp:      time.Now(),
+	}
+
+	if action.Client != nil {
+		payload.ActionClient = action.Client.Name
 	}
 
 	if err != nil {

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -109,18 +109,23 @@ type ReleaseActionStatus struct {
 }
 
 func NewReleaseActionStatus(action *Action, release *Release) *ReleaseActionStatus {
-	return &ReleaseActionStatus{
+	s := &ReleaseActionStatus{
 		ID:         0,
 		Status:     ReleasePushStatusPending,
 		Action:     action.Name,
 		Type:       action.Type,
-		Client:     action.Client.Name,
 		Filter:     release.Filter.Name,
 		FilterID:   int64(release.Filter.ID),
 		Rejections: []string{},
 		Timestamp:  time.Now(),
 		ReleaseID:  release.ID,
 	}
+
+	if action.Client != nil {
+		s.Client = action.Client.Name
+	}
+
+	return s
 }
 
 type DownloadTorrentFileResponse struct {


### PR DESCRIPTION
Fixes and error where non download client based actions would fail because of a recent change from a non nil value to action.Client now being nillable.