### PR TITLE
ci: fix docker metadata to parse semver tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,10 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/autobrr/autobrr
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
According to the docs [[1]](https://github.com/docker/metadata-action/tree/master?tab=readme-ov-file#tags-input), the default entry for tags is:

```
tags: |
  type=schedule
  type=ref,event=branch
  type=ref,event=tag
  type=ref,event=pr
```

But this **will not** parse the semver [[2]](https://github.com/docker/metadata-action/blob/master/src/meta.ts#L62) to match the pre-releases.

By set tags to `semver`, **it will** parses pre-releases [[3]](https://github.com/docker/metadata-action/blob/master/src/meta.ts#L66) and it **will not** set latest tag on them [[4]](https://github.com/docker/metadata-action/blob/master/src/meta.ts#L159-L168).

This MR also removes the ref event=tag because it is the one that will apply latest by default [[5]](https://github.com/docker/metadata-action/blob/master/src/meta.ts#L269). Using semver should already handle the tags versions making it not necessary.

This closes #1109 