### PR TITLE
fix(database): migrations log correct upgrade var version

### DIFF
--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -71,7 +71,7 @@ func (db *DB) migratePostgres() error {
 		}
 	} else {
 		for i := version; i < len(postgresMigrations); i++ {
-			db.log.Info().Msgf("Upgrading Database schema to version: %v", i)
+			db.log.Info().Msgf("Upgrading Database schema to version: %v", len(postgresMigrations))
 			if _, err := tx.Exec(postgresMigrations[i]); err != nil {
 				return errors.Wrap(err, "failed to execute migration #%v", i)
 			}

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -71,7 +71,7 @@ func (db *DB) migratePostgres() error {
 		}
 	} else {
 		for i := version; i < len(postgresMigrations); i++ {
-			db.log.Info().Msgf("Upgrading Database schema to version: %v", len(postgresMigrations))
+			db.log.Info().Msgf("Upgrading Database schema to version: %v", i+1)
 			if _, err := tx.Exec(postgresMigrations[i]); err != nil {
 				return errors.Wrap(err, "failed to execute migration #%v", i)
 			}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -39,7 +39,7 @@ func (db *DB) openSQLite() error {
 	}
 
 	// SQLite has a query planner that uses lifecycle stats to fund optimizations.
-	// This restricts the SQLite query planner optimizer to only run if sufficient 
+	// This restricts the SQLite query planner optimizer to only run if sufficient
 	// information has been gathered over the lifecycle of the connection.
 	// The SQLite documentation is inconsistent in this regard,
 	// suggestions of 400 and 1000 are both "recommended", so lets use the lower bound.
@@ -125,7 +125,7 @@ func (db *DB) migrateSQLite() error {
 		}
 	} else {
 		for i := version; i < len(sqliteMigrations); i++ {
-			db.log.Info().Msgf("Upgrading Database schema to version: %v", i)
+			db.log.Info().Msgf("Upgrading Database schema to version: %v", len(sqliteMigrations))
 			if _, err := tx.Exec(sqliteMigrations[i]); err != nil {
 				return errors.Wrap(err, "failed to execute migration #%v", i)
 			}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -125,7 +125,7 @@ func (db *DB) migrateSQLite() error {
 		}
 	} else {
 		for i := version; i < len(sqliteMigrations); i++ {
-			db.log.Info().Msgf("Upgrading Database schema to version: %v", len(sqliteMigrations))
+			db.log.Info().Msgf("Upgrading Database schema to version: %v", i+1)
 			if _, err := tx.Exec(sqliteMigrations[i]); err != nil {
 				return errors.Wrap(err, "failed to execute migration #%v", i)
 			}


### PR DESCRIPTION
This PR fixes the wrong number being printed in the logs during database schema upgrades for SQLite and PostgreSQL.

Old:
```
INF Beginning database schema upgrade from version 54 to version: 55 module=database type=sqlite
INF Upgrading Database schema to version: 54 module=database type=sqlite
INF Database schema upgraded to version: 55 module=database type=sqlite
```

New:
```
INF Beginning database schema upgrade from version 54 to version: 55 module=database type=sqlite
INF Upgrading Database schema to version: 55 module=database type=sqlite
INF Database schema upgraded to version: 55 module=database type=sqlite
```


Fixes #1440 