### PR TITLE
feat(downloadclients): arrs increase timeout for release/push

### DIFF
--- a/pkg/lidarr/lidarr.go
+++ b/pkg/lidarr/lidarr.go
@@ -44,7 +44,7 @@ type client struct {
 func New(config Config) Client {
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 30,
+		Timeout: time.Second * 120,
 	}
 
 	c := &client{

--- a/pkg/radarr/radarr.go
+++ b/pkg/radarr/radarr.go
@@ -43,7 +43,7 @@ type client struct {
 func New(config Config) Client {
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 30,
+		Timeout: time.Second * 120,
 	}
 
 	c := &client{

--- a/pkg/readarr/readarr.go
+++ b/pkg/readarr/readarr.go
@@ -45,7 +45,7 @@ type client struct {
 func New(config Config) Client {
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 30,
+		Timeout: time.Second * 120,
 	}
 
 	c := &client{

--- a/pkg/sonarr/sonarr.go
+++ b/pkg/sonarr/sonarr.go
@@ -45,7 +45,7 @@ type client struct {
 func New(config Config) Client {
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 30,
+		Timeout: time.Second * 120,
 	}
 
 	c := &client{

--- a/pkg/whisparr/whisparr.go
+++ b/pkg/whisparr/whisparr.go
@@ -42,7 +42,7 @@ type client struct {
 func New(config Config) Client {
 
 	httpClient := &http.Client{
-		Timeout: time.Second * 30,
+		Timeout: time.Second * 120,
 	}
 
 	c := &client{


### PR DESCRIPTION
For reasons unbeknownst to me, pushes can take lots of time before autobrr gets a return back. The pushes eventually succeed, but not before autobrr logs an error on the action as the connection has since "timed out". As these actions are run in a goroutine, we're not at risk of blocking main application activity, so just crank it.