### PR TITLE
chore(build): bump github action node versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20.10.0'
+          node-version: '20.11.0'
 
       - name: Set up corepack
         run: corepack enable
@@ -86,7 +86,7 @@ jobs:
         run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname -- ./... -tags=integration
 
       - name: Test Summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@dist
         with:
           paths: "unit-tests.xml"
         if: always()


### PR DESCRIPTION
Node.js 16 actions are deprecated. 
This PR updates the following actions to use Node.js 20: test-summary/action@v2.

**Disclaimer:**
This PR updates the Test Summary action from a tag to a branch which might get changes and break.
When a new release with nodejs 20 gets tagged we should switch to that.