### PR TITLE
fix(irc): view channel history

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -547,7 +547,9 @@ func (h *Handler) onNick(msg ircmsg.Message) {
 }
 
 func (h *Handler) publishSSEMsg(msg domain.IrcMessage) {
-	h.sse.Publish(fmt.Sprintf("%d%s", h.network.ID, strings.TrimPrefix(msg.Channel, "#")), &sse.Event{
+	key := genSSEKey(h.network.ID, msg.Channel)
+
+	h.sse.Publish(key, &sse.Event{
 		Data: msg.Bytes(),
 	})
 }

--- a/internal/irc/service.go
+++ b/internal/irc/service.go
@@ -5,6 +5,7 @@ package irc
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"sync"
@@ -638,7 +639,7 @@ func (s *service) SendCmd(ctx context.Context, req *domain.SendIrcCmdRequest) er
 }
 
 func (s *service) createSSEStream(networkId int64, channel string) {
-	key := fmt.Sprintf("%d%s", networkId, strings.TrimPrefix(channel, "#"))
+	key := genSSEKey(networkId, channel)
 
 	s.sse.CreateStreamWithOpts(key, sse.StreamOpts{
 		MaxEntries: sseMaxEntries,
@@ -647,7 +648,11 @@ func (s *service) createSSEStream(networkId int64, channel string) {
 }
 
 func (s *service) removeSSEStream(networkId int64, channel string) {
-	key := fmt.Sprintf("%d%s", networkId, strings.TrimPrefix(channel, "#"))
+	key := genSSEKey(networkId, channel)
 
 	s.sse.RemoveStream(key)
+}
+
+func genSSEKey(networkId int64, channel string) string {
+	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%d%s", networkId, strings.ToLower(channel))))
 }

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -629,7 +629,7 @@ export const Events = ({ network, channel }: EventsProps) => {
   };
 
   useEffect(() => {
-    const key = `${network.id}${channel.replace("#", "")}`;
+    const key = btoa(`${network.id}${channel.toLowerCase()}`);
     const es = APIClient.irc.events(key);
 
     es.onmessage = (event) => {


### PR DESCRIPTION
Fixes an issue with some IRC channels not showing any messages.

Not sure exactly why this was, but making the SSE stream key a base64 encoded string fixed it.

Fixes #985