### PR TITLE
chore(web): add ignore pattern to eslint for the unused-vars rule

### DIFF
--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -22,6 +22,13 @@ module.exports = {
     indent: ["warn", 2],
     // Don't enforce any particular brace style
     curly: "off",
+    // Allow only vars starting with _ to be ununsed vars
+    "no-unused-vars": ["warn", {
+      "varsIgnorePattern": "^_",
+      "argsIgnorePattern": "^_",
+      "caughtErrorsIgnorePattern": "^_",
+      "ignoreRestSiblings": true
+    }],
     // Let's keep these off for now and
     // maybe turn these back on sometime in the future
     "import/prefer-default-export": "off",
@@ -57,7 +64,6 @@ module.exports = {
         "@typescript-eslint/quotes": ["error", "double"],
         semi: "off",
         "@typescript-eslint/semi": ["warn", "always"],
-        // indent: "off",
         indent: ["warn", 2],
         "@typescript-eslint/indent": "off",
         "@typescript-eslint/comma-dangle": "warn",
@@ -65,6 +71,13 @@ module.exports = {
         "@typescript-eslint/keyword-spacing": ["error"],
         "object-curly-spacing": "off",
         "@typescript-eslint/object-curly-spacing": ["warn", "always"],
+        // Allow only vars starting with _ to be ununsed vars
+        "@typescript-eslint/no-unused-vars": ["warn", {
+          "varsIgnorePattern": "^_",
+          "argsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_",
+          "ignoreRestSiblings": true
+        }],
         // We have quite some "Unexpected any. Specify a different type" warnings.
         // This disables these warnings since they are false positives afaict.
         "@typescript-eslint/no-explicit-any": "off"

--- a/web/src/screens/settings/Application.tsx
+++ b/web/src/screens/settings/Application.tsx
@@ -31,26 +31,26 @@ const RowItem = ({ label, value, title, emptyText }: RowItemProps) => {
   );
 };
 
-interface RowItemNumberProps {
-  label: string;
-  value?: string | number;
-  title?: string;
-  unit?: string;
-}
+// interface RowItemNumberProps {
+//   label: string;
+//   value?: string | number;
+//   title?: string;
+//   unit?: string;
+// }
 
-const RowItemNumber = ({ label, value, title, unit }: RowItemNumberProps) => {
-  return (
-    <div className="py-4 sm:py-5 sm:grid sm:grid-cols-4 sm:gap-4 sm:px-6">
-      <dt className="font-medium text-gray-500 dark:text-white" title={title}>{label}:</dt>
-      <dd className="mt-1 text-gray-900 dark:text-white sm:mt-0 sm:col-span-2 break-all">
-        <span className="px-1 py-0.5 bg-gray-700 rounded shadow">{value}</span>
-        {unit &&
-          <span className="ml-1 text-sm text-gray-800 dark:text-gray-400">{unit}</span>
-        }
-      </dd>
-    </div>
-  );
-};
+// const RowItemNumber = ({ label, value, title, unit }: RowItemNumberProps) => {
+//   return (
+//     <div className="py-4 sm:py-5 sm:grid sm:grid-cols-4 sm:gap-4 sm:px-6">
+//       <dt className="font-medium text-gray-500 dark:text-white" title={title}>{label}:</dt>
+//       <dd className="mt-1 text-gray-900 dark:text-white sm:mt-0 sm:col-span-2 break-all">
+//         <span className="px-1 py-0.5 bg-gray-700 rounded shadow">{value}</span>
+//         {unit &&
+//           <span className="ml-1 text-sm text-gray-800 dark:text-gray-400">{unit}</span>
+//         }
+//       </dd>
+//     </div>
+//   );
+// };
 
 const RowItemVersion = ({ label, value, title, newUpdate }: RowItemProps) => {
   if (!value) {

--- a/web/src/screens/settings/Feed.tsx
+++ b/web/src/screens/settings/Feed.tsx
@@ -132,7 +132,7 @@ function FeedSettings() {
                   Last run <span className="sort-indicator">{sortedFeeds.getSortIndicator("last_run")}</span>
                 </div>
               </li>
-              {sortedFeeds.items.map((feed, idx) => (
+              {sortedFeeds.items.map((feed) => (
                 <ListItem key={feed.id} feed={feed}/>
               ))}
             </ol>

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -25,7 +25,7 @@ import { EmptySimple } from "@components/emptystates";
 import { DeleteModal } from "@components/modals";
 import Toast from "@components/notifications/Toast";
 import { SettingsContext } from "@utils/Context";
-import { useForm } from "react-hook-form";
+// import { useForm } from "react-hook-form";
 
 export const ircKeys = {
   all: ["irc_networks"] as const,
@@ -586,9 +586,9 @@ type IrcEvent = {
   time: string;
 };
 
-type IrcMsg = {
-  msg: string;
-};
+// type IrcMsg = {
+//   msg: string;
+// };
 
 interface EventsProps {
   network: IrcNetwork;
@@ -606,27 +606,27 @@ export const Events = ({ network, channel }: EventsProps) => {
   //   messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end", inline: "end" });
   // };
 
-  const { handleSubmit, register , resetField } = useForm<IrcMsg>({
-    defaultValues: { msg: ""  },
-    mode: "onBlur"
-  });
+  // const { handleSubmit, register , resetField } = useForm<IrcMsg>({
+  //   defaultValues: { msg: ""  },
+  //   mode: "onBlur"
+  // });
 
-  const cmdMutation = useMutation({
-    mutationFn: (data: SendIrcCmdRequest) => APIClient.irc.sendCmd(data),
-    onSuccess: (_, variables) => {
-      resetField("msg");
-    },
-    onError: () => {
-      toast.custom((t) => (
-        <Toast type="error" body="Error sending IRC cmd" t={t} />
-      ));
-    }
-  });
+  // const cmdMutation = useMutation({
+  //   mutationFn: (data: SendIrcCmdRequest) => APIClient.irc.sendCmd(data),
+  //   onSuccess: (_, _variables) => {
+  //     resetField("msg");
+  //   },
+  //   onError: () => {
+  //     toast.custom((t) => (
+  //       <Toast type="error" body="Error sending IRC cmd" t={t} />
+  //     ));
+  //   }
+  // });
 
-  const onSubmit = (msg: IrcMsg) => {
-    const payload = { network_id: network.id, nick: network.nick, server: network.server, channel: channel, msg: msg.msg };
-    cmdMutation.mutate(payload);
-  };
+  // const onSubmit = (msg: IrcMsg) => {
+  //   const payload = { network_id: network.id, nick: network.nick, server: network.server, channel: channel, msg: msg.msg };
+  //   cmdMutation.mutate(payload);
+  // };
 
   useEffect(() => {
     const key = `${network.id}${channel.replace("#", "")}`;


### PR DESCRIPTION
I know we dont need to be crazy about linting rules... but...

The idea is to allow the use of `_` or `_myVariable` when you **really** need an unused variable (like for skip a paramether) this way eslint wont complaing to you

There are more files to be updated but those files is being touched in another MR so I prefer to leave out for now avoiding possible conflict.