### PR TITLE
feat(downloadclients): Porla support preset

### DIFF
--- a/internal/action/porla.go
+++ b/internal/action/porla.go
@@ -64,12 +64,19 @@ func (s *service) porla(ctx context.Context, action *domain.Action, release doma
 		uploadLimit = &ulValue
 	}
 
+	var preset *string = nil
+
+	if action.Label != "" {
+		preset = &action.Label
+	}
+
 	if release.HasMagnetUri() {
 		opts := &porla.TorrentsAddReq{
 			DownloadLimit: downloadLimit,
 			MagnetUri:     release.MagnetURI,
 			SavePath:      action.SavePath,
 			UploadLimit:   uploadLimit,
+			Preset:        preset,
 		}
 
 		if err = prl.TorrentsAdd(ctx, opts); err != nil {
@@ -103,6 +110,7 @@ func (s *service) porla(ctx context.Context, action *domain.Action, release doma
 			SavePath:      action.SavePath,
 			Ti:            base64.StdEncoding.EncodeToString(content),
 			UploadLimit:   uploadLimit,
+			Preset:        preset,
 		}
 
 		if err = prl.TorrentsAdd(ctx, opts); err != nil {

--- a/internal/action/porla.go
+++ b/internal/action/porla.go
@@ -51,20 +51,25 @@ func (s *service) porla(ctx context.Context, action *domain.Action, release doma
 		return rejections, nil
 	}
 
+	var downloadLimit *int64 = nil
+	var uploadLimit *int64 = nil
+
+	if action.LimitDownloadSpeed > 0 {
+		dlValue := action.LimitDownloadSpeed * 1000
+		downloadLimit = &dlValue
+	}
+
+	if action.LimitUploadSpeed > 0 {
+		ulValue := action.LimitUploadSpeed * 1000
+		uploadLimit = &ulValue
+	}
+
 	if release.HasMagnetUri() {
 		opts := &porla.TorrentsAddReq{
-			DownloadLimit: -1,
-			UploadLimit:   -1,
-			SavePath:      action.SavePath,
+			DownloadLimit: downloadLimit,
 			MagnetUri:     release.MagnetURI,
-		}
-
-		if action.LimitDownloadSpeed > 0 {
-			opts.DownloadLimit = action.LimitDownloadSpeed * 1000
-		}
-
-		if action.LimitUploadSpeed > 0 {
-			opts.UploadLimit = action.LimitUploadSpeed * 1000
+			SavePath:      action.SavePath,
+			UploadLimit:   uploadLimit,
 		}
 
 		if err = prl.TorrentsAdd(ctx, opts); err != nil {
@@ -94,18 +99,10 @@ func (s *service) porla(ctx context.Context, action *domain.Action, release doma
 		}
 
 		opts := &porla.TorrentsAddReq{
-			DownloadLimit: -1,
+			DownloadLimit: downloadLimit,
 			SavePath:      action.SavePath,
 			Ti:            base64.StdEncoding.EncodeToString(content),
-			UploadLimit:   -1,
-		}
-
-		if action.LimitDownloadSpeed > 0 {
-			opts.DownloadLimit = action.LimitDownloadSpeed * 1000
-		}
-
-		if action.LimitUploadSpeed > 0 {
-			opts.UploadLimit = action.LimitUploadSpeed * 1000
+			UploadLimit:   uploadLimit,
 		}
 
 		if err = prl.TorrentsAdd(ctx, opts); err != nil {

--- a/pkg/porla/client.go
+++ b/pkg/porla/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/autobrr/autobrr/pkg/jsonrpc"
@@ -75,9 +76,15 @@ func NewClient(cfg Config) *Client {
 		Transport: customTransport,
 	}
 
+	token := cfg.AuthToken
+
+	if !strings.HasPrefix(token, "Bearer ") {
+		token = "Bearer " + token
+	}
+
 	c.rpcClient = jsonrpc.NewClientWithOpts(cfg.Hostname+"/api/v1/jsonrpc", &jsonrpc.ClientOpts{
 		Headers: map[string]string{
-			"X-Porla-Token": cfg.AuthToken,
+			"X-Porla-Token": token,
 		},
 		HTTPClient: httpClient,
 		BasicUser:  cfg.BasicUser,

--- a/pkg/porla/domain.go
+++ b/pkg/porla/domain.go
@@ -13,11 +13,11 @@ type SysVersionsPorla struct {
 }
 
 type TorrentsAddReq struct {
-	DownloadLimit int64  `json:"download_limit,omitempty"`
+	DownloadLimit *int64 `json:"download_limit,omitempty"`
 	SavePath      string `json:"save_path,omitempty"`
 	Ti            string `json:"ti,omitempty"`
 	MagnetUri     string `json:"magnet_uri,omitempty"`
-	UploadLimit   int64  `json:"upload_limit,omitempty"`
+	UploadLimit   *int64 `json:"upload_limit,omitempty"`
 }
 
 type TorrentsAddRes struct {

--- a/pkg/porla/domain.go
+++ b/pkg/porla/domain.go
@@ -13,11 +13,12 @@ type SysVersionsPorla struct {
 }
 
 type TorrentsAddReq struct {
-	DownloadLimit *int64 `json:"download_limit,omitempty"`
-	SavePath      string `json:"save_path,omitempty"`
-	Ti            string `json:"ti,omitempty"`
-	MagnetUri     string `json:"magnet_uri,omitempty"`
-	UploadLimit   *int64 `json:"upload_limit,omitempty"`
+	DownloadLimit *int64  `json:"download_limit,omitempty"`
+	SavePath      string  `json:"save_path,omitempty"`
+	Ti            string  `json:"ti,omitempty"`
+	MagnetUri     string  `json:"magnet_uri,omitempty"`
+	UploadLimit   *int64  `json:"upload_limit,omitempty"`
+	Preset        *string `json:"preset,omitempty"`
 }
 
 type TorrentsAddRes struct {

--- a/web/src/screens/filters/action.tsx
+++ b/web/src/screens/filters/action.tsx
@@ -476,6 +476,15 @@ const TypeForm = ({ action, idx, clients }: TypeFormProps) => {
           </div>
         </div>
 
+        <div className="mt-6 grid grid-cols-12 gap-6">
+          <TextField
+            name={`actions.${idx}.label`}
+            label="Preset"
+            columns={6}
+            placeholder="eg. default"
+            tooltip={<div>A case-sensitive preset name as configured in Porla.</div>} />
+        </div>
+
         <CollapsableSection title="Rules" subtitle="client options">
           <div className="col-span-12">
             <div className="mt-6 grid grid-cols-12 gap-6">


### PR DESCRIPTION
Some improvements to the Porla integration,

- Omit download and upload limits completely if they're set to 0.
- Prefix JWT with `Bearer ` if not already specified.
- Allow setting a preset.

Re: the preset changes - I'm reusing the label field from other clients since we don't have that concept in Porla and it seemed easier than introducing a whole new field. Lemme know if this was bad 😃

Also, I'm not sure of the idiomatic Golang way of handling pointers when I want nil, specifically the download and upload limits. If there's a better way, I'm all for it.