### PR TITLE
enhancement(filters): exclude `tags_match_logic` on export if default value

### DIFF
--- a/web/src/screens/filters/list.tsx
+++ b/web/src/screens/filters/list.tsx
@@ -391,14 +391,16 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
       delete completeFilter.external_webhook_expect_status;
   
       // Remove properties with default values from the exported filter to minimize the size of the JSON string
-      ["enabled", "priority", "smart_episode", "resolutions", "sources", "codecs", "containers"].forEach((key) => {
+      ["enabled", "priority", "smart_episode", "resolutions", "sources", "codecs", "containers", "tags_match_logic", "except_tags_match_logic"].forEach((key) => {
         const value = completeFilter[key as keyof CompleteFilterType];
         if (["enabled", "priority", "smart_episode"].includes(key) && (value === false || value === 0)) {
           delete completeFilter[key as keyof CompleteFilterType];
         } else if (["resolutions", "sources", "codecs", "containers"].includes(key) && Array.isArray(value) && value.length === 0) {
           delete completeFilter[key as keyof CompleteFilterType];
+        } else if (["tags_match_logic", "except_tags_match_logic"].includes(key) && value === "ANY") {
+          delete completeFilter[key as keyof CompleteFilterType];
         }
-      });      
+      });   
 
       // Create a JSON string from the filter data, including a name and version
       const json = JSON.stringify(


### PR DESCRIPTION
Exclude `tags_match_logic` and `except_tags_match_logic` on filter export if default values.

```ts
if (["tags_match_logic", "except_tags_match_logic"].includes(key) && value === "ANY") {
    delete completeFilter[key as keyof CompleteFilterType];
  }
```

**EDIT:** Further testing indicates that its only added to the export if the user has interacted with that field.
Like setting it to `all`, save, then setting it back to `any` again. 

I still think we should remove it if set to `any` as its the default anyway. There is no need to export default values.

But that explains why some exports has it while others don't.