### PR TITLE
fix(build): missing concat EOL on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 FROM node:18.7.0-alpine3.16 AS web-builder
 COPY . ./
 WORKDIR /web
-RUN corepack enable &&
-pnpm install --frozen-lockfile &&
-pnpm run build
+RUN corepack enable && \
+    pnpm install --frozen-lockfile && \
+    pnpm run build
 
 # build app
 FROM golang:1.20-alpine3.16 AS app-builder
@@ -39,8 +39,8 @@ FROM alpine:latest
 LABEL org.opencontainers.image.source = "https://github.com/autobrr/autobrr"
 
 ENV HOME="/config" \
-XDG_CONFIG_HOME="/config" \
-XDG_DATA_HOME="/config"
+    XDG_CONFIG_HOME="/config" \
+    XDG_DATA_HOME="/config"
 
 RUN apk --no-cache add ca-certificates curl tzdata jq
 

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -27,8 +27,8 @@ FROM alpine:latest
 LABEL org.opencontainers.image.source = "https://github.com/autobrr/autobrr"
 
 ENV HOME="/config" \
-XDG_CONFIG_HOME="/config" \
-XDG_DATA_HOME="/config"
+    XDG_CONFIG_HOME="/config" \
+    XDG_DATA_HOME="/config"
 
 RUN apk --no-cache add ca-certificates curl tzdata jq
 


### PR DESCRIPTION
Something on my editor have removed the `\`...
Tried to build it today and it broken

![](https://media.tenor.com/udq1uD9WHSQAAAAM/oops.gif)