### PR TITLE
refactor: streamline shutdown signal handling

### DIFF
--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -140,7 +140,7 @@ func main() {
 	}()
 
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGKILL, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 
 	srv := server.NewServer(log, cfg.Config, ircService, indexerService, feedService, schedulingService, updateService)
 	if err := srv.Start(); err != nil {
@@ -149,20 +149,14 @@ func main() {
 	}
 
 	for sig := range sigCh {
-		switch sig {
-		case syscall.SIGHUP:
-			log.Log().Msg("shutting down server sighup")
-			srv.Shutdown()
-			db.Close()
-			os.Exit(1)
-		case syscall.SIGINT, syscall.SIGQUIT:
-			srv.Shutdown()
-			db.Close()
-			os.Exit(1)
-		case syscall.SIGKILL, syscall.SIGTERM:
-			srv.Shutdown()
-			db.Close()
+		log.Info().Msgf("received signal: %v, shutting down server.", sig)
+
+		srv.Shutdown()
+
+		if err := db.Close(); err != nil {
+			log.Error().Err(err).Msg("failed to close the database connection properly")
 			os.Exit(1)
 		}
+		os.Exit(0)
 	}
 }


### PR DESCRIPTION
Refactored the server shutdown code to handle all signals in a unified way and removed the unnecessary `SIGKILL` case. `SIGKILL` cannot be caught, so its inclusion is unnecessary. On database closure error, we exit with status code `1` to signal a fault, otherwise, we exit with `0` for a clean shutdown.

Ref #1247 