### PR TITLE
feat(irc): add bouncer/znc support

### DIFF
--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -45,6 +45,8 @@ CREATE TABLE irc_network
     auth_account        TEXT,
     auth_password       TEXT,
     invite_command      TEXT,
+    use_bouncer         BOOLEAN,
+    bouncer_addr        TEXT,
     connected           BOOLEAN,
     connected_since     TIMESTAMP,
     created_at          TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -699,4 +701,9 @@ ADD COLUMN topic text;`,
 ALTER TABLE release_action_status
     ADD CONSTRAINT release_action_status_action_id_fk
         FOREIGN KEY (action_id) REFERENCES action;`,
+	`ALTER TABLE irc_network
+ADD COLUMN use_bouncer BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE irc_network
+ADD COLUMN bouncer_addr TEXT;`,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -45,6 +45,8 @@ CREATE TABLE irc_network
     auth_account        TEXT,
     auth_password       TEXT,
     invite_command      TEXT,
+    use_bouncer         BOOLEAN,
+    bouncer_addr        TEXT,
     connected           BOOLEAN,
     connected_since     TIMESTAMP,
     created_at          TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -1141,4 +1143,9 @@ create index release_action_status_release_id_index
 
 create index release_action_status_status_index
     on release_action_status (status);`,
+	`ALTER TABLE irc_network
+ADD COLUMN use_bouncer BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE irc_network
+ADD COLUMN bouncer_addr TEXT;`,
 }

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -43,6 +43,8 @@ type IrcNetwork struct {
 	Nick           string       `json:"nick"`
 	Auth           IRCAuth      `json:"auth,omitempty"`
 	InviteCommand  string       `json:"invite_command"`
+	UseBouncer     bool         `json:"use_bouncer"`
+	BouncerAddr    string       `json:"bouncer_addr"`
 	Channels       []IrcChannel `json:"channels"`
 	Connected      bool         `json:"connected"`
 	ConnectedSince *time.Time   `json:"connected_since"`
@@ -59,6 +61,8 @@ type IrcNetworkWithHealth struct {
 	Nick             string              `json:"nick"`
 	Auth             IRCAuth             `json:"auth,omitempty"`
 	InviteCommand    string              `json:"invite_command"`
+	UseBouncer       bool                `json:"use_bouncer"`
+	BouncerAddr      string              `json:"bouncer_addr"`
 	CurrentNick      string              `json:"current_nick"`
 	PreferredNick    string              `json:"preferred_nick"`
 	Channels         []ChannelWithHealth `json:"channels"`

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -156,6 +156,10 @@ func (h *Handler) Run() error {
 
 	addr := fmt.Sprintf("%v:%d", h.network.Server, h.network.Port)
 
+	if h.network.UseBouncer && h.network.BouncerAddr != "" {
+		addr = h.network.BouncerAddr
+	}
+
 	subLogger := zstdlog.NewStdLoggerWithLevel(h.log.With().Logger(), zerolog.TraceLevel)
 
 	h.client = &ircevent.Connection{

--- a/internal/irc/service.go
+++ b/internal/irc/service.go
@@ -416,6 +416,8 @@ func (s *service) GetNetworksWithHealth(ctx context.Context) ([]domain.IrcNetwor
 			Nick:             n.Nick,
 			Auth:             n.Auth,
 			InviteCommand:    n.InviteCommand,
+			BouncerAddr:      n.BouncerAddr,
+			UseBouncer:       n.UseBouncer,
 			Connected:        false,
 			Channels:         []domain.ChannelWithHealth{},
 			ConnectionErrors: []string{},

--- a/web/src/forms/settings/IrcForms.tsx
+++ b/web/src/forms/settings/IrcForms.tsx
@@ -235,6 +235,8 @@ interface IrcNetworkUpdateFormValues {
     nick: string;
     auth?: IrcAuth;
     invite_command: string;
+    use_bouncer: boolean;
+    bouncer_addr: string;
     channels: Array<IrcChannel>;
 }
 
@@ -288,6 +290,8 @@ export function IrcNetworkUpdateForm({
     pass: network.pass,
     auth: network.auth,
     invite_command: network.invite_command,
+    use_bouncer: network.use_bouncer,
+    bouncer_addr: network.bouncer_addr,
     channels: network.channels
   };
 
@@ -339,6 +343,15 @@ export function IrcNetworkUpdateForm({
             placeholder="nick"
             required={true}
           />
+
+          <SwitchGroupWide name="use_bouncer" label="Bouncer (BNC)" />
+          {values.use_bouncer && (
+            <TextFieldWide
+              name="bouncer_addr"
+              label="Bouncer address"
+              help="Address: Eg bouncer.server.net:6697"
+            />
+          )}
 
           <div className="border-t border-gray-200 dark:border-gray-700 py-5">
             <div className="px-4 space-y-1 mb-8">

--- a/web/src/types/Irc.d.ts
+++ b/web/src/types/Irc.d.ts
@@ -14,6 +14,8 @@ interface IrcNetwork {
   pass: string;
   auth: IrcAuth; // optional
   invite_command: string;
+  use_bouncer: boolean;
+  bouncer_addr: string;
   channels: IrcChannel[];
   connected: boolean;
   connected_since: string;
@@ -29,6 +31,8 @@ interface IrcNetworkCreate {
   nick: string;
   auth: IrcAuth; // optional
   invite_command: string;
+  use_bouncer: boolean;
+  bouncer_addr: string;
   channels: IrcChannel[];
   connected: boolean;
 }
@@ -58,6 +62,8 @@ interface IrcNetworkWithHealth {
   nick: string;
   auth: IrcAuth; // optional
   invite_command: string;
+  use_bouncer: boolean;
+  bouncer_addr: string;
   channels: IrcChannelWithHealth[];
   connected: boolean;
   connected_since: string;

--- a/web/src/types/Irc.d.ts
+++ b/web/src/types/Irc.d.ts
@@ -31,8 +31,8 @@ interface IrcNetworkCreate {
   nick: string;
   auth: IrcAuth; // optional
   invite_command: string;
-  use_bouncer: boolean;
-  bouncer_addr: string;
+  use_bouncer?: boolean;
+  bouncer_addr?: string;
   channels: IrcChannel[];
   connected: boolean;
 }


### PR DESCRIPTION
Add initial bouncer support for IRC. Only tested with ZNC so far, which is the most popular IRC bouncer.

## Todo

- [x] Add migrations for SQLite
- [x] Add migrations for Postgres
- [x] Frontend changes to Update network

## How to use

In the IRC settings for the network there's now a toggle **Bouncer (BNC)**. Toggle that and you'll get a new field below, **Bouncer address** which takes the addr to your bouncer.

Then set the password to your users password for the bouncer and Account to your `user/network` configured by the bouncer. Leave channels as is.

## Screenshots

![image](https://github.com/autobrr/autobrr/assets/43699394/48490b72-ba66-40e4-ade3-53aebbeb990f)

Fixes #488 