### PR TITLE
fix(web): tooltip z-index on filters list

### DIFF
--- a/web/src/screens/filters/List.tsx
+++ b/web/src/screens/filters/List.tsx
@@ -642,7 +642,7 @@ function FilterListItem({ filter, values, idx }: FilterListItemProps) {
           <span className="mr-2 break-words whitespace-nowrap text-xs font-medium text-gray-600 dark:text-gray-400">
             Priority: {filter.priority}
           </span>
-          <span className="whitespace-nowrap text-xs font-medium text-gray-600 dark:text-gray-400">
+          <span className="z-10 whitespace-nowrap text-xs font-medium text-gray-600 dark:text-gray-400">
             <Tooltip
               label={
                 <Link


### PR DESCRIPTION
Fix wrong z index of tooltips on filters list.

![bug1](https://github.com/autobrr/autobrr/assets/35452459/eb9649c3-35fa-4693-ba68-66e11d3def24)

(v1.33.1? 🤣 )