### PR TITLE
fix(web): autoscrolling for Logs page

### DIFF
--- a/web/src/screens/Logs.tsx
+++ b/web/src/screens/Logs.tsx
@@ -52,13 +52,20 @@ export const Logs = () => {
   const [filteredLogs, setFilteredLogs] = useState<LogEvent[]>([]);
   const [isInvalidRegex, setIsInvalidRegex] = useState(false);
 
-  const scrollToBottom = () => {
-    setTimeout(() => {
+  useEffect(() => {
+    const scrollToBottom = () => {
       if (messagesEndRef.current) {
         messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
       }
-    }, 10);
-  };
+    };
+    if (settings.scrollOnNewLog)
+      scrollToBottom();
+  }, [filteredLogs]);
+
+  // Add a useEffect to clear logs div when settings.scrollOnNewLog changes to prevent duplicate entries.
+  useEffect(() => {
+    setLogs([]);
+  }, [settings.scrollOnNewLog]);
 
   useEffect(() => {
     const es = APIClient.events.logs();
@@ -66,9 +73,6 @@ export const Logs = () => {
     es.onmessage = (event) => {
       const newData = JSON.parse(event.data) as LogEvent;
       setLogs((prevState) => [...prevState, newData]);
-
-      if (settings.scrollOnNewLog)
-        scrollToBottom();
     };
 
     return () => es.close();

--- a/web/src/screens/Logs.tsx
+++ b/web/src/screens/Logs.tsx
@@ -53,7 +53,11 @@ export const Logs = () => {
   const [isInvalidRegex, setIsInvalidRegex] = useState(false);
 
   const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end", inline: "end" });
+    setTimeout(() => {
+      if (messagesEndRef.current) {
+        messagesEndRef.current.scrollTop = messagesEndRef.current.scrollHeight;
+      }
+    }, 10);
   };
 
   useEffect(() => {
@@ -122,7 +126,7 @@ export const Logs = () => {
             <LogsDropdown />
           </div>
 
-          <div className="overflow-y-auto px-2 rounded-lg h-[60vh] min-w-full bg-gray-100 dark:bg-gray-900 overflow-auto">
+          <div className="overflow-y-auto px-2 rounded-lg h-[60vh] min-w-full bg-gray-100 dark:bg-gray-900 overflow-auto" ref={messagesEndRef}>
             {filteredLogs.map((entry, idx) => (
               <div
                 key={idx}
@@ -153,7 +157,6 @@ export const Logs = () => {
                 </span>
               </div>
             ))}
-            <div className="mt-6" ref={messagesEndRef} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR fixes the autoscrolling issues we had on the Logs page.

I noticed when settings.scrollOnNewLog gets changed it loads the entire map again..
To circumvent duplicate entries it will now clear the div once, resulting in resetting the position to the top of the div or respectively the bottom of the div depending on the value of settings.scrollOnNewLog .
If someone has a better way of handling this please ping me on discord or comment here.