### PR TITLE
fix(indexers): BTN api handle errors

### DIFF
--- a/pkg/btn/btn.go
+++ b/pkg/btn/btn.go
@@ -16,9 +16,12 @@ func (c *Client) TestAPI(ctx context.Context) (bool, error) {
 		return false, errors.Wrap(err, "test api userInfo failed")
 	}
 
+	if res.Error != nil {
+		return false, errors.New("btn: API test error: %s", res.Error.Message)
+	}
+
 	var u *UserInfo
-	err = res.GetObject(&u)
-	if err != nil {
+	if err := res.GetObject(&u); err != nil {
 		return false, errors.Wrap(err, "test api get userInfo")
 	}
 
@@ -39,9 +42,12 @@ func (c *Client) GetTorrentByID(ctx context.Context, torrentID string) (*domain.
 		return nil, errors.Wrap(err, "call getTorrentById failed")
 	}
 
+	if res.Error != nil {
+		return nil, errors.New("btn: getTorrentById error: %s", res.Error.Message)
+	}
+
 	var r *domain.TorrentBasic
-	err = res.GetObject(&r)
-	if err != nil {
+	if err := res.GetObject(&r); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fix for BTN api to return any errors that occurred, instead of crashing the web ui :see_no_evil: 