### PR TITLE
feat(indexers): BHD freeleech announces

### DIFF
--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -656,7 +656,7 @@ func (r *Release) MapVars(def *IndexerDefinition, varMap map[string]string) erro
 	}
 
 	if freeleech, err := getStringMapValue(varMap, "freeleech"); err == nil {
-		fl := StringEqualFoldMulti(freeleech, "freeleech", "yes", "1", "VIP")
+		fl := StringEqualFoldMulti(freeleech, "freeleech", "freeleech!", "yes", "1", "VIP")
 		if fl {
 			r.Freeleech = true
 			// default to 100 and override if freeleechPercent is present in next function
@@ -666,6 +666,15 @@ func (r *Release) MapVars(def *IndexerDefinition, varMap map[string]string) erro
 	}
 
 	if freeleechPercent, err := getStringMapValue(varMap, "freeleechPercent"); err == nil {
+		// special handling for BHD to map their freeleech into percent
+		if def.Identifier == "beyondhd" {
+			if freeleechPercent == "Capped FL" {
+				freeleechPercent = "100%"
+			} else if strings.Contains(freeleechPercent, "% FL") {
+				freeleechPercent = strings.Replace(freeleechPercent, " FL", "", -1)
+			}
+		}
+
 		// remove % and trim spaces
 		freeleechPercent = strings.Replace(freeleechPercent, "%", "", -1)
 		freeleechPercent = strings.Trim(freeleechPercent, " ")

--- a/internal/indexer/definitions/beyondhd.yaml
+++ b/internal/indexer/definitions/beyondhd.yaml
@@ -66,7 +66,7 @@ irc:
         pattern: 'New Torrent: (.*?) (?:\[(.*)\] )?Category: (.*) By: (.*) Size: (.*) Link: (https?\:\/\/[^\/]+\/).*[&\?]id=(\d+)'
         vars:
           - torrentName
-          - freeleech
+          - freeleechPercent
           - category
           - uploader
           - torrentSize

--- a/internal/indexer/definitions/beyondhd.yaml
+++ b/internal/indexer/definitions/beyondhd.yaml
@@ -59,10 +59,14 @@ irc:
     type: single
     lines:
       - test:
-          - "New Torrent: That.Show.S01.1080p.Blu-ray.AVC.DTS-HD.MA.5.1-Test Category: TV By: Uploader Size: 137.73 GB Link: https://beyond-hd.me/torrents/autodl?id=00000"
-        pattern: 'New Torrent: (.*) Category: (.*) By: (.*) Size: (.*) Link: (https?\:\/\/[^\/]+\/).*[&\?]id=(\d+)'
+          - "New Torrent: This.Show.S01.1080p.Blu-ray.AVC.DTS-HD.MA.5.1-Test Category: TV By: Uploader Size: 137.73 GB Link: https://beyond-hd.me/torrents/autodl?id=00000"
+          - "New Torrent: That Show S03E04 1080p WEB-DL DDP 5.1 H.264-GROUP [Capped FL] Category: TV By: Anonymous Size: 1.62 GiB Link: https://beyond-hd.me/torrents/autodl?id=00000"
+          - "New Torrent: Another Show S03E04 1080p WEB-DL DDP 5.1 H.264-NoGRP [Capped Free] Category: TV By: Anonymous Size: 1.62 GiB Link: https://beyond-hd.me/torrents/autodl?id=00000"
+          - "New Torrent: Movie BluRay 1080p DD5.1 x264-GudGRP [50% Free] Category: Movies By: Uploader Size: 6.09 GiB Link: https://beyond-hd.me/torrents/autodl?id=00000"
+        pattern: 'New Torrent: (.*?) (?:\[(.*)\] )?Category: (.*) By: (.*) Size: (.*) Link: (https?\:\/\/[^\/]+\/).*[&\?]id=(\d+)'
         vars:
           - torrentName
+          - freeleech
           - category
           - uploader
           - torrentSize


### PR DESCRIPTION
This PR adapts the BHD regex to match the new announces which now announce their various freeleech options.
I am unsure of what to do with the freeleech var so i improvised and used `freeleech` for a start..
Do we want to use `freeleech` or `freeleechPercent` here?
There might me some changes needed at other files to overcome that problem?

(pun intended)

Regex101 Link: https://regex101.com/r/KQeS0G/1