### PR TITLE
fix(filters): ensure sort by priority

### DIFF
--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -4,10 +4,10 @@
 package database
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -18,6 +18,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/lib/pq"
 	"github.com/rs/zerolog"
+	"golang.org/x/exp/slices"
 )
 
 type FilterRepo struct {
@@ -715,8 +716,8 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, indexer string
 	}
 
 	// the filterMap messes up the order, so we need to sort the filters slice
-	sort.Slice(filters, func(i, j int) bool {
-		return filters[i].Priority > filters[j].Priority
+	slices.SortStableFunc(filters, func(a, b *domain.Filter) int {
+		return cmp.Compare(b.Priority, a.Priority)
 	})
 
 	return filters, nil

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -4,7 +4,6 @@
 package database
 
 import (
-	"cmp"
 	"context"
 	"database/sql"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
+	"github.com/autobrr/autobrr/pkg/cmp"
 	"github.com/autobrr/autobrr/pkg/errors"
 
 	sq "github.com/Masterminds/squirrel"
@@ -717,6 +717,7 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, indexer string
 
 	// the filterMap messes up the order, so we need to sort the filters slice
 	slices.SortStableFunc(filters, func(a, b *domain.Filter) int {
+		// TODO remove with Go 1.21 and use std lib cmp
 		return cmp.Compare(b.Priority, a.Priority)
 	})
 

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -712,6 +713,11 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, indexer string
 		filter := filter
 		filters = append(filters, filter)
 	}
+
+	// the filterMap messes up the order, so we need to sort the filters slice
+	sort.Slice(filters, func(i, j int) bool {
+		return filters[i].Priority > filters[j].Priority
+	})
 
 	return filters, nil
 }

--- a/pkg/cmp/cmp.go
+++ b/pkg/cmp/cmp.go
@@ -1,0 +1,59 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cmp provides types and functions related to comparing
+// ordered values.
+package cmp
+
+// Ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+// If future releases of Go add new ordered types,
+// this constraint will be modified to include them.
+//
+// Note that floating-point types may contain NaN ("not-a-number") values.
+// An operator such as == or < will always report false when
+// comparing a NaN value with any other value, NaN or not.
+// See the [Compare] function for a consistent way to compare NaN values.
+type Ordered interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
+		~float32 | ~float64 |
+		~string
+}
+
+// Less reports whether x is less than y.
+// For floating-point types, a NaN is considered less than any non-NaN,
+// and -0.0 is not less than (is equal to) 0.0.
+func Less[T Ordered](x, y T) bool {
+	return (isNaN(x) && !isNaN(y)) || x < y
+}
+
+// Compare returns
+//
+//	-1 if x is less than y,
+//	 0 if x equals y,
+//	+1 if x is greater than y.
+//
+// For floating-point types, a NaN is considered less than any non-NaN,
+// a NaN is considered equal to a NaN, and -0.0 is equal to 0.0.
+func Compare[T Ordered](x, y T) int {
+	xNaN := isNaN(x)
+	yNaN := isNaN(y)
+	if xNaN && yNaN {
+		return 0
+	}
+	if xNaN || x < y {
+		return -1
+	}
+	if yNaN || x > y {
+		return +1
+	}
+	return 0
+}
+
+// isNaN reports whether x is a NaN without requiring the math package.
+// This will always return false if T is not floating-point.
+func isNaN[T Ordered](x T) bool {
+	return x != x
+}


### PR DESCRIPTION
With the recent refactor of `FilterRepo.FindByIndexerIdentifier` we use a map to hold the results and then make a slice of it. The map does not keep order by priority.

This PR fixes that by sorting the `filters slice` by `filter.Priority`.