### PR TITLE
build(ci): change goreleaser back to ubuntu runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
   goreleaserbuild:
     name: Build distribution binaries
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     needs: [web, test]
     steps:
       - name: Disable Windows Defender

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
   goreleaserbuild:
     name: Build distribution binaries
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: [web, test]
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,11 @@ jobs:
     runs-on: windows-2019
     needs: [web, test]
     steps:
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        shell: powershell
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [web, test]
     steps:
-      - name: Disable Windows Defender
-        if: runner.os == 'Windows'
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
-        shell: powershell
-
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Windows performance on GitHub is wildly unpredictable. I/O patterns are non-deterministic, and even though the compute is substantially faster, prepping the filesystem still takes upwards of 5 minutes before kicking off any real work.