### PR TITLE
build(docker): do not tag pre-release as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,9 +190,12 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-            type=semver,pattern={{raw}}
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
             type=ref,event=branch
             type=ref,event=pr
+          flavor: |
+            latest=auto
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -218,7 +221,9 @@ jobs:
             REVISION=${{ github.event.pull_request.head.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Export digest
+          provenance: false
+
+      - name: Export image digest
         id: digest-prep
         run: |
           mkdir -p /tmp/digests
@@ -226,7 +231,7 @@ jobs:
           echo "manifest-hash=${digest#sha256:}" >> "$GITHUB_OUTPUT"
           touch "/tmp/digests/${digest#sha256:}"
 
-      - name: Upload digest
+      - name: Upload image digest
         uses: actions/upload-artifact@v4
         with:
           name: docker-digests-${{ steps.digest-prep.outputs.manifest-hash }}
@@ -240,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [docker, test]
     steps:
-      - name: Download digests
+      - name: Download image digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
@@ -262,6 +267,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=ref,event=branch
+            type=ref,event=pr
+          flavor: |
+            latest=auto
 
       - name: Create manifest list and push
         working-directory: /tmp/digests


### PR DESCRIPTION
Fix for mistakenly tagging pre-releases as `latest`.