### PR TITLE
feat(macros): add Type

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -29,6 +29,7 @@ type Macro struct {
 	InfoUrl             string
 	Indexer             string
 	Title               string
+	Type                string
 	Category            string
 	Categories          []string
 	Resolution          string
@@ -65,6 +66,7 @@ func NewMacro(release Release) Macro {
 		DownloadUrl:         release.DownloadURL,
 		Indexer:             release.Indexer,
 		Title:               release.Title,
+		Type:                release.Type,
 		Category:            release.Category,
 		Categories:          release.Categories,
 		Resolution:          release.Resolution,

--- a/internal/domain/macros_test.go
+++ b/internal/domain/macros_test.go
@@ -227,6 +227,15 @@ func TestMacros_Parse(t *testing.T) {
 			want:    "movies-thisgrp",
 			wantErr: false,
 		},
+		{
+			name: "test_type",
+			release: Release{
+				Type: "episode",
+			},
+			args:    args{text: "Type: {{ .Type }}"},
+			want:    "Type: episode",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Exposes the Type field to macros.  This is beneficial for external scripts and webhooks that may want to alter their behavior based on the type of the Release.