### PR TITLE
enhancement(web): pending component placement

### DIFF
--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -316,7 +316,7 @@ export const AuthRoute = createRoute({
 
 function AuthenticatedLayout() {
   return (
-    <div className="min-h-screen">
+    <div className="flex flex-col min-h-screen">
       <Header/>
       <Outlet/>
     </div>
@@ -364,7 +364,7 @@ const routeTree = RootRoute.addChildren([
 export const Router = createRouter({
   routeTree,
   defaultPendingComponent: () => (
-    <div className="absolute top-1/4 left-1/2 !border-0">
+    <div className="flex flex-grow items-center justify-center col-span-9">
       <RingResizeSpinner className="text-blue-500 size-24"/>
     </div>
   ),

--- a/web/src/screens/Dashboard.tsx
+++ b/web/src/screens/Dashboard.tsx
@@ -7,8 +7,10 @@ import { Stats } from "./dashboard/Stats";
 import { ActivityTable } from "./dashboard/ActivityTable";
 
 export const Dashboard = () => (
-  <div className="my-6 max-w-screen-xl mx-auto pb-6 px-2 sm:px-6 lg:pb-16 lg:px-8">
-    <Stats />
-    <ActivityTable />
-  </div>
+  <main>
+    <div className="my-6 max-w-screen-xl mx-auto pb-6 px-2 sm:px-6 lg:pb-16 lg:px-8">
+      <Stats />
+      <ActivityTable />
+    </div>
+  </main>
 );


### PR DESCRIPTION
Okay this PR is a little bit of a hack/stretch/whatever you wanna call it.
Here is why:

---

These changes center the pending spinner vertically and horizontally for every flexbox and 
in the settings grid where there are 3 columns for the navigation and 9 columns for the "main" area.

**If** the pending spinner would appear in any other grid box (which it currently shouldn't),
**anything** is possible in terms of where it lands.

To center it on the dashboard i had to span a flex box over the `AuthenticatedLayout` div.

---

In case any of the maintainers have doubts, **please** express them as I am aware this might lead to unwanted behaviour!