### PR TITLE
enhancement(web): force run feed with enter key

### DIFF
--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -151,7 +151,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
     }, 200);
   };
 
-  const handleForceRun = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleForceRun = (e: React.SyntheticEvent) => {
     e.preventDefault();
     if (props.isOpen && isInputCorrect) {
       props.forceRunAction();
@@ -211,6 +211,11 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
                   placeholder="Type 'I understand' to enable the button"
                   value={inputValue}
                   onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      handleForceRun(e);
+                    }
+                  }}
                 />
               </div>
 


### PR DESCRIPTION
This PR enables the Force Run modal to be confirmed with the ENTER key instead of clicking the Force Run button