### PR TITLE
fix(downloadclient): Porla remove flags property

### DIFF
--- a/pkg/porla/domain.go
+++ b/pkg/porla/domain.go
@@ -42,7 +42,6 @@ type TorrentsListRes struct {
 type Torrent struct {
 	DownloadRate  int      `json:"download_rate"`
 	UploadRate    int      `json:"upload_rate"`
-	Flags         int      `json:"flags"`
 	InfoHash      []string `json:"info_hash"`
 	ListPeers     int      `json:"list_peers"`
 	ListSeeds     int      `json:"list_seeds"`


### PR DESCRIPTION
The `flags` property in the Porla `torrents.list` response has changed from an int to a string. Instead of breaking things, just remove the property in the serialization since it is unused.