### PR TITLE
fix(http): specify ip stack when listen fails

### DIFF
--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -75,17 +75,31 @@ func NewServer(log logger.Logger, config *config.AppConfig, sse *sse.Server, db 
 
 func (s Server) Open() error {
 	addr := fmt.Sprintf("%v:%v", s.config.Config.Host, s.config.Config.Port)
-	listener, err := net.Listen("tcp", addr)
+
+	var err error
+	for _, proto := range []string{"tcp", "tcp4", "tcp6"} {
+		if err = s.tryToServe(addr, proto); err == nil {
+			return err
+		}
+
+		s.log.Err(err).Msgf("Failed to start %s server. Attempted to listen on %s", proto, addr)
+	}
+
+	return err
+}
+
+func (s Server) tryToServe(addr, protocol string) error {
+	listener, err := net.Listen(protocol, addr)
 	if err != nil {
 		return err
 	}
+
+	s.log.Info().Msgf("Starting server %s. Listening on %s", protocol, listener.Addr().String())
 
 	server := http.Server{
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: time.Second * 15,
 	}
-
-	s.log.Info().Msgf("Starting server. Listening on %s", listener.Addr().String())
 
 	return server.Serve(listener)
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -79,7 +79,7 @@ func (s Server) Open() error {
 	var err error
 	for _, proto := range []string{"tcp", "tcp4", "tcp6"} {
 		if err = s.tryToServe(addr, proto); err == nil {
-			return err
+			break
 		}
 
 		s.log.Err(err).Msgf("Failed to start %s server. Attempted to listen on %s", proto, addr)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -82,7 +82,7 @@ func (s Server) Open() error {
 			break
 		}
 
-		s.log.Err(err).Msgf("Failed to start %s server. Attempted to listen on %s", proto, addr)
+		s.log.Error().Err(err).Msgf("Failed to start %s server. Attempted to listen on %s", proto, addr)
 	}
 
 	return err


### PR DESCRIPTION
Linux capabilities can limit the usage of dual stack configurations through namespaces. It's rather silly, but there's been sporadic reports over the years about this - so try for the best, downgrade to v4, then v6.