### PR TITLE
fix(filters): point to the correct docs page anchor for `skipping seasons packs`

### DIFF
--- a/web/src/screens/filters/sections/MoviesAndTV.tsx
+++ b/web/src/screens/filters/sections/MoviesAndTV.tsx
@@ -31,7 +31,7 @@ const SeasonsAndEpisodes = () => (
         tooltip={
           <div>
             <p>See docs for information about how to <b>only</b> grab episodes:</p>
-            <DocsLink href="https://autobrr.com/filters/examples/#skip-season-packs" />
+            <DocsLink href="https://autobrr.com/filters/examples#only-episodes-skip-season-packs" />
           </div>
         }
       />


### PR DESCRIPTION
Small fix to correctly link to a proper anchor on the page.

The correct anchor was found using the actual documentation page.