### PR TITLE
feat(macros): add Group

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -23,6 +23,7 @@ type Macro struct {
 	TorrentUrl          string
 	TorrentDataRawBytes []byte
 	MagnetURI           string
+	Group               string
 	GroupID             string
 	DownloadUrl         string
 	InfoUrl             string
@@ -58,6 +59,7 @@ func NewMacro(release Release) Macro {
 		TorrentHash:         release.TorrentHash,
 		TorrentID:           release.TorrentID,
 		MagnetURI:           release.MagnetURI,
+		Group:               release.Group,
 		GroupID:             release.GroupID,
 		InfoUrl:             release.InfoURL,
 		DownloadUrl:         release.DownloadURL,

--- a/internal/domain/macros_test.go
+++ b/internal/domain/macros_test.go
@@ -214,6 +214,19 @@ func TestMacros_Parse(t *testing.T) {
 			want:    "DownloadUrl: https://test.local/this/page/1001",
 			wantErr: false,
 		},
+		{
+			name: "test_group",
+			release: Release{
+				TorrentName: "This movie 2021",
+				DownloadURL: "https://some.site/download/fakeid",
+				Group:       "thisgrp",
+				Indexer:     "mock1",
+				Year:        2021,
+			},
+			args:    args{text: "movies-{{.Group}}"},
+			want:    "movies-thisgrp",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Add "Group" to available filter macros, ie available as `{{ .Group }}`
