### PR TITLE
ci: back-off Dependabot to monthly due to spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,7 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
-      day: saturday
-      time: "07:30"
+      interval: monthly
     groups:
       golang:
         patterns:
@@ -25,9 +23,7 @@ updates:
   - package-ecosystem: npm
     directory: /web
     schedule:
-      interval: weekly
-      day: saturday
-      time: "08:00"
+      interval: monthly
     groups:
       npm:
         patterns:


### PR DESCRIPTION
Way too much churn in golang and npm unfortunately. Turning this down for the health of the project until such a time that dependabot is ready.

https://github.com/dependabot/dependabot-core/issues/2264