### PR TITLE
fix(indexers): API get torrent check for nil body

### DIFF
--- a/internal/indexer/api.go
+++ b/internal/indexer/api.go
@@ -58,6 +58,10 @@ func (s *apiService) GetTorrentByID(ctx context.Context, indexer string, torrent
 		return nil, err
 	}
 
+	if torrent == nil {
+		return nil, errors.New("could not get torrent: %s from: %s", torrentID, indexer)
+	}
+
 	s.log.Trace().Str("method", "GetTorrentByID").Msgf("%s api successfully fetched torrent: %+v", indexer, torrent)
 
 	return torrent, nil


### PR DESCRIPTION
Add additional check for empty body from indexer API check for GetTorrentByID.

Depending on the response from the indexer it would only trigger rejection errors for certain errors. Found out that some responses answer with 200 OK but bad status body and those were not caught.