### PR TITLE
feat(release): add torrent download link to release table

### DIFF
--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -198,5 +198,9 @@ export const APIClient = {
   updates: {
     check: () => appClient.Get("api/updates/check"),
     getLatestRelease: () => appClient.Get<GithubRelease | undefined>("api/updates/latest")
+  },
+  torrents: {
+    sendToClient: (torrentId: number) => appClient.Post(`api/torrents/${torrentId}/send`)
   }
+  
 };

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -198,5 +198,5 @@ export const APIClient = {
   updates: {
     check: () => appClient.Get("api/updates/check"),
     getLatestRelease: () => appClient.Get<GithubRelease | undefined>("api/updates/latest")
-  }  
+  }
 };

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -198,9 +198,5 @@ export const APIClient = {
   updates: {
     check: () => appClient.Get("api/updates/check"),
     getLatestRelease: () => appClient.Get<GithubRelease | undefined>("api/updates/latest")
-  },
-  torrents: {
-    sendToClient: (torrentId: number) => appClient.Post(`api/torrents/${torrentId}/send`)
-  }
-  
+  }  
 };

--- a/web/src/screens/releases/ReleaseTable.tsx
+++ b/web/src/screens/releases/ReleaseTable.tsx
@@ -21,7 +21,7 @@ import * as DataTable from "@components/data-table";
 
 import { IndexerSelectColumnFilter, PushStatusSelectColumnFilter, SearchColumnFilter } from "./Filters";
 import { classNames } from "@utils";
-import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import { ArrowTopRightOnSquareIcon, ArrowDownTrayIcon } from "@heroicons/react/24/outline";
 import { Tooltip } from "@components/tooltips/Tooltip";
 
 export const releaseKeys = {
@@ -101,16 +101,28 @@ export const ReleaseTable = () => {
                 {String(props.cell.value)}
               </span>
             </Tooltip>
-            {props.row.original.info_url && (
-              <a
-                rel="noopener noreferrer"
-                target="_blank"
-                href={props.row.original.info_url}
-                className="max-w-[90vw] mr-2"
-              >
-                <ArrowTopRightOnSquareIcon className="h-5 w-5 text-blue-400 hover:text-blue-500 dark:text-blue-500 dark:hover:text-blue-600" aria-hidden="true" />
-              </a>
-            )}
+            <div className="flex mr-0">
+              {props.row.original.download_url && (
+                <a
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  href={props.row.original.download_url}
+                  className="max-w-[90vw] px-2"
+                >
+                  <ArrowDownTrayIcon className="h-5 w-5 text-blue-400 hover:text-blue-500 dark:text-blue-500 dark:hover:text-blue-600" aria-hidden="true" />
+                </a>
+              )}
+              {props.row.original.info_url && (
+                <a
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  href={props.row.original.info_url}
+                  className="max-w-[90vw]"
+                >
+                  <ArrowTopRightOnSquareIcon className="h-5 w-5 text-blue-400 hover:text-blue-500 dark:text-blue-500 dark:hover:text-blue-600" aria-hidden="true" />
+                </a>
+              )}
+            </div>
           </div>
         );
       },


### PR DESCRIPTION
Add torrent download link to Release Table. A good interim solution until a more proper function is implemented.

By using an extension like [Torrent Control](https://addons.mozilla.org/en-GB/firefox/addon/torrent-control/), users can easily add torrents to their client if they were rejected or for any other reason. This can be done by simply right-clicking the torrent link and selecting the option to add it to their client.

<img width="498" alt="image" src="https://user-images.githubusercontent.com/18177310/236583776-fb03a349-762b-4ccd-a76a-5d6961a89039.png">
