### PR TITLE
fix(backend): do not exit on `GOMAXPROCS` error

### DIFF
--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -58,7 +58,7 @@ func main() {
 	undo, err := maxprocs.Set(maxprocs.Logger(zstdlog.NewStdLoggerWithLevel(log.With().Logger(), zerolog.InfoLevel).Printf))
 	defer undo()
 	if err != nil {
-		log.Fatal().Err(err).Msg("failed to set GOMAXPROCS")
+		log.Error().Err(err).Msg("failed to set GOMAXPROCS")
 	}
 
 	// init dynamic config


### PR DESCRIPTION
Do not exit with log fatal on error from setting `GOMAXPROCS`.