### PR TITLE
fix(web): manually specify build targets instead of browserlist

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,18 +11,6 @@
     "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx --color",
     "lint:watch": "pnpm run lint -- --watch"
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
   "pnpm": {
     "overrides": {
       "react": "$react"

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,19 @@
     "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx --color",
     "lint:watch": "pnpm run lint -- --watch"
   },
+  "browserslist": {
+    "production": [
+      "iOS >= 13",
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
   "pnpm": {
     "overrides": {
       "react": "$react"
@@ -31,6 +44,7 @@
     "@types/react-table": "^7.7.15",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
+    "@vitejs/plugin-legacy": "^4.1.1",
     "@vitejs/plugin-react-swc": "^3.3.2",
     "autoprefixer": "^10.4.15",
     "buffer": "^6.0.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -50,6 +50,9 @@ dependencies:
   '@typescript-eslint/parser':
     specifier: ^6.5.0
     version: 6.5.0(eslint@8.48.0)(typescript@5.2.2)
+  '@vitejs/plugin-legacy':
+    specifier: ^4.1.1
+    version: 4.1.1(terser@5.19.3)(vite@4.4.9)
   '@vitejs/plugin-react-swc':
     specifier: ^3.3.2
     version: 3.3.2(vite@4.4.9)
@@ -142,7 +145,7 @@ dependencies:
     version: 5.2.2
   vite:
     specifier: ^4.4.9
-    version: 4.4.9(@types/node@20.5.9)
+    version: 4.4.9(@types/node@20.5.9)(terser@5.19.3)
   vite-plugin-pwa:
     specifier: ^0.16.4
     version: 0.16.4(vite@4.4.9)(workbox-build@7.0.0)(workbox-window@7.0.0)
@@ -2510,13 +2513,33 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: false
 
+  /@vitejs/plugin-legacy@4.1.1(terser@5.19.3)(vite@4.4.9):
+    resolution: {integrity: sha512-um3gbVouD2Q/g19C0qpDfHwveXDCAHzs8OC3e9g6aXpKoD1H14himgs7wkMnhAynBJy7QqUoZNAXDuqN8zLR2g==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      terser: ^5.4.0
+      vite: ^4.0.0
+    dependencies:
+      '@babel/core': 7.22.11
+      '@babel/preset-env': 7.22.14(@babel/core@7.22.11)
+      browserslist: 4.21.10
+      core-js: 3.32.2
+      magic-string: 0.30.3
+      regenerator-runtime: 0.13.11
+      systemjs: 6.14.2
+      terser: 5.19.3
+      vite: 4.4.9(@types/node@20.5.9)(terser@5.19.3)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@vitejs/plugin-react-swc@3.3.2(vite@4.4.9):
     resolution: {integrity: sha512-VJFWY5sfoZerQRvJrh518h3AcQt6f/yTuWn4/TRB+dqmYU0NX1qz7qM5Wfd+gOQqUzQW4gxKqKN3KpE/P3+zrA==}
     peerDependencies:
       vite: ^4
     dependencies:
       '@swc/core': 1.3.76
-      vite: 4.4.9(@types/node@20.5.9)
+      vite: 4.4.9(@types/node@20.5.9)(terser@5.19.3)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: false
@@ -2935,6 +2958,11 @@ packages:
     resolution: {integrity: sha512-GSvKDv4wE0bPnQtjklV101juQ85g6H3rm5PDP20mqlS5j0kXF3pP97YvAu5hl+uFHqMictp3b2VxOHljWMAtuA==}
     dependencies:
       browserslist: 4.21.10
+    dev: false
+
+  /core-js@3.32.2:
+    resolution: {integrity: sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==}
+    requiresBuild: true
     dev: false
 
   /cosmiconfig@7.1.0:
@@ -4305,6 +4333,13 @@ packages:
       sourcemap-codec: 1.4.8
     dev: false
 
+  /magic-string@0.30.3:
+    resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: false
+
   /memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
     dev: false
@@ -4938,6 +4973,10 @@ packages:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
     dev: false
 
+  /regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+    dev: false
+
   /regenerator-runtime@0.14.0:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
     dev: false
@@ -5311,6 +5350,10 @@ packages:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
     dev: false
 
+  /systemjs@6.14.2:
+    resolution: {integrity: sha512-1TlOwvKWdXxAY9vba+huLu99zrQURDWA8pUTYsRIYDZYQbGyK+pyEP4h4dlySsqo7ozyJBmYD20F+iUHhAltEg==}
+    dev: false
+
   /tailwindcss@3.3.3:
     resolution: {integrity: sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==}
     engines: {node: '>=14.0.0'}
@@ -5618,7 +5661,7 @@ packages:
       debug: 4.3.4
       fast-glob: 3.3.1
       pretty-bytes: 6.1.1
-      vite: 4.4.9(@types/node@20.5.9)
+      vite: 4.4.9(@types/node@20.5.9)(terser@5.19.3)
       workbox-build: 7.0.0
       workbox-window: 7.0.0
     transitivePeerDependencies:
@@ -5633,13 +5676,13 @@ packages:
       '@rollup/pluginutils': 5.0.2(rollup@2.79.1)
       '@svgr/core': 7.0.0
       '@svgr/plugin-jsx': 7.0.0
-      vite: 4.4.9(@types/node@20.5.9)
+      vite: 4.4.9(@types/node@20.5.9)(terser@5.19.3)
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: false
 
-  /vite@4.4.9(@types/node@20.5.9):
+  /vite@4.4.9(@types/node@20.5.9)(terser@5.19.3):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -5671,6 +5714,7 @@ packages:
       esbuild: 0.18.20
       postcss: 8.4.29
       rollup: 3.28.0
+      terser: 5.19.3
     optionalDependencies:
       fsevents: 2.3.3
     dev: false

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -9,7 +9,7 @@
     "types": ["vite/client"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -112,7 +112,22 @@ export default ({ mode }: ConfigEnv) => {
             return "assets/[name]-[hash][extname]";
           }
         }
-      }
+      },
+      //
+      // NOTE(stacksmash76):
+      // There isn't a nice way to pass browserslist to esbuild.
+      //
+      // One option is to use browserslist-to-esbuild package,
+      // but so far this seems to give incorrect results which leads
+      // to the transpiler erroring on unsupported features.
+      //
+      // Instead, the simplest thing to do is just flat out define
+      // relatively modern and recent minimally supported browser versions
+      // and use that as a pivotal point. This list can later be refreshed
+      // if there is ever such a need, but for the next year or so, it should suffice.
+      //
+      target: ["chrome79", "edge114", "firefox114", "ios13"],
+      cssTarget: ["chrome79", "edge114", "firefox114", "ios13"]
     }
   });
 };


### PR DESCRIPTION
get rid of browserlist for now, manually specify minimal targets via vite to esbuild