### PR TITLE
fix(releases): improve search keyword specifiers

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -135,7 +135,7 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 
 		search := strings.TrimSpace(params.Search)
 		for k, v := range reserved {
-			r := regexp.MustCompile(fmt.Sprintf(`(?:%s:)(?P<value>'.*?'|".*?"|\S+)`, k))
+			r := regexp.MustCompile(fmt.Sprintf(`(?i)(?:%s:)(?P<value>'.*?'|".*?"|\S+)`, k))
 			if reskey := r.FindAllStringSubmatch(search, -1); len(reskey) != 0 {
 				filter := sq.Or{}
 				for _, found := range reskey {


### PR DESCRIPTION
Now that there's full documentation for this on the page in-product, it's going to see more usage. This makes the keys case-insensitive (Season:9 is accepted, as opposed to just season:9) to help prevent reports of it "not working".