### PR TITLE
fix(web): font preloading

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#141415" />
     <meta name="description" content="autobrr" />
-    <link rel="preload" href="/Inter.var.woff2" as="font" type="font/woff2" crossorigin="use-credentials">
+    <link rel="preload" href="/Inter.var.woff2" as="font" type="font/woff2" crossorigin="anonymous">
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon-iphone-60x60.png" />
     <link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-ipad-76x76.png" />


### PR DESCRIPTION
This PR fixes the following console error for font preloading on certain systems.
```
A preload for 'https://example.com/autobrr/Inter.var.woff2' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
```

I tested this fix on my server to make sure it is working with subfolder installs since there were concerns about that.
Network tab in DevTools shows it successfully preloads the fonts without any error about this in the console.