### PR TITLE
docs: update Saltbox link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ sudo box install autobrr
 
 ### Saltbox
 
-[Saltbox](https://saltbox.dev/) users can simply run:
+[Saltbox](https://docs.saltbox.dev/) users can simply run:
 
 ```
 sb install sandbox-autobrr


### PR DESCRIPTION
https://saltbox.dev/ gives 404, even https://github.com/saltyorg/Saltbox about section links to https://docs.saltbox.dev/