### PR TITLE
fix(config): env var prefix clashing in k8s

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@
 #
 # Default: "localhost"
 #
-host = "0.0.0.0"
+host = "127.0.0.1"
 
 # Port
 #
@@ -25,7 +25,7 @@ port = 7474
 #
 # Optional
 #
-#logPath = ""
+#logPath = "log/autobrr.log"
 
 # Log level
 #
@@ -55,7 +55,7 @@ logLevel = "TRACE"
 #
 # Default: true
 #
-checkForUpdates = false
+checkForUpdates = true
 
 # Session secret
 #
@@ -63,13 +63,4 @@ sessionSecret = "secret-session-key"
 
 # Custom definitions
 #
-customDefinitions = "test/definitions"
-
-# Database config
-#
-databaseType = "postgres"
-postgresHost = "localhost"
-postgresPort = 5432
-postgresDatabase = "autobrr3"
-postgresUser = "autobrr"
-postgresPass = "postgres"
+#customDefinitions = "test/definitions"

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@
 #
 # Default: "localhost"
 #
-host = "127.0.0.1"
+host = "0.0.0.0"
 
 # Port
 #
@@ -25,7 +25,7 @@ port = 7474
 #
 # Optional
 #
-#logPath = "log/autobrr.log"
+#logPath = ""
 
 # Log level
 #
@@ -55,7 +55,7 @@ logLevel = "TRACE"
 #
 # Default: true
 #
-checkForUpdates = true
+checkForUpdates = false
 
 # Session secret
 #
@@ -63,4 +63,13 @@ sessionSecret = "secret-session-key"
 
 # Custom definitions
 #
-#customDefinitions = "test/definitions"
+customDefinitions = "test/definitions"
+
+# Database config
+#
+databaseType = "postgres"
+postgresHost = "localhost"
+postgresPort = 5432
+postgresDatabase = "autobrr3"
+postgresUser = "autobrr"
+postgresPass = "postgres"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -243,7 +243,7 @@ func (c *AppConfig) load(configPath string) {
 
 	for _, key := range viper.AllKeys() {
 		envKey := strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
-		err := viper.BindEnv(key, "AUTOBRR_"+envKey)
+		err := viper.BindEnv(key, "AUTOBRR__"+envKey)
 		if err != nil {
 			log.Fatal("config: unable to bind env: " + err.Error())
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -250,7 +250,7 @@ func (c *AppConfig) load(configPath string) {
 	}
 
 	if err := viper.Unmarshal(c.Config); err != nil {
-		log.Fatalf("Could not unmarshal config file: %v", viper.ConfigFileUsed())
+		log.Fatalf("Could not unmarshal config file: %v: err %q", viper.ConfigFileUsed(), err)
 	}
 }
 


### PR DESCRIPTION
Fixes an issue where the config would try merge with env vars in k8s environments.