### PR TITLE
fix(indexers): pbay regex pattern

### DIFF
--- a/internal/indexer/definitions/pbay.yaml
+++ b/internal/indexer/definitions/pbay.yaml
@@ -60,7 +60,7 @@ irc:
       - test:
           - "[XXX-Cateogry] [SomeXXXSite] Wow So Much Come [2015-05-30, 3K, 1500p] [4.77 GB - Uploader: Tester] - https://pornbay.org/torrents.php?id=000000"
           - "[XXX-Category-2] SomeXXXSite - Some Name [1.35 GB - Uploader: someUploader] - https://pornbay.org/torrents.php?id=000000"
-        pattern: '\[(.+)\] (.*) \[([0-9]+?.*?) - Uploader: (.+)\] - (https:\/\/.+\/)torrents.php\?id=(\d+)'
+        pattern: '\[(.+?)\] (\[?.*\]?.*) \[([0-9]+?.*?) - Uploader: (.+)\] - (https:\/\/.+\/)torrents.php\?id=(\d+)'
         vars:
           - category
           - torrentName


### PR DESCRIPTION
This PR fixes the pbay regex pattern which would previously cause misparsing of the category in following case:
`[Category] [Some] Release`
In this case the category did include `] [Some`, which we do not want.