### PR TITLE
feat(web): disable 1password prompts

### DIFF
--- a/web/src/components/inputs/input_wide.tsx
+++ b/web/src/components/inputs/input_wide.tsx
@@ -69,6 +69,7 @@ export const TextFieldWide = ({
             hidden={hidden}
             required={required}
             autoComplete={autoComplete}
+            data-1p-ignore
           />
         )}
       </Field>
@@ -87,6 +88,7 @@ interface PasswordFieldWideProps {
     defaultValue?: string;
     help?: string;
     required?: boolean;
+    autoComplete?: string;
     defaultVisible?: boolean;
     tooltip?: JSX.Element;
     validate?: FieldValidator;
@@ -99,6 +101,7 @@ export const PasswordFieldWide = ({
   defaultValue,
   help,
   required,
+  autoComplete,
   defaultVisible,
   tooltip,
   validate
@@ -134,6 +137,8 @@ export const PasswordFieldWide = ({
                 className={classNames(meta.touched && meta.error ? "focus:ring-red-500 focus:border-red-500 border-red-500" : "focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 border-gray-300 dark:border-gray-700", "block w-full pr-10 dark:bg-gray-800 shadow-sm dark:text-gray-100 sm:text-sm rounded-md")}
                 placeholder={placeholder}
                 required={required}
+                autoComplete={autoComplete}
+                data-1p-ignore
               />
               <div className="absolute inset-y-0 right-0 px-3 flex items-center" onClick={toggleVisibility}>
                 {!isVisible ? <EyeIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" /> : <EyeSlashIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" />}


### PR DESCRIPTION
Doesn’t currently work on the `auth.password` and `nickserv password` fields for some reason. I believe they share the `name=auth.password`. 