### PR TITLE
ci: goreleaser lower parallelism to mitigate OOM issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --skip-validate --skip-publish --parallelism 99
+          args: release --clean --skip-validate --skip-publish --parallelism 5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
During testing and frustrations with the performance of a Linux node, it was found that Mac and Windows are significantly more powerful. This reverts a change from 99 to a more realistic number, as Windows nodes appear more stable, but have less memory available than Apple.