### PR TITLE
fix(indexers): IRC URL for Sharewood

### DIFF
--- a/internal/indexer/definitions/sharewood.yaml
+++ b/internal/indexer/definitions/sharewood.yaml
@@ -20,7 +20,7 @@ settings:
 
 irc:
   network: HiddenForest
-  server: irc.hiddenforest.ml
+  server: hiddenforest.joe.dj
   port: 7000
   tls: true
   channels:

--- a/internal/indexer/definitions/sharewood.yaml
+++ b/internal/indexer/definitions/sharewood.yaml
@@ -26,7 +26,7 @@ irc:
   channels:
     - "#rss"
   announcers:
-    - Lana
+    - lana
   settings:
     - name: nick
       type: text


### PR DESCRIPTION
Sharewood URL has been changed recently. This updates the IRC URL for newly created connections