### PR TITLE
build(docker): improve cache on web-builder stage

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -55,6 +55,7 @@
     "formik": "^2.4.3",
     "http-proxy-middleware": "^2.0.6",
     "postcss": "^8.4.27",
+    "postcss-import": "^15.1.0",
     "react": "^18.2.0",
     "react-debounce-input": "^3.3.0",
     "react-dom": "^18.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "homepage": ".",
-  "packageManager": "pnpm@8.6.2",
+  "packageManager": "pnpm@8.6.11",
   "scripts": {
     "start": "vite",
     "build": "tsc && vite build",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -86,6 +86,9 @@ dependencies:
   postcss:
     specifier: ^8.4.27
     version: 8.4.27
+  postcss-import:
+    specifier: ^15.1.0
+    version: 15.1.0(postcss@8.4.27)
   react:
     specifier: ^18.2.0
     version: 18.2.0

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,8 +1,8 @@
-module.exports = {  
-    plugins: {
-      "postcss-import": {},
-      "tailwindcss/nesting": {},
-      tailwindcss: {},    
-      autoprefixer: {},  
-    }
-  }
+module.exports = {
+  plugins: {
+    "postcss-import": {},
+    "tailwindcss/nesting": {},
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
The idea is that we improve the Docker cache layers on the web-builder.

If theres no changes on package.json or pnpm-lock, we dont need to run the install command.

This is the similar that we already have implemented on the app-builder stage.