### PR TITLE
fix(filters): remove unusable resolution constants

### DIFF
--- a/web/src/domain/constants.ts
+++ b/web/src/domain/constants.ts
@@ -6,12 +6,12 @@
 import { MultiSelectOption } from "@components/inputs/select";
 
 export const resolutions = [
-  "2160i/p",
-  "1080i/p",
-  "810i/p",
-  "720i/p",
-  "576i/p",
-  "480i/p",
+  "2160p",
+  "1080p",
+  "810p",
+  "720p",
+  "576p",
+  "480p",
 ];
 
 export const RESOLUTION_OPTIONS: MultiSelectOption[] = resolutions.map(r => ({ value: r, label: r, key: r }));

--- a/web/src/domain/constants.ts
+++ b/web/src/domain/constants.ts
@@ -6,14 +6,12 @@
 import { MultiSelectOption } from "@components/inputs/select";
 
 export const resolutions = [
-  "2160p",
-  "1080p",
-  "1080i",
-  "810p",
-  "720p",
-  "576p",
-  "480p",
-  "480i"
+  "2160i/p",
+  "1080i/p",
+  "810i/p",
+  "720i/p",
+  "576i/p",
+  "480i/p",
 ];
 
 export const RESOLUTION_OPTIONS: MultiSelectOption[] = resolutions.map(r => ({ value: r, label: r, key: r }));


### PR DESCRIPTION
The parsing library doesn't differentiate between 1080i and 1080p but we have both options in the resolution dropdown which causes missed releases because autobrr will say that a 1080i is 1080p which will not result in a match..

This PR removes the interlaced option in the resolution dropdown because of that.

~~As a miniscule further change the AHDTV source has been added and an according test with it.~~