### PR TITLE
fix(http): set ReadHeaderTimeout to mitigate Slowloris

### DIFF
--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -81,6 +81,7 @@ func (s Server) Open() error {
 
 	server := http.Server{
 		Handler: s.Handler(),
+		ReadHeaderTimeout: time.Second * 15,
 	}
 
 	s.log.Info().Msgf("Starting server. Listening on %s", listener.Addr().String())

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/autobrr/autobrr/internal/config"
 	"github.com/autobrr/autobrr/internal/database"


### PR DESCRIPTION
Protect against Slowloris attacks.

> Configuring ReadHeaderTimeout would protect directly against this attack by closing the connection once the deadline is reached. By default, Go does not define any value — meaning there is no timeout.