### PR TITLE
fix(indexers): pbay announce bot name

### DIFF
--- a/internal/indexer/definitions/pbay.yaml
+++ b/internal/indexer/definitions/pbay.yaml
@@ -35,6 +35,7 @@ irc:
   announcers:
     - "PB-Announcer"
     - "Llamab1t"
+    - "Llamab3t"
   settings:
     - name: nick
       type: text


### PR DESCRIPTION
pbay changed their announce bot name (again)
added the new bot to the definition.

ref #790 