### PR TITLE
feat(filter): add rejection on invalid size set

### DIFF
--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -551,7 +551,7 @@ func (f Filter) checkSizeFilter(r *Release, minSize string, maxSize string) bool
 		// string to bytes
 		minSizeBytes, err := humanize.ParseBytes(minSize)
 		if err != nil {
-			// log could not parse into bytes
+			r.addRejection("size: invalid minSize set")
 		}
 
 		if r.Size <= minSizeBytes {
@@ -565,7 +565,7 @@ func (f Filter) checkSizeFilter(r *Release, minSize string, maxSize string) bool
 		// string to bytes
 		maxSizeBytes, err := humanize.ParseBytes(maxSize)
 		if err != nil {
-			// log could not parse into bytes
+			r.addRejection("size: invalid maxSize set")
 		}
 
 		if r.Size >= maxSizeBytes {

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -551,7 +551,8 @@ func (f Filter) checkSizeFilter(r *Release, minSize string, maxSize string) bool
 		// string to bytes
 		minSizeBytes, err := humanize.ParseBytes(minSize)
 		if err != nil {
-			r.addRejection("size: invalid minSize set")
+			r.addRejectionF("size: invalid minSize set: %s err: %q", minSize, err)
+			return false
 		}
 
 		if r.Size <= minSizeBytes {
@@ -565,7 +566,8 @@ func (f Filter) checkSizeFilter(r *Release, minSize string, maxSize string) bool
 		// string to bytes
 		maxSizeBytes, err := humanize.ParseBytes(maxSize)
 		if err != nil {
-			r.addRejection("size: invalid maxSize set")
+			r.addRejectionF("size: invalid maxSize set: %s err: %q", maxSize, err)
+			return false
 		}
 
 		if r.Size >= maxSizeBytes {


### PR DESCRIPTION
If user sets a min or max size without specifying a unit, the rejection returns blank