### PR TITLE
feat(indexers): add FearNoPeer

### DIFF
--- a/internal/indexer/definitions/fearnopeer.yaml
+++ b/internal/indexer/definitions/fearnopeer.yaml
@@ -1,0 +1,83 @@
+---
+name: FearNoPeer
+identifier: fnp
+description: FearNoPeer (FnP) is a private torrent tracker for Movies, TV Shows & General releases
+language: en-us
+urls:
+  - https://fearnopeer.com/
+privacy: private
+protocol: torrent
+supports:
+  - irc
+  - rss
+# source: UNIT3D
+settings:
+  - name: rsskey
+    type: secret
+    required: true
+    label: RSS key (RID)
+    help: "Go to your profile > Settings > Security > RSS Key (RID) and paste your RID into this field."
+
+irc:
+  network: LibraIRC
+  server: irc.librairc.net
+  port: 6697
+  tls: true
+  channels:
+    - "#fearnopeer-announce"
+  announcers:
+    - FnP
+  settings:
+    - name: nick
+      type: text
+      required: true
+      label: Nick
+      help: Bot nick. Eg. user|autodl
+
+    - name: auth.account
+      type: text
+      required: false
+      label: NickServ Account
+      help: NickServ account. Make sure to group your user and bot.
+
+    - name: auth.password
+      type: secret
+      required: false
+      label: NickServ Password
+      help: NickServ password
+
+  parse:
+    type: single
+    lines:
+      - tests:
+        - line: "[FnP] New Upload - Category: [Movies] Type: [WEB-DL] Name: [Air Bud: World Pup 2001 1080p NF WEB-DL DD 5.1 x264-monkee] Size: [4.54 GiB] Uploader: [MartyMcFly] Url: [https://fearnopeer.com/torrents/12345]"
+          expect:
+            category: Movies
+            releaseTags: WEB-DL
+            torrentName: "Air Bud: World Pup 2001 1080p NF WEB-DL DD 5.1 x264-monkee"
+            torrentSize: 4.54 GiB
+            uploader: MartyMcFly
+            baseUrl: https://fearnopeer.com/
+            torrentId: "12345"
+        - line: "[FnP] New Upload - Category: [TV] Type: [WEB-DL] Name: [The Regime S01E03 1080p AMZN WEB-DL DD+ 5.1 H.264-FLUX] Size: [4.14 GiB] Uploader: [oppie] Url: [https://fearnopeer.com/torrents/54321]"
+          expect:
+            category: TV
+            releaseTags: WEB-DL
+            torrentName: The Regime S01E03 1080p AMZN WEB-DL DD+ 5.1 H.264-FLUX
+            torrentSize: 4.14 GiB
+            uploader: oppie
+            baseUrl: https://fearnopeer.com/
+            torrentId: "54321"
+        pattern: '.*\[(.*)\].*\[(.*)\].*\[(.*)\].*\[(.*)\].*\[(.*)\].*\[(https?\:\/\/.*?\/).*\/(\d+)\]'
+        vars:
+          - category
+          - releaseTags
+          - torrentName
+          - torrentSize
+          - uploader
+          - baseUrl
+          - torrentId
+
+    match:
+      infourl: "/torrents/{{ .torrentId }}"
+      torrenturl: "/torrent/download/{{ .torrentId }}.{{ .rsskey }}"


### PR DESCRIPTION
# Indexer request

-  Do they have irc announce? Yes
-  Link to existing `autodl-irssi .tracker` file: N/a

### If no existing `autodl-irssi .tracker` file

- Indexer name: FearNoPeer
- Short name: FnP
- URL: https://fearnopeer.com/
- Download link: UNIT3D format, https://fearnopeer.com/torrents/77448.rsskey

## Announce examples

Multi-line announce:

Sample movie
```
[FnP] New Upload - Category: [Movies] Type: [Remux] Name: [Terror Out of the Sky 1978 1080p BluRay REMUX AVC DTS-HD MA 2.0-HDT] Size: [17.11 GiB] Uploader: [MartyMcFly] Url: [https://fearnopeer.com/torrents/78627]
```

Sample TV
```
[FnP] New Upload - Category: [TV] Type: [WEB-DL] Name: [江河之上 2024 S01E12 1080p WEB-DL AAC 2.0 H.264-HHWEB] Size: [703.09 MiB] Uploader: [oppie] Url: [https://fearnopeer.com/torrents/78626]
```

## IRC Network

- Network name: LibraIRC
- Network address: irc.librairc.net
- Port: 6697
- IRC Channels: \#fearnopeer and \#fearnopeer-announce
- IRC Announce Bot: `FnP`
- SSL/TLS: Yes
- NickServ registration required? No
- Is there a required format for the nick? No
- Invite command: n/a

## Bonus

Check their categories in the announce an on site

Announce categories
- Movies
- TV
- Music
- Anime
- Games
- Apps
- Sport
- Assorted

Announce Types
- Full Disc
- Remux
- Encode
- WEB-DL
- WEBRip
- HDTV
- FLAC
- MP3
- Mac
- Windows
- PlayStation
- AudioBooks
- Books
- Misc

## Other notes
Tested locally and works on my filter that filters minimum and maximum size
