### PR TITLE
fix(indexers): TorrentSeeds remove nickserv fields

### DIFF
--- a/internal/indexer/definitions/torrentseeds.yaml
+++ b/internal/indexer/definitions/torrentseeds.yaml
@@ -35,18 +35,6 @@ irc:
       label: Nick
       help: Bot nick. Eg. user_bot
 
-    - name: auth.account
-      type: text
-      required: false
-      label: NickServ Account
-      help: NickServ account. Make sure to group your user and bot.
-
-    - name: auth.password
-      type: secret
-      required: false
-      label: NickServ Password
-      help: NickServ password
-
     - name: invite_command
       type: secret
       default: "Cerberus identify USERNAME PID"


### PR DESCRIPTION
There is no way of issuing an `IDENTIFY` or `GROUP` a bot nick with NickServ on the TorrentSeeds network.
It only supports the `HELP` and `SET GREET` command for users.
So I would suggest to remove those fields for the indexer setup with TorrentSeeds to not cause any confusion.