### PR TITLE
fix(web)?: font loading

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <base href="{{.BaseUrl}}">
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#141415" />
@@ -18,7 +19,6 @@
     <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-iphone-retina-120x120.png" />
     <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-ipad-retina-152x152.png" />
     <title>autobrr</title>
-    <base href="{{.BaseUrl}}">
     <style>
 @font-face {
   font-family: "Inter Var";


### PR DESCRIPTION
speculative fix for #1166 

According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base 
baseURL must be specified before any links with href attributes for a proper implementation of base URLs.