### PR TITLE
fix(web): view button alignment in irc settings

### DIFF
--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -416,7 +416,7 @@ const ChannelItem = ({ network, channel }: ChannelItemProps) => {
             {IsEmptyDate(channel.last_announce)}
           </span>
         </div>
-        <div className="col-span-1 flex items-center">
+        <div className="col-span-1 flex items-center justify-end">
           <button className="hover:text-gray-500 px-2 py-1 dark:bg-gray-800 rounded dark:border-gray-900">
             {viewChannel ? "Hide" : "View"}
           </button>


### PR DESCRIPTION
This PR fixes the View button on the IRC settings page sticking out to the right if the viewport is too narrow.

Old:
![image](https://github.com/autobrr/autobrr/assets/35452459/58a14aac-c9cc-4e4e-9c87-49f098416dbe)

New:
![image](https://github.com/autobrr/autobrr/assets/35452459/db90eae3-2b26-4f74-865c-2f19251030c7)
