### PR TITLE
fix(irc): urlencode SSEKey for SSE streams

### DIFF
--- a/internal/irc/service.go
+++ b/internal/irc/service.go
@@ -654,5 +654,5 @@ func (s *service) removeSSEStream(networkId int64, channel string) {
 }
 
 func genSSEKey(networkId int64, channel string) string {
-	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%d%s", networkId, strings.ToLower(channel))))
+	return base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf("%d%s", networkId, strings.ToLower(channel))))
 }

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -629,7 +629,11 @@ export const Events = ({ network, channel }: EventsProps) => {
   };
 
   useEffect(() => {
-    const key = btoa(`${network.id}${channel.toLowerCase()}`);
+    // Following RFC4648
+    const key = window.btoa(`${network.id}${channel.toLowerCase()}`)
+      .replaceAll("+", "-")
+      .replaceAll("/", "_")
+      .replaceAll("=", "");
     const es = APIClient.irc.events(key);
 
     es.onmessage = (event) => {


### PR DESCRIPTION
Apply RFC4648 to base64 sseKey to fix urlEncoding of SSE stream key.