### PR TITLE
build: goreleaser parallel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
   goreleaserbuild:
     name: Build Go binaries
     if: github.event_name == 'pull_request'
-    runs-on: windows-latest
+    runs-on: macos-latest
     needs: [web, test]
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   web:
     name: Build web
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --skip-validate --skip-publish -p99
+          args: release --clean --skip-validate --skip-publish --parallelism 99
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   web:
     name: Build web
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -201,4 +201,3 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,9 @@ jobs:
         run: go test -v ./...
 
   goreleaserbuild:
-    matrix:
-      os: [macos-latest, windows-latest, ubuntu-latest]
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
     name: Build Go binaries ${{ matrix.os }}
     if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --skip-validate --skip-publish -p8
+          args: release --clean --skip-validate --skip-publish -p99
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,11 @@ jobs:
         run: go test -v ./...
 
   goreleaserbuild:
-    name: Build Go binaries
+    matrix:
+      os: [macos-latest, windows-latest, ubuntu-latest]
+    name: Build Go binaries ${{ matrix.os }}
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: [web, test]
     steps:
       - name: Checkout
@@ -103,6 +105,7 @@ jobs:
           args: release --clean --skip-validate --skip-publish -p99
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GGOOS: ${{ matrix.os }}
 
       - name: Upload assets
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,3 +201,4 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           args: release --clean --skip-validate --skip-publish -p99
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GGOOS: ${{ matrix.os }}
+          GGOOS: windows
 
       - name: Upload assets
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
   goreleaserbuild:
     name: Build Go binaries
     if: github.event_name == 'pull_request'
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     needs: [web, test]
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --skip-validate --skip-publish
+          args: release --clean --skip-validate --skip-publish -p8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,7 @@ jobs:
         run: go test -v ./...
 
   goreleaserbuild:
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-    name: Build Go binaries ${{ matrix.os }}
+    name: Build Go binaries
     if: github.event_name == 'pull_request'
     runs-on: ${{ matrix.os }}
     needs: [web, test]
@@ -106,7 +103,6 @@ jobs:
           args: release --clean --skip-validate --skip-publish -p99
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GGOOS: windows
 
       - name: Upload assets
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: autobrr
-          path: dist/*.tar.gz
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
 
   goreleaser:
     name: Build and publish binaries
@@ -147,7 +149,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: autobrr
-          path: dist/*.tar.gz
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
 
   docker:
     name: Build and publish Docker images

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,6 +65,9 @@ archives:
       - autobrrctl
     replacements:
       amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
 
 release:
   prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,6 +63,8 @@ archives:
     builds:
       - autobrr
       - autobrrctl
+    files:
+      - none*
     replacements:
       amd64: x86_64
     format_overrides:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,8 +63,6 @@ archives:
     builds:
       - autobrr
       - autobrrctl
-    files:
-      - none*
     replacements:
       amd64: x86_64
 


### PR DESCRIPTION
So... goreleaser does not allow opensource users to use GGOOS (which lets you filter the goreleaser file) so matrix builds are possible but it's constructing the file each time (not a problem, just work).

The linux nodes on GHA only have a single CPU which is fine, but takes a lot of time with cross-compilation. MacOS and Windows still run on (or close to) metal. Windows with setup-go from years ago still suffers from zstd compression times (taking 4 minutes), with a pretty beefy node. MacOS runs in a similar fashion, but uses gzip which decompresses faster (3 minutes) to be exact.

As these are both faster than linux... lets change nodes until such a time that this no longer makes sense, or there's an easier way.