### PR TITLE
fix(indexers): MTV announce regex pattern

### DIFF
--- a/internal/indexer/definitions/morethantv.yaml
+++ b/internal/indexer/definitions/morethantv.yaml
@@ -58,7 +58,7 @@ irc:
     lines:
       - test:
           - "TV.Show.2008.720p.BluRay.DTS.x264-TEST - Size: 6.56 GiB - Uploader: Test - Tags: autoup,h264,hd,dts.audio,bluray,720p,p2p.group.release,Test.release,hd.movie - https://www.morethantv.me/torrents.php?torrentid=000000"
-        pattern: '(.+) - Size: (.+) - Uploader: (.+) - Tags: (.+(hd.episode|hd.season|sd.episode|sd.season|sd.movie|hd.movie)) - (https?:\/\/.+\/)torrents.php\?torrentid=(\d+)'
+        pattern: '(.*) - Size: (.*) - Uploader: (.*) - Tags: (.*(hd.episode|hd.season|sd.episode|sd.season|sd.movie|hd.movie).*) - (https?:\/\/.+\/)torrents.php\?torrentid=(\d+)'
         vars:
           - torrentName
           - torrentSize


### PR DESCRIPTION
They changed something in their announce regarding tags. This fixes that thanks to @martylukyy 

New: https://regex101.com/r/F565KE/1
Old: https://regex101.com/r/dll2hL/1