### PR TITLE
ci: add eslint step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ jobs:
         working-directory: web
         run: pnpm install --frozen-lockfile
 
+      - name: ESLint
+        working-directory: web
+        continue-on-error: true
+        run: CI= pnpm run lint
+
       - name: Build web frontend
         working-directory: web
         run: CI= pnpm run build


### PR DESCRIPTION
With the allow-to-failure it dont even raise a warn flag... if we want to fail we need to be more responsable... dont know if is a good idea