### PR TITLE
fix(indexers): NBL new irc address

### DIFF
--- a/internal/indexer/definitions/nebulance.yaml
+++ b/internal/indexer/definitions/nebulance.yaml
@@ -27,7 +27,7 @@ settings:
 
 irc:
   network: Nebulance
-  server: irc.nebulance.cc
+  server: irc.nebulance.io
   port: 6697
   tls: true
   channels:


### PR DESCRIPTION
A user asked us to change the IRC address in our definition for NBL too since they share the same network as ANT.

Related #1403 