### PR TITLE
fix(indexers): DigitalCore InfoURL

### DIFF
--- a/internal/indexer/definitions/digitalcore.yaml
+++ b/internal/indexer/definitions/digitalcore.yaml
@@ -81,5 +81,5 @@ irc:
           - tags
 
     match:
-      infourl: "/torrent/{{ .torrentId }}"
+      infourl: "/torrent/{{ .torrentId }}/"
       torrenturl: "/api/v1/torrents/download/{{ .torrentId }}/{{ .passkey }}"


### PR DESCRIPTION
Append a trailing slash to infourl to avoid site redirecting to home page.