### PR TITLE
fix(releases): bad postgres fk migration

### DIFF
--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -707,7 +707,10 @@ ADD COLUMN use_bouncer BOOLEAN DEFAULT FALSE;
 ALTER TABLE irc_network
 ADD COLUMN bouncer_addr TEXT;`,
 	`ALTER TABLE release_action_status
-    DROP CONSTRAINT release_action_status_action_id_fkey;
+    DROP CONSTRAINT IF EXISTS release_action_status_action_id_fkey;
+         
+ALTER TABLE release_action_status
+    DROP CONSTRAINT IF EXISTS release_action_status_action_id_fk;
 
 ALTER TABLE release_action_status
     ADD FOREIGN KEY (action_id) REFERENCES action


### PR DESCRIPTION
Different naming of foreign key constraints led to failing migrations.

This adds `IF EXISTS` check and the other naming variant which should fix the issue.

Reporters @jpalenz77 and @BaukeZwart