### PR TITLE
fix(irc): allow insecure TLS cipher suites

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -230,8 +230,21 @@ func (h *Handler) Run() (err error) {
 	}
 
 	if h.network.TLS {
+		// In Go 1.22 old insecure ciphers was removed. A lot of old IRC networks still uses those, so we need to allow those.
+		unsafeCipherSuites := make([]uint16, 0, len(tls.InsecureCipherSuites())+len(tls.CipherSuites()))
+		for _, suite := range tls.InsecureCipherSuites() {
+			unsafeCipherSuites = append(unsafeCipherSuites, suite.ID)
+		}
+		for _, suite := range tls.CipherSuites() {
+			unsafeCipherSuites = append(unsafeCipherSuites, suite.ID)
+		}
+
 		client.UseTLS = true
-		client.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+		client.TLSConfig = &tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS10,
+			CipherSuites:       unsafeCipherSuites,
+		}
 	}
 
 	client.AddConnectCallback(h.onConnect)


### PR DESCRIPTION
With Go v1.22 they deprecated a lot of old TLS cipher suites that was deemed insecure. https://go.dev/doc/go1.22#crypto/tls

In the world of IRC there is a lot of networks running on ancient ircd versions, so we unfortunately have to comply with that. 

This only fixes IRC for now, not sure yet if we need to change anything for HTTP calls.

Fixes #1443 