### PR TITLE
feat(macros): add FilterID

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -35,6 +35,7 @@ type Macro struct {
 	Resolution          string
 	Source              string
 	HDR                 string
+	FilterID            int
 	FilterName          string
 	Size                uint64
 	SizeString          string
@@ -72,6 +73,7 @@ func NewMacro(release Release) Macro {
 		Resolution:          release.Resolution,
 		Source:              release.Source,
 		HDR:                 strings.Join(release.HDR, ", "),
+		FilterID:            release.FilterID,
 		FilterName:          release.FilterName,
 		Size:                release.Size,
 		SizeString:          humanize.Bytes(release.Size),

--- a/internal/domain/macros_test.go
+++ b/internal/domain/macros_test.go
@@ -236,6 +236,15 @@ func TestMacros_Parse(t *testing.T) {
 			want:    "Type: episode",
 			wantErr: false,
 		},
+		{
+			name: "test_filter_id",
+			release: Release{
+				FilterID: 1,
+			},
+			args:    args{text: "FilterID: {{ .FilterID }}"},
+			want:    "FilterID: 1",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Exposes the FilterID field to macros. This is beneficial as another way to allow external tools to know which filter generated an event.  This should be more stable than the Filter Name which is already present because the Filter ID is immutable.
