### PR TITLE
fix(feeds): process RSS on initial run

### DIFF
--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -227,12 +227,6 @@ func (j *RSSJob) getFeed(ctx context.Context) (items []*gofeed.Item, err error) 
 
 	//sort.Sort(feed)
 
-	bucketCount, err := j.CacheRepo.GetCountByBucket(ctx, bucketKey)
-	if err != nil {
-		j.Log.Error().Err(err).Msg("could not check if item exists")
-		return nil, err
-	}
-
 	// set ttl to 1 month
 	ttl := time.Now().AddDate(0, 1, 0)
 
@@ -264,11 +258,8 @@ func (j *RSSJob) getFeed(ctx context.Context) (items []*gofeed.Item, err error) 
 			continue
 		}
 
-		// first time we fetch the feed the cached bucket count will be 0
-		// only append to items if it's bigger than 0, so we get new items only
-		if bucketCount > 0 {
-			items = append(items, item)
-		}
+		// only append if we successfully added to cache
+		items = append(items, item)
 	}
 
 	// send to filters


### PR DESCRIPTION
Do not cache items on initial run for RSS feeds.

Neither Torznab or Newznab does this and allows items to be processed from the start.

This supersede #885