### PR TITLE
docs(definitions): MAM clarify cookie usage

### DIFF
--- a/internal/indexer/definitions/myanonamouse.yaml
+++ b/internal/indexer/definitions/myanonamouse.yaml
@@ -17,7 +17,7 @@ settings:
     type: secret
     required: true
     label: Cookie (mam_id)
-    help: "Check how to get cookies in your browser and find the mam_id cookie. Changes monthly"
+    help: "Check how to get cookies in your browser and find the mam_id cookie. Changes monthly. Format mam_id=$ID;"
 
 irc:
   network: MyAnonamouse


### PR DESCRIPTION
Autobrr's Discord had a user indicate that the format needs to be "mam_id=$id;"

The $id being the one created in the Preferences > Security in MAM website for the relevant IP.