### PR TITLE
fix(web): unify border colors in indexer form

### DIFF
--- a/web/src/components/inputs/common.tsx
+++ b/web/src/components/inputs/common.tsx
@@ -51,7 +51,7 @@ export const SelectInput = (props: InputProps) => (
 export const SelectControl = (props: ControlProps) => (
   <components.Control
     {...props}
-    className="p-1 block w-full !bg-gray-100 dark:!bg-gray-850 border border-gray-300 dark:border-gray-775 dark:hover:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:text-gray-100 sm:text-sm"
+    className="p-1 block w-full !bg-gray-100 dark:!bg-gray-850 border border-gray-300 dark:border-gray-700 dark:hover:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:text-gray-100 sm:text-sm"
     children={props.children}
   />
 );


### PR DESCRIPTION
@stacksmash76 noticed a color difference in the indexer forms.

Old:
![image](https://github.com/autobrr/autobrr/assets/35452459/77939adb-4856-49e4-98c4-bbbbe44c8d12)

New:
![image](https://github.com/autobrr/autobrr/assets/35452459/71b5bc9f-e78a-4524-9143-e459a60d83b4)
