### PR TITLE
fix(filters): duplicate missing actions

### DIFF
--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -256,6 +256,12 @@ func (s *service) Duplicate(ctx context.Context, filterID int) (*domain.Filter, 
 	}
 	filter.Indexers = filterIndexers
 
+	// reset action id to 0
+	for i, a := range filterActions {
+		a.ID = 0
+		filterActions[i] = a
+	}
+
 	// take care of filter actions
 	actions, err := s.actionRepo.StoreFilterActions(ctx, filterActions, int64(filter.ID))
 	if err != nil {


### PR DESCRIPTION
This fixes the issue with actions missing from duplicated filters.

## Why

With the recent change introduced in https://github.com/autobrr/autobrr/pull/932 we do not longer remove all the actions before saving them again. Instead we check if `id > 0` to update existing actions, and if `id == 0` then we store a new action.

By resetting each `action.ID` to 0 in the **duplicate** method it will now treat that as a new action on the new filter, and thus store it and give it an ID.

- [x] I have tested this

Fixes #938 