### PR TITLE
feat(indexers): PTP support freeleech

### DIFF
--- a/internal/indexer/definitions/ptp.yaml
+++ b/internal/indexer/definitions/ptp.yaml
@@ -94,11 +94,12 @@ irc:
     lines:
       - test:
           - "That Movie [1972] by Some Director | x264 / Blu-ray / MKV / 1080p | 204371 | 964303 | That.Movie.1972.1080p.BluRay.FLAC.x264-GROUP | comedy, drama, romance"
-          - "That Other Movie [1972] | x264 / Blu-ray / MKV / 1080p | 204371 | 964303 | That.Other.Movie.1972.1080p.BluRay.FLAC.x264-GROUP | comedy, drama, romance"
-        pattern: '.* \[(.*)\] (?:by .*)?\| (.*) \| .* \| (.*) \| (.*) \| (.*)'
+          - "That Other Movie [1972] | x264 / Blu-ray / MKV / 1080p / Freeleech! | 204371 | 964303 | That.Other.Movie.1972.1080p.BluRay.FLAC.x264-GROUP | comedy, drama, romance"
+        pattern: '.* \[(.*)\] (?:by .*)?\| (.*?(?: \/ (Freeleech)!)?) \| .* \| (.*) \| (.*) \| (.*)'
         vars:
           - year
           - releaseTags
+          - freeleech
           - torrentId
           - torrentName
           - tags


### PR DESCRIPTION
PTP has started to announce freeleech recently so this PR adds support to parse it properly instead of having to use `Match release tags` like `*freeleech*`.

https://regex101.com/r/QapE4W/1