### PR TITLE
ci(docker): change docker metadata tag to `{{raw}}` from `{{version}}`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           images: ghcr.io/autobrr/autobrr
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern={{raw}}
             type=ref,event=branch
             type=ref,event=pr
 


### PR DESCRIPTION
Ref https://github.com/docker/metadata-action?tab=readme-ov-file#typesemver

`{{version}}` was missing the v prefix for the tag that we have used since the start.