### PR TITLE
build(deps): bump go-deluge to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/anacrolix/torrent v1.52.5
 	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef
-	github.com/autobrr/go-deluge v1.0.1
+	github.com/autobrr/go-deluge v1.1.0
 	github.com/autobrr/go-qbittorrent v1.3.3
 	github.com/autobrr/go-rtorrent v1.10.0
 	github.com/avast/retry-go v3.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef h1:2JGTg6JapxP9/R33ZaagQtAM4EkkSYnIAlOG5EI8gkM=
 github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
-github.com/autobrr/go-deluge v1.0.1 h1:JH2RJnWWaYvN/29KuajtRXS/HxQhAxOk4yq54pjnn68=
-github.com/autobrr/go-deluge v1.0.1/go.mod h1:ndiXT1eHWv/ATNk9TpE8GHIs8OSSUnsImt4Syk+y5LM=
+github.com/autobrr/go-deluge v1.1.0 h1:wT+FUxjNrYnUhOcZmZSIApCz4tT2n0FzXVfuvOBtcIM=
+github.com/autobrr/go-deluge v1.1.0/go.mod h1:ndiXT1eHWv/ATNk9TpE8GHIs8OSSUnsImt4Syk+y5LM=
 github.com/autobrr/go-qbittorrent v1.3.3 h1:kc48/hsmDgbrTVtlsNc7qXIQrDCkZ6CdBYQVtprU5l0=
 github.com/autobrr/go-qbittorrent v1.3.3/go.mod h1:z88B3+O/1/3doQABErvIOOxE4hjpmIpulu6XzDG/q78=
 github.com/autobrr/go-rtorrent v1.10.0 h1:SCs7Rdi1BZ3MxNoVIdWK0qTUHQyhSj9rEU8KUTRi4Ug=


### PR DESCRIPTION
Bump go-deluge to v1.1.0 to fix issues.