### PR TITLE
refactor(config): copylocks and staticcheck findings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,7 +117,7 @@ func (c *AppConfig) writeConfig(configPath string, configFile string) error {
 			host = "0.0.0.0"
 		} else if pd, _ := os.Open("/proc/1/cgroup"); pd != nil {
 			defer pd.Close()
-			b := make([]byte, 4096, 4096)
+			b := make([]byte, 4096)
 			pd.Read(b)
 			if strings.Contains(string(b), "/docker") || strings.Contains(string(b), "/lxc") {
 				host = "0.0.0.0"
@@ -166,7 +166,7 @@ type Config interface {
 
 type AppConfig struct {
 	Config *domain.Config
-	m      sync.Mutex
+	m      *sync.Mutex
 }
 
 func New(configPath string, version string) *AppConfig {
@@ -275,8 +275,6 @@ func (c *AppConfig) DynamicReload(log logger.Logger) {
 		c.m.Unlock()
 	})
 	viper.WatchConfig()
-
-	return
 }
 
 func (c *AppConfig) UpdateConfig() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,7 +15,7 @@ import (
 func TestAppConfig_processLines(t *testing.T) {
 	type fields struct {
 		Config *domain.Config
-		m      sync.Mutex
+		m      *sync.Mutex
 	}
 	type args struct {
 		lines []string
@@ -30,7 +30,7 @@ func TestAppConfig_processLines(t *testing.T) {
 			name: "append missing",
 			fields: fields{
 				Config: &domain.Config{CheckForUpdates: true, LogLevel: "TRACE"},
-				m:      sync.Mutex{},
+				m:      new(sync.Mutex),
 			},
 			args: args{[]string{}},
 			want: []string{"# Check for updates", "#", "checkForUpdates = true", "# Log level", "#", "# Default: \"DEBUG\"", "#", "# Options: \"ERROR\", \"DEBUG\", \"INFO\", \"WARN\", \"TRACE\"", "#", `logLevel = "TRACE"`, "# Log Path", "#", "# Optional", "#", "#logPath = \"\""},
@@ -39,7 +39,7 @@ func TestAppConfig_processLines(t *testing.T) {
 			name: "update existing",
 			fields: fields{
 				Config: &domain.Config{CheckForUpdates: true, LogLevel: "TRACE"},
-				m:      sync.Mutex{},
+				m:      new(sync.Mutex),
 			},
 			args: args{[]string{"# Check for updates", "#", "checkForUpdates = false", "# Log level", "#", "# Default: \"DEBUG\"", "#", "# Options: \"ERROR\", \"DEBUG\", \"INFO\", \"WARN\", \"TRACE\"", "#", `logLevel = "TRACE"`, "# Log Path", "#", "# Optional", "#", "#logPath = \"\""}},
 			want: []string{"# Check for updates", "#", "checkForUpdates = true", "# Log level", "#", "# Default: \"DEBUG\"", "#", "# Options: \"ERROR\", \"DEBUG\", \"INFO\", \"WARN\", \"TRACE\"", "#", `logLevel = "TRACE"`, "# Log Path", "#", "# Optional", "#", "#logPath = \"\""},


### PR DESCRIPTION
Refactor mutex handling, optimize byte slice creation, and clean up code in accordance with go.staticcheck and copylocks guidelines.

- Changed `AppConfig`'s mutex to `*sync.Mutex`, preventing mutex copying and enhancing thread safety.
- Simplified byte slice initialization in `writeConfig` for efficiency.
- Removed redundant return in `DynamicReload` for better code clarity.