### PR TITLE
build(web): use pnpm from corepack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
-          cache: 'pnpm'
+          node-version: '18.7.0'
+          cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Fetch web dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
           node-version: '18.7.0'
+
+      - name: Set up corepack
+        run: corepack enable
+
+      # It can not be done before enable corepack
+      - name: Set up cache
+        uses: actions/setup-node@v3
+        with:
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 FROM node:18.7.0-alpine3.16 AS web-builder
 COPY . ./
 WORKDIR /web
-RUN npm install -g pnpm && \
-pnpm install --frozen-lockfile && \
+RUN corepack enable &&
+pnpm install --frozen-lockfile &&
 pnpm run build
 
 # build app

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BINDIR = bin
 all: clean build
 
 deps:
-	cd web && pnpm install --frozen-lockfile
+	pnpm --dir web install --frozen-lockfile
 	go mod download
 
 test:
@@ -30,7 +30,7 @@ build/ctl:
 	go build -ldflags $(GOFLAGS) -o bin/autobrrctl cmd/autobrrctl/main.go
 
 build/web:
-	cd web && pnpm run build
+	pnpm --dir web run build
 
 build/docker:
 	docker build -t autobrr:dev -f Dockerfile . --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BINDIR = bin
 all: clean build
 
 deps:
-	cd web && pnpm install
+	cd web && pnpm install --frozen-lockfile
 	go mod download
 
 test:

--- a/web/package.json
+++ b/web/package.json
@@ -77,5 +77,6 @@
     "tailwindcss": "^3.1.3",
     "typescript": "^4.7.3",
     "vite": "^4.2.1"
-  }
+  },
+  "packageManager": "pnpm@8.5.1"
 }


### PR DESCRIPTION
[Corepack](https://nodejs.org/api/corepack.html) is enable since node v14, it has the package manager built-in and we can just use it.

When using corepack it will respect the version at package.json but it needs to be locked version.

I also think its nice to lock node-version on the github actions to the same as the docker image is using.

I have not tested the github actions changes, just Google and it seems to work, but we need to run to test it.

For Dockerfile I have tested and it works fine:

<img width="620" alt="image" src="https://github.com/autobrr/autobrr/assets/15933/99c2ab5f-5d08-41cc-9c66-2ecc129d4d27">
