### PR TITLE
enhancement(web): IRC logs view

### DIFF
--- a/web/src/components/Checkbox.tsx
+++ b/web/src/components/Checkbox.tsx
@@ -15,7 +15,7 @@ interface CheckboxProps {
 export const Checkbox = ({ label, description, value, setValue }: CheckboxProps) => (
   <Switch.Group as="li" className="py-4 flex items-center justify-between">
     <div className="flex flex-col">
-      <Switch.Label as="p" className="text-sm font-medium text-gray-900 dark:text-white" passive>
+      <Switch.Label as="p" className="text-sm font-medium whitespace-nowrap text-gray-900 dark:text-white" passive>
         {label}
       </Switch.Label>
       {description === undefined ? null : (

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -630,9 +630,13 @@ export const Events = ({ network, channel }: EventsProps) => {
 
   const [logs, setLogs] = useState<IrcEvent[]>([]);
 
-  // const scrollToBottom = () => {
-  //   messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end", inline: "end" });
-  // };
+  const scrollToBottom = () => {
+    setTimeout(() => {
+      if (messagesEndRef.current) {
+        messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
+      }
+    }, 0);
+  };
 
   // const { handleSubmit, register , resetField } = useForm<IrcMsg>({
   //   defaultValues: { msg: ""  },
@@ -669,7 +673,7 @@ export const Events = ({ network, channel }: EventsProps) => {
       setLogs((prevState) => [...prevState, newData]);
 
       // if (settings.scrollOnNewLog)
-      //   scrollToBottom();
+      scrollToBottom();
     };
 
     return () => es.close();
@@ -699,8 +703,9 @@ export const Events = ({ network, channel }: EventsProps) => {
           "overflow-y-auto rounded-lg min-w-full bg-gray-100 dark:bg-gray-900 overflow-auto",
           isFullscreen ? "max-w-full h-full p-2 border-gray-300 dark:border-gray-700" : "px-2 py-1 aspect-[2/1]"
         )}
+        ref={messagesEndRef}
       >
-        {logs.slice().reverse().map((entry, idx) => (
+        {logs.map((entry, idx) => (
           <div
             key={idx}
             className={classNames(
@@ -711,7 +716,6 @@ export const Events = ({ network, channel }: EventsProps) => {
             <span className="font-mono text-gray-500 dark:text-gray-500 mr-1"><span className="dark:text-gray-600"><span className="dark:text-gray-700">[{simplifyDate(entry.time)}]</span> {entry.nick}:</span> {entry.msg}</span>
           </div>
         ))}
-        <div className="mt-6" ref={messagesEndRef} />
       </div>
 
       {/*<div>*/}

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -417,7 +417,7 @@ const ChannelItem = ({ network, channel }: ChannelItemProps) => {
           </span>
         </div>
         <div className="col-span-1 flex items-center justify-end">
-          <button className="hover:text-gray-500 px-2 py-1 dark:bg-gray-800 rounded dark:border-gray-900">
+          <button className="hover:text-gray-500 px-2 mx-2 py-1 dark:bg-gray-800 rounded dark:border-gray-900">
             {viewChannel ? "Hide" : "View"}
           </button>
         </div>
@@ -700,7 +700,7 @@ export const Events = ({ network, channel }: EventsProps) => {
           isFullscreen ? "max-w-full h-full p-2 border-gray-300 dark:border-gray-700" : "px-2 py-1 aspect-[2/1]"
         )}
       >
-        {logs.map((entry, idx) => (
+        {logs.slice().reverse().map((entry, idx) => (
           <div
             key={idx}
             className={classNames(
@@ -708,7 +708,7 @@ export const Events = ({ network, channel }: EventsProps) => {
               settings.hideWrappedText ? "truncate hover:text-ellipsis hover:whitespace-normal" : ""
             )}
           >
-            <span className="font-mono text-gray-500 dark:text-gray-500 mr-1"><span className="dark:text-gray-600" title={simplifyDate(entry.time)}>{entry.nick}:</span> {entry.msg}</span>
+            <span className="font-mono text-gray-500 dark:text-gray-500 mr-1"><span className="dark:text-gray-600"><span className="dark:text-gray-700">[{simplifyDate(entry.time)}]</span> {entry.nick}:</span> {entry.msg}</span>
           </div>
         ))}
         <div className="mt-6" ref={messagesEndRef} />

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -10,7 +10,8 @@ import { Menu, Switch, Transition } from "@headlessui/react";
 import { toast } from "react-hot-toast";
 import {
   ArrowsPointingInIcon,
-  ArrowsPointingOutIcon, Cog6ToothIcon,
+  ArrowsPointingOutIcon,
+  Cog6ToothIcon,
   EllipsisHorizontalIcon,
   ExclamationCircleIcon,
   PencilSquareIcon,


### PR DESCRIPTION
This PR now implements auto scrolling for IRC logs.
Sorting is now newest at the bottom again and you start out scrolled all the way down when the setting is activated.
Additionally I added the timestamp to the logs because in one case I wanted to see the timestamps at a glance instead of moving the mouse over the different entries.
I am not too worried about it there being to much information in for a single entry since we have the fullscreen view too.
Also, I added some margin to the show/hide button because it looked crowded.

I noticed when `settings.scrollOnNewLog` gets changed it loads the entire map again..
To circumvent duplicate entries it will now clear the div once, resulting in resetting the position to the top of the div or respectively the bottom of the div depending on the value of `settings.scrollOnNewLog` .
If someone has a better way of handling this please ping me on discord or comment here.