### PR TITLE
fix(filters): could not delete filter without actions

### DIFF
--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/pkg/errors"

--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
 	"github.com/autobrr/autobrr/pkg/errors"
@@ -402,15 +401,9 @@ func (r *ActionRepo) Delete(ctx context.Context, req *domain.DeleteActionRequest
 		return errors.Wrap(err, "error building query")
 	}
 
-	result, err := r.db.handler.ExecContext(ctx, query, args...)
+	_, err = r.db.handler.ExecContext(ctx, query, args...)
 	if err != nil {
 		return errors.Wrap(err, "error executing query")
-	}
-
-	if rowsAffected, err := result.RowsAffected(); err != nil {
-		return errors.Wrap(err, "error getting rows affected")
-	} else if rowsAffected == 0 {
-		return domain.ErrRecordNotFound
 	}
 
 	r.log.Debug().Msgf("action.delete: %v", req.ActionId)
@@ -428,15 +421,9 @@ func (r *ActionRepo) DeleteByFilterID(ctx context.Context, filterID int) error {
 		return errors.Wrap(err, "error building query")
 	}
 
-	result, err := r.db.handler.ExecContext(ctx, query, args...)
+	_, err = r.db.handler.ExecContext(ctx, query, args...)
 	if err != nil {
 		return errors.Wrap(err, "error executing query")
-	}
-
-	if rowsAffected, err := result.RowsAffected(); err != nil {
-		return errors.Wrap(err, "error getting rows affected")
-	} else if rowsAffected == 0 {
-		return domain.ErrRecordNotFound
 	}
 
 	r.log.Debug().Msgf("action.deleteByFilterID: %v", filterID)

--- a/internal/database/action_test.go
+++ b/internal/database/action_test.go
@@ -408,11 +408,6 @@ func TestActionRepo_Delete(t *testing.T) {
 			_ = downloadClientRepo.Delete(context.Background(), createdClient.ID)
 		})
 
-		t.Run(fmt.Sprintf("Delete_Fails_No_Record [%s]", dbType), func(t *testing.T) {
-			err := repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: 9999})
-			assert.Error(t, err)
-		})
-
 		t.Run(fmt.Sprintf("Delete_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 			defer cancel()
@@ -463,11 +458,6 @@ func TestActionRepo_DeleteByFilterID(t *testing.T) {
 			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
 			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
 			_ = downloadClientRepo.Delete(context.Background(), createdClient.ID)
-		})
-
-		t.Run(fmt.Sprintf("DeleteByFilterID_Fails_No_Record [%s]", dbType), func(t *testing.T) {
-			err := repo.DeleteByFilterID(context.Background(), 9999)
-			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("DeleteByFilterID_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {


### PR DESCRIPTION
This fixes the no sql row set, no idea why it does that but removing the row check I added fixes it, Not sure if it affects others rowsAffected in the delete function.  I haven't come across it and it happened on postgresdb, probably gives same error in sqlite but I could be wrong, someone can just test the dev version and confirm it, if needed.

![image](https://github.com/autobrr/autobrr/assets/41852205/a218bcf2-6587-440e-86d3-849d918733ab)
