### PR TITLE
Updating AnimeBytes IRC Domain

### DIFF
--- a/internal/indexer/definitions/animebytes.yaml
+++ b/internal/indexer/definitions/animebytes.yaml
@@ -21,7 +21,7 @@ settings:
 
 irc:
   network: AnimeBytes-IRC
-  server: irc.animebytes.tv
+  server: irc.animefriends.moe
   port: 7000
   tls: true
   channels:


### PR DESCRIPTION
AnimeBtyes IRC domain has changed to irc.animefriends.moe