### PR TITLE
feat(irc): manually re-process announces

### DIFF
--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"syscall"
 	_ "time/tzdata"
-	_ "go.uber.org/automaxprocs"
 
 	"github.com/autobrr/autobrr/internal/action"
 	"github.com/autobrr/autobrr/internal/api"
@@ -31,8 +30,11 @@ import (
 	"github.com/autobrr/autobrr/internal/user"
 
 	"github.com/asaskevich/EventBus"
+	"github.com/dcarbone/zadapters/zstdlog"
 	"github.com/r3labs/sse/v2"
+	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
+	"go.uber.org/automaxprocs/maxprocs"
 )
 
 var (
@@ -51,6 +53,13 @@ func main() {
 
 	// init new logger
 	log := logger.New(cfg.Config)
+
+	// Set GOMAXPROCS to match the Linux container CPU quota (if any)
+	undo, err := maxprocs.Set(maxprocs.Logger(zstdlog.NewStdLoggerWithLevel(log.With().Logger(), zerolog.InfoLevel).Printf))
+	defer undo()
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to set GOMAXPROCS")
+	}
 
 	// init dynamic config
 	cfg.DynamicReload(log)
@@ -106,7 +115,7 @@ func main() {
 		actionService         = action.NewService(log, actionRepo, downloadClientService, bus)
 		indexerService        = indexer.NewService(log, cfg.Config, indexerRepo, indexerAPIService, schedulingService)
 		filterService         = filter.NewService(log, filterRepo, actionRepo, releaseRepo, indexerAPIService, indexerService)
-		releaseService        = release.NewService(log, releaseRepo, actionService, filterService)
+		releaseService        = release.NewService(log, releaseRepo, actionService, filterService, indexerService)
 		ircService            = irc.NewService(log, serverEvents, ircRepo, releaseService, indexerService, notificationService)
 		feedService           = feed.NewService(log, feedRepo, feedCacheRepo, releaseService, schedulingService)
 	)

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -94,6 +94,14 @@ type ChannelHealth struct {
 	LastAnnounce    time.Time `json:"last_announce"`
 }
 
+type IRCManualProcessRequest struct {
+	NetworkId int64  `json:"-"`
+	Server    string `json:"server"`
+	Channel   string `json:"channel"`
+	Nick      string `json:"nick"`
+	Message   string `json:"msg"`
+}
+
 type SendIrcCmdRequest struct {
 	NetworkId int64  `json:"network_id"`
 	Server    string `json:"server"`

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -270,6 +270,12 @@ type ReleaseActionRetryReq struct {
 	ActionId       int
 }
 
+type ReleaseProcessReq struct {
+	IndexerIdentifier     string   `json:"indexer_identifier"`
+	IndexerImplementation string   `json:"indexer_implementation"`
+	AnnounceLines         []string `json:"announce_lines"`
+}
+
 type GetReleaseRequest struct {
 	Id int
 }

--- a/internal/http/irc.go
+++ b/internal/http/irc.go
@@ -6,8 +6,10 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/autobrr/autobrr/internal/domain"
 
@@ -25,6 +27,7 @@ type ircService interface {
 	StoreChannel(ctx context.Context, networkID int64, channel *domain.IrcChannel) error
 	RestartNetwork(ctx context.Context, id int64) error
 	SendCmd(ctx context.Context, req *domain.SendIrcCmdRequest) error
+	ManualProcessAnnounce(ctx context.Context, req *domain.IRCManualProcessRequest) error
 }
 
 type ircHandler struct {
@@ -54,6 +57,8 @@ func (h ircHandler) Routes(r chi.Router) {
 		r.Post("/cmd", h.sendCmd)
 		r.Post("/channel", h.storeChannel)
 		r.Get("/restart", h.restartNetwork)
+
+		r.Post("/channel/{channel}/announce/process", h.announceProcess)
 	})
 
 	r.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
@@ -178,6 +183,58 @@ func (h ircHandler) sendCmd(w http.ResponseWriter, r *http.Request) {
 	data.NetworkId = int64(id)
 
 	if err := h.service.SendCmd(ctx, &data); err != nil {
+		h.encoder.Error(w, err)
+		return
+	}
+
+	h.encoder.NoContent(w)
+}
+
+// announceProcess manually trigger announce process
+func (h ircHandler) announceProcess(w http.ResponseWriter, r *http.Request) {
+	var (
+		ctx  = r.Context()
+		data domain.IRCManualProcessRequest
+	)
+
+	paramNetworkID := chi.URLParam(r, "networkID")
+	if paramNetworkID == "" {
+		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]interface{}{
+			"code":    "BAD_REQUEST_PARAMS",
+			"message": "parameter networkID missing",
+		})
+		return
+	}
+
+	networkID, err := strconv.Atoi(paramNetworkID)
+	if err != nil {
+		h.encoder.Error(w, err)
+		return
+	}
+
+	paramChannel := chi.URLParam(r, "channel")
+	if paramChannel == "" {
+		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]interface{}{
+			"code":    "BAD_REQUEST_PARAMS",
+			"message": "parameter channel missing",
+		})
+		return
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		h.encoder.Error(w, err)
+		return
+	}
+
+	data.NetworkId = int64(networkID)
+	data.Channel = paramChannel
+
+	// we cant pass # as an url parameter so the frontend has to strip it
+	if !strings.HasPrefix("#", data.Channel) {
+		data.Channel = fmt.Sprintf("#%s", data.Channel)
+	}
+
+	if err := h.service.ManualProcessAnnounce(ctx, &data); err != nil {
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/release.go
+++ b/internal/http/release.go
@@ -5,6 +5,7 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -22,6 +23,7 @@ type releaseService interface {
 	Stats(ctx context.Context) (*domain.ReleaseStats, error)
 	Delete(ctx context.Context, req *domain.DeleteReleaseRequest) error
 	Retry(ctx context.Context, req *domain.ReleaseActionRetryReq) error
+	ProcessManual(ctx context.Context, req *domain.ReleaseProcessReq) error
 }
 
 type releaseHandler struct {
@@ -42,6 +44,8 @@ func (h releaseHandler) Routes(r chi.Router) {
 	r.Get("/stats", h.getStats)
 	r.Get("/indexers", h.getIndexerOptions)
 	r.Delete("/", h.deleteReleases)
+
+	r.Post("/process", h.retryAction)
 
 	r.Route("/{releaseId}", func(r chi.Router) {
 		r.Post("/actions/{actionStatusId}/retry", h.retryAction)
@@ -215,6 +219,38 @@ func (h releaseHandler) deleteReleases(w http.ResponseWriter, r *http.Request) {
 	h.encoder.NoContent(w)
 }
 
+func (h releaseHandler) process(w http.ResponseWriter, r *http.Request) {
+	var req *domain.ReleaseProcessReq
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		h.encoder.Error(w, err)
+		return
+	}
+
+	if req.IndexerIdentifier == "" {
+		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]interface{}{
+			"code":    "VALIDATION_ERROR",
+			"message": "field indexer_identifier empty",
+		})
+	}
+
+	if len(req.AnnounceLines) == 0 {
+		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]interface{}{
+			"code":    "VALIDATION_ERROR",
+			"message": "field announce_lines empty",
+		})
+	}
+
+	err = h.service.ProcessManual(r.Context(), req)
+	if err != nil {
+		h.encoder.Error(w, err)
+		return
+	}
+
+	h.encoder.NoContent(w)
+}
+
 func (h releaseHandler) retryAction(w http.ResponseWriter, r *http.Request) {
 	var (
 		req *domain.ReleaseActionRetryReq
@@ -223,7 +259,10 @@ func (h releaseHandler) retryAction(w http.ResponseWriter, r *http.Request) {
 
 	releaseIdParam := chi.URLParam(r, "releaseId")
 	if releaseIdParam == "" {
-		h.encoder.StatusError(w, http.StatusBadRequest, err)
+		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]interface{}{
+			"code":    "BAD_REQUEST_PARAMS",
+			"message": "parameter releaseId missing",
+		})
 		return
 	}
 
@@ -235,7 +274,10 @@ func (h releaseHandler) retryAction(w http.ResponseWriter, r *http.Request) {
 
 	actionStatusIdParam := chi.URLParam(r, "actionStatusId")
 	if actionStatusIdParam == "" {
-		h.encoder.StatusError(w, http.StatusBadRequest, err)
+		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]interface{}{
+			"code":    "BAD_REQUEST_PARAMS",
+			"message": "parameter actionStatusId missing",
+		})
 		return
 	}
 

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -94,7 +94,7 @@ func (s Server) tryToServe(addr, protocol string) error {
 		return err
 	}
 
-	s.log.Info().Msgf("Starting server %s. Listening on %s", protocol, listener.Addr().String())
+	s.log.Info().Msgf("Starting API %s server. Listening on %s", protocol, listener.Addr().String())
 
 	server := http.Server{
 		Handler:           s.Handler(),

--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -35,6 +35,7 @@ type Service interface {
 	LoadIndexerDefinitions() error
 	GetIndexersByIRCNetwork(server string) []*domain.IndexerDefinition
 	GetTorznabIndexers() []domain.IndexerDefinition
+	GetMappedDefinitionByName(name string) (*domain.IndexerDefinition, error)
 	Start() error
 	TestApi(ctx context.Context, req domain.IndexerTestApiRequest) error
 	ToggleEnabled(ctx context.Context, indexerID int, enabled bool) error
@@ -650,6 +651,15 @@ func (s *service) getDefinitionByName(name string) *domain.IndexerDefinition {
 	}
 
 	return nil
+}
+
+func (s *service) GetMappedDefinitionByName(name string) (*domain.IndexerDefinition, error) {
+	v, ok := s.mappedDefinitions[name]
+	if !ok {
+		return nil, errors.New("unknown indexer identifier: %s", name)
+	}
+
+	return v, nil
 }
 
 func (s *service) getMappedDefinitionByName(name string) *domain.IndexerDefinition {

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -706,6 +706,10 @@ func (h *Handler) onMessage(msg ircmsg.Message) {
 	return
 }
 
+func (h *Handler) SendToAnnounceProcessor(channel string, msg string) error {
+	return h.sendToAnnounceProcessor(channel, msg)
+}
+
 // send the msg to announce processor
 func (h *Handler) sendToAnnounceProcessor(channel string, msg string) error {
 	channel = strings.ToLower(channel)

--- a/internal/irc/service.go
+++ b/internal/irc/service.go
@@ -36,6 +36,7 @@ type Service interface {
 	UpdateNetwork(ctx context.Context, network *domain.IrcNetwork) error
 	StoreChannel(ctx context.Context, networkID int64, channel *domain.IrcChannel) error
 	SendCmd(ctx context.Context, req *domain.SendIrcCmdRequest) error
+	ManualProcessAnnounce(ctx context.Context, req *domain.IRCManualProcessRequest) error
 }
 
 type service struct {
@@ -406,6 +407,26 @@ func (s *service) GetNetworkByID(ctx context.Context, id int64) (*domain.IrcNetw
 	network.Channels = append(network.Channels, channels...)
 
 	return network, nil
+}
+
+func (s *service) ManualProcessAnnounce(ctx context.Context, req *domain.IRCManualProcessRequest) error {
+	network, err := s.repo.GetNetworkByID(ctx, req.NetworkId)
+	if err != nil {
+		s.log.Error().Err(err).Msgf("failed to get network: %d", req.NetworkId)
+		return err
+	}
+
+	handler, ok := s.handlers[network.ID]
+	if !ok {
+		return errors.New("could not find irc handler with id: %d", network.ID)
+	}
+
+	err = handler.sendToAnnounceProcessor(req.Channel, req.Message)
+	if err != nil {
+		return errors.Wrap(err, "could not send manual announce to processor")
+	}
+
+	return nil
 }
 
 func (s *service) ListNetworks(ctx context.Context) ([]domain.IrcNetwork, error) {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -29,6 +29,8 @@ type Logger interface {
 	With() zerolog.Context
 	RegisterSSEWriter(sse *sse.Server)
 	SetLogLevel(level string)
+	Printf(format string, v ...interface{})
+	Print(v ...interface{})
 }
 
 // DefaultLogger default logging controller
@@ -142,6 +144,18 @@ func (l *DefaultLogger) Debug() *zerolog.Event {
 // Trace log something at fatal level. This will panic!
 func (l *DefaultLogger) Trace() *zerolog.Event {
 	return l.log.Trace().Timestamp()
+}
+
+// Print sends a log event using debug level and no extra field.
+// Arguments are handled in the manner of fmt.Print.
+func (l *DefaultLogger) Print(v ...interface{}) {
+	l.log.Print(v...)
+}
+
+// Printf sends a log event using debug level and no extra field.
+// Arguments are handled in the manner of fmt.Printf.
+func (l *DefaultLogger) Printf(format string, v ...interface{}) {
+	l.log.Printf(format, v...)
 }
 
 // With log with context

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -278,6 +278,9 @@ export const APIClient = {
     sendCmd: (cmd: SendIrcCmdRequest) => appClient.Post(`api/irc/network/${cmd.network_id}/cmd`, {
       body: cmd
     }),
+    reprocessAnnounce: (networkId: number, channel: string, msg: string) => appClient.Post(`api/irc/network/${networkId}/channel/${channel}/announce/process`, {
+      body: { msg: msg }
+    }),
     events: (network: string) => new EventSource(
       `${sseBaseUrl()}api/irc/events?stream=${encodeRFC3986URIComponent(network)}`,
       { withCredentials: true }

--- a/web/src/screens/Logs.tsx
+++ b/web/src/screens/Logs.tsx
@@ -139,7 +139,7 @@ export const Logs = () => {
               >
                 <span
                   title={entry.time}
-                  className="font-mono text-gray-500 dark:text-gray-600 mr-2 h-full"
+                  className="font-mono text-gray-500 dark:text-gray-600 h-full"
                 >
                   {format(new Date(entry.time), "HH:mm:ss")}
                 </span>
@@ -150,10 +150,10 @@ export const Logs = () => {
                       "font-mono font-semibold h-full"
                     )}
                   >
-                    {entry.level}
+                    {` ${entry.level} `}
                   </span>
                 ) : null}
-                <span className="ml-2 text-black dark:text-gray-300">
+                <span className="text-black dark:text-gray-300">
                   {entry.message}
                 </span>
               </div>

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -607,13 +607,14 @@ const ReprocessAnnounceButton = ({ networkId, channel, msg }: ReprocessAnnounceP
   };
 
   return (
-    <button className="flex items-center m-auto px-1.5 py-1 ml-2 rounded transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600" onClick={reprocessAnnounce} title="Re-process announce">
-      {/*<span className="mr-1.5">Retry</span>*/}
+    <div className="block">
+    <button className="flex items-center justify-center size-5 mr-1 p-1 rounded transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600" onClick={reprocessAnnounce} title="Re-process announce">
       {mutation.isPending
-        ? <RingResizeSpinner className="text-blue-500 w-4 h-4 iconHeight" aria-hidden="true" />
-        : <ArrowPathIcon className="h-4 w-4" />
+        ? <RingResizeSpinner className="text-blue-500 iconHeight" aria-hidden="true" />
+        : <ArrowPathIcon />
       }
     </button>
+    </div>
   );
 
 }
@@ -728,13 +729,15 @@ export const Events = ({ network, channel }: EventsProps) => {
             className={classNames(
               settings.indentLogLines ? "grid justify-start grid-flow-col" : "",
               settings.hideWrappedText ? "truncate hover:text-ellipsis hover:whitespace-normal" : "",
-              "flex hover:bg-gray-200 hover:dark:bg-gray-800"
+              "flex items-center hover:bg-gray-200 hover:dark:bg-gray-800"
             )}
           >
-            <span className="font-mono text-gray-500 dark:text-gray-500 mr-1">
-              <span className="dark:text-gray-600"><span className="dark:text-gray-700">[{simplifyDate(entry.time)}]</span> {entry.nick}:</span> {entry.msg}
-            </span>
             <ReprocessAnnounceButton networkId={network.id} channel={channel} msg={entry.msg} />
+            <div className="flex-1">
+              <span className="font-mono text-gray-500 dark:text-gray-500 mr-1">
+                <span className="dark:text-gray-600"><span className="dark:text-gray-700">[{simplifyDate(entry.time)}]</span> {entry.nick}:</span> {entry.msg}
+              </span>
+            </div>
           </div>
         ))}
       </div>

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -5,7 +5,7 @@
 
 import { Fragment, MouseEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { LockClosedIcon, LockOpenIcon, PlusIcon } from "@heroicons/react/24/solid";
+import { ArrowPathIcon, LockClosedIcon, LockOpenIcon, PlusIcon } from "@heroicons/react/24/solid";
 import { Menu, Transition } from "@headlessui/react";
 import { toast } from "react-hot-toast";
 import {
@@ -31,6 +31,7 @@ import { SettingsContext } from "@utils/Context";
 import { Checkbox } from "@components/Checkbox";
 
 import { Section } from "./_components";
+import { RingResizeSpinner } from "@components/Icons.tsx";
 
 interface SortConfig {
   key: keyof ListItemProps["network"] | "enabled";
@@ -575,6 +576,48 @@ const ListItemDropdown = ({
   );
 };
 
+interface ReprocessAnnounceProps {
+  networkId: number;
+  channel: string;
+  msg: string;
+}
+
+const ReprocessAnnounceButton = ({ networkId, channel, msg }: ReprocessAnnounceProps) => {
+  const mutation = useMutation({
+    mutationFn: (req: IrcProcessManualRequest) => APIClient.irc.reprocessAnnounce(req.network_id, req.channel, req.msg),
+    onSuccess: () => {
+      toast.custom((t) => (
+        <Toast type="success" body={`Announce sent to re-process!`} t={t} />
+      ));
+    }
+  });
+
+  const reprocessAnnounce = () => {
+    const req: IrcProcessManualRequest = {
+      network_id: networkId,
+      msg: msg,
+      channel: channel,
+    }
+
+    if (channel.startsWith("#")) {
+      req.channel = channel.replace("#", "")
+    }
+
+    mutation.mutate(req);
+  };
+
+  return (
+    <button className="flex items-center m-auto px-1.5 py-1 ml-2 rounded transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600" onClick={reprocessAnnounce} title="Re-process announce">
+      {/*<span className="mr-1.5">Retry</span>*/}
+      {mutation.isPending
+        ? <RingResizeSpinner className="text-blue-500 w-4 h-4 iconHeight" aria-hidden="true" />
+        : <ArrowPathIcon className="h-4 w-4" />
+      }
+    </button>
+  );
+
+}
+
 type IrcEvent = {
   channel: string;
   nick: string;
@@ -684,10 +727,14 @@ export const Events = ({ network, channel }: EventsProps) => {
             key={idx}
             className={classNames(
               settings.indentLogLines ? "grid justify-start grid-flow-col" : "",
-              settings.hideWrappedText ? "truncate hover:text-ellipsis hover:whitespace-normal" : ""
+              settings.hideWrappedText ? "truncate hover:text-ellipsis hover:whitespace-normal" : "",
+              "flex hover:bg-gray-200 hover:dark:bg-gray-800"
             )}
           >
-            <span className="font-mono text-gray-500 dark:text-gray-500 mr-1"><span className="dark:text-gray-600"><span className="dark:text-gray-700">[{simplifyDate(entry.time)}]</span> {entry.nick}:</span> {entry.msg}</span>
+            <span className="font-mono text-gray-500 dark:text-gray-500 mr-1">
+              <span className="dark:text-gray-600"><span className="dark:text-gray-700">[{simplifyDate(entry.time)}]</span> {entry.nick}:</span> {entry.msg}
+            </span>
+            <ReprocessAnnounceButton networkId={network.id} channel={channel} msg={entry.msg} />
           </div>
         ))}
       </div>

--- a/web/src/types/Irc.d.ts
+++ b/web/src/types/Irc.d.ts
@@ -89,3 +89,10 @@ interface SendIrcCmdRequest {
   nick: string;
   msg: string;
 }
+
+interface IrcProcessManualRequest {
+  network_id: number;
+  channel: string;
+  nick?: string;
+  msg: string;
+}


### PR DESCRIPTION
Implement re-process from network channel logs.

![image](https://github.com/autobrr/autobrr/assets/43699394/bd262cac-01c3-4884-895c-16db7327efc8)


> [!IMPORTANT]
> Only supports single line announces to start with.