### PR TITLE
feat(irc): view announces per channel

### DIFF
--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -56,8 +56,7 @@ func main() {
 
 	// setup server-sent-events
 	serverEvents := sse.New()
-	serverEvents.AutoReplay = false
-	serverEvents.CreateStream("logs")
+	serverEvents.CreateStreamWithOpts("logs", sse.StreamOpts{MaxEntries: 1000, AutoReplay: true})
 
 	// register SSE hook on logger
 	log.RegisterSSEHook(serverEvents)

--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -107,7 +107,7 @@ func main() {
 		indexerService        = indexer.NewService(log, cfg.Config, indexerRepo, indexerAPIService, schedulingService)
 		filterService         = filter.NewService(log, filterRepo, actionRepo, releaseRepo, indexerAPIService, indexerService)
 		releaseService        = release.NewService(log, releaseRepo, actionService, filterService)
-		ircService            = irc.NewService(log, ircRepo, releaseService, indexerService, notificationService)
+		ircService            = irc.NewService(log, serverEvents, ircRepo, releaseService, indexerService, notificationService)
 		feedService           = feed.NewService(log, feedRepo, feedCacheRepo, releaseService, schedulingService)
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/dcarbone/zadapters/zstdlog v0.3.1
 	github.com/dustin/go-humanize v1.0.0
-	github.com/ergochat/irc-go v0.2.0
+	github.com/ergochat/irc-go v0.3.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/render v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/autobrr/autobrr
 
 go 1.20
 
+replace github.com/r3labs/sse/v2 => github.com/autobrr/sse/v2 v2.0.0-20230520125637-530e06346d7d
+
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/Masterminds/squirrel v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -89,14 +89,14 @@ github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9Pq
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef h1:2JGTg6JapxP9/R33ZaagQtAM4EkkSYnIAlOG5EI8gkM=
 github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
-github.com/autobrr/go-deluge v1.0.0 h1:dGpA3elktcH8eQ5ctzpU5dTjzR0eOBOnrhTZEGPVv6E=
-github.com/autobrr/go-deluge v1.0.0/go.mod h1:ndiXT1eHWv/ATNk9TpE8GHIs8OSSUnsImt4Syk+y5LM=
 github.com/autobrr/go-deluge v1.0.1 h1:JH2RJnWWaYvN/29KuajtRXS/HxQhAxOk4yq54pjnn68=
 github.com/autobrr/go-deluge v1.0.1/go.mod h1:ndiXT1eHWv/ATNk9TpE8GHIs8OSSUnsImt4Syk+y5LM=
 github.com/autobrr/go-qbittorrent v1.3.2 h1:Jk6W4bGUAlmFmSefiK1jwAvITy6sGe6GG3zIP8gOJVg=
 github.com/autobrr/go-qbittorrent v1.3.2/go.mod h1:z88B3+O/1/3doQABErvIOOxE4hjpmIpulu6XzDG/q78=
 github.com/autobrr/go-rtorrent v1.0.1 h1:KbSBGcgsThYs4qHBYyFlgSOhDhfRXkJoAxVkB0atIzg=
 github.com/autobrr/go-rtorrent v1.0.1/go.mod h1:1CyQ2tcLOGP+p9drOqFiVPb/+QvfExMPCHnEGQd0BmM=
+github.com/autobrr/sse/v2 v2.0.0-20230520125637-530e06346d7d h1:9EGCYgeugAVWLBAtjHC7AFnXSwUdYfCB98WaOgdDREE=
+github.com/autobrr/sse/v2 v2.0.0-20230520125637-530e06346d7d/go.mod h1:zCozZ9lp4DE340T2+wfMPL/eoQwLVIGDOCKCDEFwTQU=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/benbjohnson/immutable v0.2.0/go.mod h1:uc6OHo6PN2++n98KHLxW8ef4W42ylHiQSENghE1ezxI=
@@ -360,8 +360,6 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/r3labs/sse/v2 v2.8.1 h1:lZH+W4XOLIq88U5MIHOsLec7+R62uhz3bIi2yn0Sg8o=
-github.com/r3labs/sse/v2 v2.8.1/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
@@ -498,7 +496,6 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ergochat/irc-go v0.2.0 h1:3vHdy4c56UTY6+/rTBrQc1fmt32N5G8PrEZacJDOr+E=
 github.com/ergochat/irc-go v0.2.0/go.mod h1:2vi7KNpIPWnReB5hmLpl92eMywQvuIeIIGdt/FQCph0=
+github.com/ergochat/irc-go v0.3.0 h1:qgvb2knh8d6yIVsHX+PRQ2CiRj1NGG5x88ABmR1lWng=
+github.com/ergochat/irc-go v0.3.0/go.mod h1:2vi7KNpIPWnReB5hmLpl92eMywQvuIeIIGdt/FQCph0=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/internal/database/irc.go
+++ b/internal/database/irc.go
@@ -447,7 +447,7 @@ func (r *IrcRepo) StoreNetworkChannels(ctx context.Context, networkID int64, cha
 	return nil
 }
 
-func (r *IrcRepo) StoreChannel(networkID int64, channel *domain.IrcChannel) error {
+func (r *IrcRepo) StoreChannel(ctx context.Context, networkID int64, channel *domain.IrcChannel) error {
 	pass := toNullString(channel.Password)
 
 	var err error

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -95,9 +95,10 @@ type SendIrcCmdRequest struct {
 }
 
 type IrcMessage struct {
-	Channel string `json:"channel"`
-	Nick    string `json:"nick"`
-	Message string `json:"msg"`
+	Channel string    `json:"channel"`
+	Nick    string    `json:"nick"`
+	Message string    `json:"msg"`
+	Time    time.Time `json:"time"`
 }
 
 func (m IrcMessage) ToJsonString() string {

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -87,11 +87,11 @@ type ChannelHealth struct {
 }
 
 type SendIrcCmdRequest struct {
-	Id      int    `json:"id"`
-	Server  string `json:"server"`
-	Channel string `json:"channel"`
-	Nick    string `json:"nick"`
-	Message string `json:"msg"`
+	NetworkId int64  `json:"network_id"`
+	Server    string `json:"server"`
+	Channel   string `json:"channel"`
+	Nick      string `json:"nick"`
+	Message   string `json:"msg"`
 }
 
 type IrcMessage struct {
@@ -119,7 +119,7 @@ func (m IrcMessage) Bytes() []byte {
 type IrcRepo interface {
 	StoreNetwork(network *IrcNetwork) error
 	UpdateNetwork(ctx context.Context, network *IrcNetwork) error
-	StoreChannel(networkID int64, channel *IrcChannel) error
+	StoreChannel(ctx context.Context, networkID int64, channel *IrcChannel) error
 	UpdateChannel(channel *IrcChannel) error
 	UpdateInviteCommand(networkID int64, invite string) error
 	StoreNetworkChannels(ctx context.Context, networkID int64, channels []IrcChannel) error

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -5,6 +5,7 @@ package domain
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 )
 
@@ -83,6 +84,36 @@ type ChannelHealth struct {
 	Monitoring      bool      `json:"monitoring"`
 	MonitoringSince time.Time `json:"monitoring_since"`
 	LastAnnounce    time.Time `json:"last_announce"`
+}
+
+type SendIrcCmdRequest struct {
+	Id      int    `json:"id"`
+	Server  string `json:"server"`
+	Channel string `json:"channel"`
+	Nick    string `json:"nick"`
+	Message string `json:"msg"`
+}
+
+type IrcMessage struct {
+	Channel string `json:"channel"`
+	Nick    string `json:"nick"`
+	Message string `json:"msg"`
+}
+
+func (m IrcMessage) ToJsonString() string {
+	j, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(j)
+}
+
+func (m IrcMessage) Bytes() []byte {
+	j, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	return j
 }
 
 type IrcRepo interface {

--- a/internal/http/irc.go
+++ b/internal/http/irc.go
@@ -22,7 +22,7 @@ type ircService interface {
 	GetNetworkByID(ctx context.Context, id int64) (*domain.IrcNetwork, error)
 	StoreNetwork(ctx context.Context, network *domain.IrcNetwork) error
 	UpdateNetwork(ctx context.Context, network *domain.IrcNetwork) error
-	StoreChannel(networkID int64, channel *domain.IrcChannel) error
+	StoreChannel(ctx context.Context, networkID int64, channel *domain.IrcChannel) error
 	RestartNetwork(ctx context.Context, id int64) error
 	SendCmd(ctx context.Context, req *domain.SendIrcCmdRequest) error
 }
@@ -120,8 +120,7 @@ func (h ircHandler) storeNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := h.service.StoreNetwork(r.Context(), &data)
-	if err != nil {
+	if err := h.service.StoreNetwork(r.Context(), &data); err != nil {
 		h.encoder.Error(w, err)
 		return
 	}
@@ -140,8 +139,7 @@ func (h ircHandler) updateNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := h.service.UpdateNetwork(ctx, &data)
-	if err != nil {
+	if err := h.service.UpdateNetwork(ctx, &data); err != nil {
 		h.encoder.Error(w, err)
 		return
 	}
@@ -151,8 +149,9 @@ func (h ircHandler) updateNetwork(w http.ResponseWriter, r *http.Request) {
 
 func (h ircHandler) sendCmd(w http.ResponseWriter, r *http.Request) {
 	var (
-		data      domain.SendIrcCmdRequest
+		ctx       = r.Context()
 		networkID = chi.URLParam(r, "networkID")
+		data      domain.SendIrcCmdRequest
 	)
 
 	id, _ := strconv.Atoi(networkID)
@@ -162,9 +161,9 @@ func (h ircHandler) sendCmd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data.Id = id
+	data.NetworkId = int64(id)
 
-	if err := h.service.SendCmd(r.Context(), &data); err != nil {
+	if err := h.service.SendCmd(ctx, &data); err != nil {
 		h.encoder.Error(w, err)
 		return
 	}
@@ -174,8 +173,9 @@ func (h ircHandler) sendCmd(w http.ResponseWriter, r *http.Request) {
 
 func (h ircHandler) storeChannel(w http.ResponseWriter, r *http.Request) {
 	var (
-		data      domain.IrcChannel
+		ctx       = r.Context()
 		networkID = chi.URLParam(r, "networkID")
+		data      domain.IrcChannel
 	)
 
 	id, _ := strconv.Atoi(networkID)
@@ -185,8 +185,7 @@ func (h ircHandler) storeChannel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := h.service.StoreChannel(int64(id), &data)
-	if err != nil {
+	if err := h.service.StoreChannel(ctx, int64(id), &data); err != nil {
 		h.encoder.Error(w, err)
 		return
 	}
@@ -202,8 +201,7 @@ func (h ircHandler) deleteNetwork(w http.ResponseWriter, r *http.Request) {
 
 	id, _ := strconv.Atoi(networkID)
 
-	err := h.service.DeleteNetwork(ctx, int64(id))
-	if err != nil {
+	if err := h.service.DeleteNetwork(ctx, int64(id)); err != nil {
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/irc.go
+++ b/internal/http/irc.go
@@ -40,11 +40,15 @@ func newIrcHandler(encoder encoder, service ircService) *ircHandler {
 func (h ircHandler) Routes(r chi.Router) {
 	r.Get("/", h.listNetworks)
 	r.Post("/", h.storeNetwork)
-	r.Put("/network/{networkID}", h.updateNetwork)
-	r.Post("/network/{networkID}/channel", h.storeChannel)
-	r.Get("/network/{networkID}/restart", h.restartNetwork)
-	r.Get("/network/{networkID}", h.getNetworkByID)
-	r.Delete("/network/{networkID}", h.deleteNetwork)
+
+	r.Route("/network/{networkID}", func(r chi.Router) {
+		r.Put("/", h.updateNetwork)
+		r.Get("/", h.getNetworkByID)
+		r.Delete("/", h.deleteNetwork)
+
+		r.Post("/channel", h.storeChannel)
+		r.Get("/restart", h.restartNetwork)
+	})
 }
 
 func (h ircHandler) listNetworks(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -121,7 +121,7 @@ func (s Server) Handler() http.Handler {
 			r.Route("/download_clients", newDownloadClientHandler(encoder, s.downloadClientService).Routes)
 			r.Route("/filters", newFilterHandler(encoder, s.filterService).Routes)
 			r.Route("/feeds", newFeedHandler(encoder, s.feedService).Routes)
-			r.Route("/irc", newIrcHandler(encoder, s.ircService).Routes)
+			r.Route("/irc", newIrcHandler(encoder, s.sse, s.ircService).Routes)
 			r.Route("/indexer", newIndexerHandler(encoder, s.indexerService, s.ircService).Routes)
 			r.Route("/keys", newAPIKeyHandler(encoder, s.apiService).Routes)
 			r.Route("/logs", newLogsHandler(s.config).Routes)

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -543,11 +543,15 @@ func (h *Handler) onNick(msg ircmsg.Message) {
 	}
 }
 
-// onMessage handles PRIVMSG events
-func (h *Handler) onMessage(msg ircmsg.Message) {
-	h.sse.Publish(h.network.Server, &sse.Event{
+func (h *Handler) publishMsg(msg ircmsg.Message) {
+	h.sse.Publish(fmt.Sprintf("%d%s", h.network.ID, strings.TrimPrefix(msg.Params[0], "#")), &sse.Event{
 		Data: domain.IrcMessage{Nick: msg.Nick(), Channel: msg.Params[0], Message: msg.Params[1]}.Bytes(),
 	})
+}
+
+// onMessage handles PRIVMSG events
+func (h *Handler) onMessage(msg ircmsg.Message) {
+	h.publishMsg(msg)
 
 	if len(msg.Params) < 2 {
 		return
@@ -815,9 +819,7 @@ func (h *Handler) PreferredNick() string {
 func (h *Handler) handleMsg(msg ircmsg.Message) {
 	h.log.Trace().Msgf("msg: %v", msg)
 
-	h.sse.Publish(h.network.Server, &sse.Event{
-		Data: []byte(msg.Params[1]),
-	})
+	h.publishMsg(msg)
 }
 
 // listens for MODE events

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -565,7 +565,7 @@ func (h *Handler) onMessage(msg ircmsg.Message) {
 	h.log.Debug().Str("channel", channel).Str("nick", nick).Msg(cleanedMsg)
 
 	// publish to SSE stream
-	h.publishSSEMsg(domain.IrcMessage{Channel: channel, Nick: nick, Message: cleanedMsg})
+	h.publishSSEMsg(domain.IrcMessage{Channel: channel, Nick: nick, Message: cleanedMsg, Time: time.Now()})
 
 	// check if message is from a valid channel, if not return
 	if validChannel := h.isValidChannel(channel); !validChannel {

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -198,7 +198,6 @@ func (h *Handler) Run() error {
 	h.client.AddCallback("NOTICE", h.onNotice)
 	h.client.AddCallback("NICK", h.onNick)
 	h.client.AddCallback("903", h.handleSASLSuccess)
-	h.client.AddCallback("*", h.handleMsg)
 
 	//h.setConnectionStatus()
 	h.saslauthed = false
@@ -814,12 +813,6 @@ func (h *Handler) CurrentNick() string {
 // PreferredNick returns our preferred nick from settings
 func (h *Handler) PreferredNick() string {
 	return h.client.PreferredNick()
-}
-
-func (h *Handler) handleMsg(msg ircmsg.Message) {
-	h.log.Trace().Msgf("msg: %v", msg)
-
-	h.publishMsg(msg)
 }
 
 // listens for MODE events

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -546,8 +546,9 @@ func (h *Handler) onNick(msg ircmsg.Message) {
 // onMessage handles PRIVMSG events
 func (h *Handler) onMessage(msg ircmsg.Message) {
 	h.sse.Publish(h.network.Server, &sse.Event{
-		Data: []byte(msg.Params[1]),
+		Data: domain.IrcMessage{Nick: msg.Nick(), Channel: msg.Params[0], Message: msg.Params[1]}.Bytes(),
 	})
+
 	if len(msg.Params) < 2 {
 		return
 	}
@@ -833,6 +834,17 @@ func (h *Handler) handleMode(msg ircmsg.Message) {
 	}
 
 	return
+}
+
+func (h *Handler) SendMsg(channel, msg string) error {
+	h.log.Debug().Msgf("sending msg command: %s", msg)
+
+	if err := h.client.Privmsg(channel, msg); err != nil {
+		h.log.Error().Stack().Err(err).Msgf("error sending msg: %v", msg)
+		return err
+	}
+
+	return nil
 }
 
 // check if announcer is one from the list in the definition

--- a/test/mockindexer/irc/handlers.go
+++ b/test/mockindexer/irc/handlers.go
@@ -37,5 +37,7 @@ func CommandHandler(c *Client, cmd []string) {
 		c.writer <- fmt.Sprintf("366 %s %s :End", c.nick, c.channelName)
 	case "PING":
 		c.writer <- fmt.Sprintf("PONG n %s", strings.Join(cmd[1:], " "))
+	case "PRIVMSG":
+		c.writer <- fmt.Sprintf("%s PRIVMSG %s %s", fmt.Sprintf(":%s", c.nick), cmd[1], fmt.Sprintf("%s", strings.Join(cmd[2:], " ")))
 	}
 }

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -151,7 +151,7 @@ export const APIClient = {
     updateNetwork: (network: IrcNetwork) => appClient.Put(`api/irc/network/${network.id}`, network),
     deleteNetwork: (id: number) => appClient.Delete(`api/irc/network/${id}`),
     restartNetwork: (id: number) => appClient.Get(`api/irc/network/${id}/restart`),
-    sendCmd: (cmd: SendIrcCmdRequest) => appClient.Post(`api/irc/network/${cmd.id}/cmd`, cmd),
+    sendCmd: (cmd: SendIrcCmdRequest) => appClient.Post(`api/irc/network/${cmd.network_id}/cmd`, cmd),
     events: (network: string) => new EventSource(`${sseBaseUrl()}api/irc/events?stream=${network}`, { withCredentials: true })
   },
   logs: {

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -150,7 +150,9 @@ export const APIClient = {
     createNetwork: (network: IrcNetworkCreate) => appClient.Post("api/irc", network),
     updateNetwork: (network: IrcNetwork) => appClient.Put(`api/irc/network/${network.id}`, network),
     deleteNetwork: (id: number) => appClient.Delete(`api/irc/network/${id}`),
-    restartNetwork: (id: number) => appClient.Get(`api/irc/network/${id}/restart`)
+    restartNetwork: (id: number) => appClient.Get(`api/irc/network/${id}/restart`),
+    sendCmd: (cmd: SendIrcCmdRequest) => appClient.Post(`api/irc/network/${cmd.id}/cmd`, cmd),
+    events: (network: string) => new EventSource(`${sseBaseUrl()}api/irc/events?stream=${network}`, { withCredentials: true })
   },
   logs: {
     files: () => appClient.Get<LogFileResponse>("api/logs/files"),

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -346,7 +346,7 @@ const ListItem = ({ idx, network, expanded }: ListItemProps) => {
                   <div className="col-span-4 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Monitoring since
                   </div>
-                  <div className="col-span-4 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  <div className="col-span-3 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Last announce
                   </div>
                 </li>
@@ -403,10 +403,13 @@ const ChannelItem = ({ network, channel }: ChannelItemProps) => {
             {IsEmptyDate(channel.monitoring_since)}
           </span>
         </div>
-        <div className="col-span-4 flex items-center md:px-6 ">
+        <div className="col-span-3 flex items-center md:px-6 ">
           <span title={simplifyDate(channel.last_announce)}>
             {IsEmptyDate(channel.last_announce)}
           </span>
+        </div>
+        <div className="col-span-1 flex items-center">
+          <button className="hover:text-gray-500 px-2 py-1 dark:bg-gray-800 rounded dark:border-gray-900">{viewChannel ? "Hide" : "View"}</button>
         </div>
       </div>
       {viewChannel && (

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -237,7 +237,7 @@ const ListItem = ({ idx, network, expanded }: ListItemProps) => {
 
   return (
     <li key={idx}>
-      <div className={classNames("grid grid-cols-12 gap-2 lg:gap-4 items-center py-2", network.enabled && !network.healthy ? "bg-red-50 dark:bg-red-900 hover:bg-red-100 dark:hover:bg-red-800" : "hover:bg-gray-50 dark:hover:bg-gray-700 ")}>
+      <div className={classNames("grid grid-cols-12 gap-2 lg:gap-4 items-center py-2", network.enabled && !network.healthy ? "bg-red-50 dark:bg-red-900 hover:bg-red-100 dark:hover:bg-red-800" : "hover:bg-gray-50 dark:hover:bg-gray-700")}>
         <IrcNetworkUpdateForm
           isOpen={updateIsOpen}
           toggle={toggleUpdate}
@@ -375,8 +375,8 @@ const ChannelItem = ({ network, channel }: ChannelItemProps) => {
   const [viewChannel, toggleView] = useToggle(false);
 
   return (
-    <li key={channel.id} className={classNames("mb-2 text-gray-500 dark:text-gray-400", viewChannel ? "bg-gray-200 dark:bg-gray-800" : "")}>
-      <div className="grid grid-cols-12 gap-4 items-center py-4 hover:bg-gray-300 dark:hover:bg-gray-800 hover:cursor-pointer rounded" onClick={toggleView}>
+    <li key={channel.id} className={classNames("mb-2 text-gray-500 dark:text-gray-400", viewChannel ? "bg-gray-200 dark:bg-gray-800 rounded-md" : "")}>
+      <div className="grid grid-cols-12 gap-4 items-center py-4 hover:bg-gray-300 dark:hover:bg-gray-800 hover:cursor-pointer rounded-md" onClick={toggleView}>
         <div className="col-span-4 flex items-center md:px-6 ">
           <span className="relative inline-flex items-center">
             {network.enabled ? (
@@ -643,7 +643,7 @@ export const Events = ({ network, channel }: EventsProps) => {
   }, [settings]);
 
   return (
-    <div className="dark:bg-gray-800 rounded-lg shadow-lg p-1">
+    <div className="dark:bg-gray-800 rounded-lg shadow-lg p-1.5">
       <div className="flex relative">
       </div>
 

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -583,6 +583,7 @@ type IrcEvent = {
   channel: string;
   nick: string;
   msg: string;
+  time: string;
 };
 
 type IrcMsg = {
@@ -656,7 +657,7 @@ export const Events = ({ network, channel }: EventsProps) => {
               settings.hideWrappedText ? "truncate hover:text-ellipsis hover:whitespace-normal" : ""
             )}
           >
-            <span className="font-mono text-gray-500 dark:text-gray-500 mr-1"><span className="dark:text-gray-600">{entry.nick}:</span> {entry.msg}</span>
+            <span className="font-mono text-gray-500 dark:text-gray-500 mr-1"><span className="dark:text-gray-600" title={simplifyDate(entry.time)}>{entry.nick}:</span> {entry.msg}</span>
           </div>
         ))}
         <div className="mt-6" ref={messagesEndRef} />

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -604,7 +604,7 @@ export const Events = ({ network }: EventsProps) => {
   });
 
   const onSubmit = (msg: IrcMsg) => {
-    const payload = { id: network.id, nick: network.nick, server: network.server, channel: "#announces", msg: msg.msg };
+    const payload = { network_id: network.id, nick: network.nick, server: network.server, channel: "#announces", msg: msg.msg };
     console.log("payload", payload);
     cmdMutation.mutate(payload);
   };

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -375,8 +375,8 @@ const ChannelItem = ({ network, channel }: ChannelItemProps) => {
   const [viewChannel, toggleView] = useToggle(false);
 
   return (
-    <li key={channel.id} className={classNames("mb-2 text-gray-500 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-gray-800 hover:cursor-pointer rounded", viewChannel ? "bg-gray-200 dark:bg-gray-800" : "")} onClick={toggleView}>
-      <div className="grid grid-cols-12 gap-4 items-center py-4">
+    <li key={channel.id} className={classNames("mb-2 text-gray-500 dark:text-gray-400", viewChannel ? "bg-gray-200 dark:bg-gray-800" : "")}>
+      <div className="grid grid-cols-12 gap-4 items-center py-4 hover:bg-gray-300 dark:hover:bg-gray-800 hover:cursor-pointer rounded" onClick={toggleView}>
         <div className="col-span-4 flex items-center md:px-6 ">
           <span className="relative inline-flex items-center">
             {network.enabled ? (

--- a/web/src/types/Irc.d.ts
+++ b/web/src/types/Irc.d.ts
@@ -74,7 +74,7 @@ interface IrcAuth {
 }
 
 interface SendIrcCmdRequest {
-  id: number;
+  network_id: number;
   server: string;
   channel: string;
   nick: string;

--- a/web/src/types/Irc.d.ts
+++ b/web/src/types/Irc.d.ts
@@ -72,3 +72,11 @@ interface IrcAuth {
   account?: string; // optional
   password?: string; // optional
 }
+
+interface SendIrcCmdRequest {
+  id: number;
+  server: string;
+  channel: string;
+  nick: string;
+  msg: string;
+}

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -28,6 +28,7 @@ export const InitializeGlobalContext = () => {
     FilterListContext.set(JSON.parse(filterList_ctx));
   }
 };
+
 interface AuthInfo {
   username: string;
   isLoggedIn: boolean;
@@ -104,6 +105,41 @@ export const FilterListContext = newRidgeState<FilterListState>(
         localStorage.setItem("filterList", JSON.stringify(new_state));
       } catch (e) {
         console.log("An error occurred while trying to modify the local filter list context state.");
+        console.log("Error:", e);
+      }
+    }
+  }
+);
+
+export type IrcNetworkState = {
+  id: number;
+  name: string;
+  status: string;
+};
+
+export type IrcBufferType = "NICK" | "CHANNEL" | "SERVER";
+
+export type IrcBufferState = {
+  id: number;
+  name: string;
+  type: IrcBufferType;
+  messages: string[];
+};
+
+export type IrcState = {
+  networks: Map<string, IrcNetworkState>;
+  buffers: Map<string, IrcBufferState>
+};
+export const IrcContext = newRidgeState<IrcState>(
+  {
+    networks: new Map,
+    buffers: new Map
+  },
+  {
+    onSet: (new_state) => {
+      try {
+        console.log("set irc state", new_state);
+      } catch (e) {
         console.log("Error:", e);
       }
     }

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -132,8 +132,8 @@ export type IrcState = {
 };
 export const IrcContext = newRidgeState<IrcState>(
   {
-    networks: new Map,
-    buffers: new Map
+    networks: new Map(),
+    buffers: new Map()
   },
   {
     onSet: (new_state) => {


### PR DESCRIPTION
View messages/announces per channel of IRC networks.

With the improved functionality in the Server Sent Events library we can now store events from channels and replay those easily. The current number is set to replay 1000 messages when opening the channel log. This might be too many messages but they are streamed and not a giant blob. We can always reduce this in the future.

## Screenshots

![image](https://github.com/autobrr/autobrr/assets/43699394/2d086b0a-66d5-4a73-9fef-647d5600a6a4)

Expanded
![image](https://github.com/autobrr/autobrr/assets/43699394/e5e33145-d6c8-4bbf-835c-83f00715c07b)


Fixes #826 