### PR TITLE
fix(web): set theme before app loads

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,6 +25,10 @@
     <script>
       window.APP = {};
       window.APP.baseUrl = "{{.BaseUrl}}";
+
+      const browserPrefers = !(window.matchMedia !== undefined && window.matchMedia("(prefers-color-scheme: light)").matches);
+      const { darkTheme = browserPrefers } = JSON.parse(localStorage.getItem("settings")) || {};
+      document.documentElement.classList.toggle("dark", darkTheme);
     </script>
   </head>
   <body class="bg-color">

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -72,12 +72,7 @@ export const SettingsContext = newRidgeState<SettingsType>(
   {
     onSet: (new_state) => {
       try {
-        if (new_state.darkTheme) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
-
+        document.documentElement.classList.toggle("dark", new_state.darkTheme);
         localStorage.setItem("settings", JSON.stringify(new_state));
       } catch (e) {
         console.log("An error occurred while trying to modify the local settings context state.");


### PR DESCRIPTION
It have been report on #1016 that firefox is flashing on dark theme.

This happens because the whole js is needed to set the user theme and Firefox likes to play as faster guy so the css renders first with default styles.

My idea was to quickly read the user theme and apply, setting the dark class ready there for the styles.

We know that is dangerous to use `JSON.parse` without try catch because it throws exception and stop execution, but I also notice theres not many places doing try/catch for the localStorage values as well. 