### PR TITLE
fix(indexers): SubsPlease parse line pattern

### DIFF
--- a/internal/indexer/definitions/subsplease.yaml
+++ b/internal/indexer/definitions/subsplease.yaml
@@ -47,7 +47,7 @@ irc:
     lines:
       - test: 
           - "[Release] [SubsPlease] Title - 01 (480p) [636F636B].mkv (420.69MB) - https://nyaa.si/view/0000000 - https://nyaa.si/view/0000000/torrent"
-      - pattern: '\[Release\] (.*(SubsPlease).*?)\.?(mkv)? \((\d+.?\d*[KMGTP]?B)\) - (.*) - (.*)'
+        pattern: '\[Release\] (.*(SubsPlease).*?)\.?(mkv)? \((\d+.?\d*[KMGTP]?B)\) - (.*) - (.*)'
         vars:
           - torrentName
           - releaseGroup


### PR DESCRIPTION
Some releases wouldn't parse, and the culprit was the `lines` part where `pattern` was set as `- pattern` and that made the `lines` be split in two, even though SubsPlease is using single lines for announce and not multiple.

ref #494 