### PR TITLE
feat(indexers): add freeleech support for TS

### DIFF
--- a/internal/indexer/definitions/torrentseeds.yaml
+++ b/internal/indexer/definitions/torrentseeds.yaml
@@ -59,7 +59,7 @@ irc:
     lines:
       - test:
           - "New: This.Is.A.New.show.S00E00.720p.WEB.H264-Test .:. Category: TV/HD .:. Size: 706.15 MiB .:. URL:  https://www.torrentseeds.org/torrents/0000000 .:. Uploaded by: George."
-        pattern: 'New: (.+) \.:\. Category: (.+) \.:\. Size: (.+) \.:\. URL:  (https?\:\/\/.+\/).+/(\d+) \.:\. Uploaded by: (.*)\.'
+        pattern: 'New: (.+) \.:\. Category: (.+) \.:\. Size: (.+) \.:\. URL:  (https?\:\/\/.+\/).+/(\d+) \.:\. Uploaded by: (\w+)\s?(FREELEECH)?.*'
         vars:
           - torrentName
           - category
@@ -67,6 +67,7 @@ irc:
           - baseUrl
           - torrentId
           - uploader
+          - freeleech
 
     match:
       infourl: "/torrents/{{ .torrentId }}"


### PR DESCRIPTION
This PR adds freeleech to the regex and the vars for new TS announce format.

Since there is no seperator between the username and freeleech,
i had to get a bit creative and need to change the group for the uploader var to `\w` which is the character class `[a-zA-Z0-9_]`.
Hope this doesn't come back to get us, but i didn't see usernames with any other characters upon a quick look.

https://regex101.com/r/Y3n2Vu/1