### PR TITLE
fix(filters): external webhook remove jitter

### DIFF
--- a/web/src/screens/filters/Details.tsx
+++ b/web/src/screens/filters/Details.tsx
@@ -221,7 +221,6 @@ const externalFilterSchema = z.object({
   webhook_retry_status: z.string().optional(),
   webhook_retry_attempts: z.number().optional(),
   webhook_retry_delay_seconds: z.number().optional(),
-  webhook_retry_max_jitter_seconds: z.number().optional(),
 });
 
 const indexerSchema = z.object({

--- a/web/src/screens/filters/External.tsx
+++ b/web/src/screens/filters/External.tsx
@@ -332,11 +332,6 @@ const TypeForm = ({ external, idx }: TypeFormProps) => {
           label="Retry delay in seconds"
           placeholder="1"
         />
-        <NumberField
-          name={`external.${idx}.webhook_retry_max_jitter_seconds`}
-          label="Max jitter in seconds"
-          placeholder="1"
-        />
       </div>
     );
 

--- a/web/src/screens/filters/List.tsx
+++ b/web/src/screens/filters/List.tsx
@@ -295,7 +295,6 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
         external_webhook_retry_status: any;
         external_webhook_retry_attempts: any;
         external_webhook_retry_delay_seconds: any;
-        external_webhook_retry_max_jitter_seconds: any;
       };
 
       const completeFilter = await APIClient.filters.getByID(filter.id) as Partial<CompleteFilterType>;
@@ -320,7 +319,6 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
       delete completeFilter.external_webhook_retry_status;
       delete completeFilter.external_webhook_retry_attempts;
       delete completeFilter.external_webhook_retry_delay_seconds;
-      delete completeFilter.external_webhook_retry_max_jitter_seconds;
 
       // Remove properties with default values from the exported filter to minimize the size of the JSON string
       ["enabled", "priority", "smart_episode", "resolutions", "sources", "codecs", "containers", "tags_match_logic", "except_tags_match_logic"].forEach((key) => {


### PR DESCRIPTION
I was too quick to merge #1227 and it did need some more work.

This removes External Webhook jitter options since it is not really needed and leads to unexpected delays.