### PR TITLE
fix(indexers): remove nickserv options for AlphaRatio

### DIFF
--- a/internal/indexer/definitions/alpharatio.yaml
+++ b/internal/indexer/definitions/alpharatio.yaml
@@ -41,18 +41,6 @@ irc:
       label: Nick
       help: Bot nick. Eg. user_bot
 
-    - name: auth.account
-      type: text
-      required: true
-      label: NickServ Account
-      help: NickServ account. Make sure to group your main user and bot.
-
-    - name: auth.password
-      type: secret
-      required: true
-      label: NickServ Password
-      help: NickServ password
-
     - name: invite_command
       type: secret
       default: "Voyager autobot USERNAME IRCKEY"


### PR DESCRIPTION
AR got rid of NickServ completely on their IRC, but we still have NickServ as a requirement for them.
I would propose to get rid of the NickServ fields completely to avoid complications.