### PR TITLE
feat(indexers): add AnimeWorld

### DIFF
--- a/internal/indexer/definitions/animeworld.yaml
+++ b/internal/indexer/definitions/animeworld.yaml
@@ -47,6 +47,12 @@ irc:
       label: NickServ Password
       help: NickServ password
 
+    - name: channels.password
+      type: secret
+      required: true
+      label: Channel Password
+      help: Channel password
+
   parse:
     type: single
     lines:

--- a/internal/indexer/definitions/animeworld.yaml
+++ b/internal/indexer/definitions/animeworld.yaml
@@ -11,7 +11,7 @@ protocol: torrent
 supports:
   - irc
   - rss
-# source: unknown
+# source: UNIT3D
 settings:
   - name: rss_key
     type: secret

--- a/internal/indexer/definitions/animeworld.yaml
+++ b/internal/indexer/definitions/animeworld.yaml
@@ -1,0 +1,113 @@
+---
+#id: animeworld
+name: AnimeWorld
+identifier: animeworld
+description: AnimeWorld is a private indexer for Anime.
+language: de-DE
+urls:
+  - https://animeworld.cx/
+privacy: private
+protocol: torrent
+supports:
+  - irc
+  - rss
+# source: unknown
+settings:
+  - name: rss_key
+    type: secret
+    required: true
+    label: RSS key
+    help: "Your RSS key, required to download torrent files. (User-Avatar -> 'Meine Sicherheit' -> 'RSS Key (RID)')"
+
+irc:
+  network: Rizon
+  server: irc.rizon.net
+  port: 6697
+  tls: true
+  channels:
+    - "#animeworld"
+  announcers:
+    - "ryuko"
+  settings:
+    - name: nick
+      type: text
+      required: true
+      label: Nick
+      help: Bot nick. Eg. user_bot
+
+    - name: auth.account
+      type: text
+      required: true
+      label: NickServ Account
+      help: NickServ account. Make sure to group your main user and bot.
+
+    - name: auth.password
+      type: secret
+      required: true
+      label: NickServ Password
+      help: NickServ password
+
+  parse:
+    type: single
+    lines:
+      - tests:
+        - line: 'Neuer Upload: Magic.S02E10.Ger.Eng.Sub.AAC.1080p.WEB.h264-ABC [Kategorie: Anime Serien][Typ: WebDL][Auflösung: 1080p][Größe: 1.35 GB][FL: 100%] | https://animeworld.cx/torrents/00000 | Uploader: NotAnonymous'
+          expect:
+            torrentName: 'Magic.S02E10.Ger.Eng.Sub.AAC.1080p.WEB.h264-ABC'
+            category: Anime Serien
+            releaseTags: WebDL
+            resolution: 1080p
+            torrentSize: 1.35 GB
+            freeleechPercent: 100
+            baseUrl: https://animeworld.cx/
+            torrentId: "00000"
+            uploader: NotAnonymous
+        - line: 'Neuer Upload: The.Zero.S04.German.DL.DTS.1080p.BluRay.10bit.x265.Repack-ABC [Kategorie: Anime Serien][Typ: Encode][Auflösung: 1080p][Größe: 17.28 GiB][FL: 100%][Vorgestellt] | https://animeworld.cx/torrents/00000 | Uploader: Anonym'
+          expect:
+            torrentName: 'The.Zero.S04.German.DL.DTS.1080p.BluRay.10bit.x265.Repack-ABC'
+            category: Anime Serien
+            releaseTags: Encode
+            resolution: 1080p
+            torrentSize: 17.28 GiB
+            freeleechPercent: 100
+            baseUrl: https://animeworld.cx/
+            torrentId: "00000"
+            uploader: Anonym
+        - line: 'Neuer Upload: How.to.Train.2010.German.DL.AC3.1080p.BluRay.x264-ABC [Kategorie: Cartoon Filme][Typ: Encode][Auflösung: 1080p][Größe: 3.45 GiB][FL: 0%] | https://animeworld.cx/torrents/00000 | Uploader: Anonym'
+          expect:
+            torrentName: 'How.to.Train.2010.German.DL.AC3.1080p.BluRay.x264-ABC'
+            category: Cartoon Filme
+            releaseTags: Encode
+            resolution: 1080p
+            torrentSize: 3.45 GiB
+            freeleechPercent: 0
+            baseUrl: https://animeworld.cx/
+            torrentId: "00000"
+            uploader: Anonym
+        - line: 'Neuer Upload: Irgendein Testrelease ohne Schema [Kategorie: H-Manga / Doujinshi][Typ: Digital][Auflösung: No Res][Größe: 673.21 MiB][FL: 0%] | https://animeworld.cx/torrents/00000 | Uploader: Anonym'
+          expect:
+            torrentName: 'Irgendein Testrelease ohne Schema'
+            category: 'H-Manga / Doujinshi'
+            releaseTags: Digital
+            resolution: No Res
+            torrentSize: 673.21 MiB
+            freeleechPercent: 0
+            baseUrl: https://animeworld.cx/
+            torrentId: "00000"
+            uploader: Anonym
+        pattern: 'Neuer Upload: (.+) \[Kategorie: (.+)\]\[Typ: (.+)\]\[Auflösung: (.+)\]\[Größe: (.+)\]\[FL: (.+)%\](\[Vorgestellt\])? \| (https?\:\/\/.*\/)torrents\/(\d+) \| Uploader: (.+)'
+        vars:
+          - torrentName
+          - category
+          - releaseTags
+          - resolution
+          - torrentSize
+          - freeleechPercent
+          - tags
+          - baseUrl
+          - torrentId
+          - uploader
+
+    match:
+      infourl: "/torrents/{{ .torrentId }}"
+      torrenturl: "/torrent/download/{{ .torrentId }}.{{ .rss_key }}"

--- a/internal/indexer/definitions/animeworld.yaml
+++ b/internal/indexer/definitions/animeworld.yaml
@@ -59,6 +59,7 @@ irc:
             resolution: 1080p
             torrentSize: 1.35 GB
             freeleechPercent: 100
+            tags: ""
             baseUrl: https://animeworld.cx/
             torrentId: "00000"
             uploader: NotAnonymous
@@ -70,7 +71,7 @@ irc:
             resolution: 1080p
             torrentSize: 17.28 GiB
             freeleechPercent: 100
-            tags: "[Vorgestellt]"
+            tags: "Vorgestellt"
             baseUrl: https://animeworld.cx/
             torrentId: "00000"
             uploader: Anonym
@@ -98,7 +99,7 @@ irc:
             baseUrl: https://animeworld.cx/
             torrentId: "00000"
             uploader: Anonym
-        pattern: 'Neuer Upload: (.+) \[Kategorie: (.+)\]\[Typ: (.+)\]\[Auflösung: (.+)\]\[Größe: (.+)\]\[FL: (.+)%\](\[Vorgestellt\])? \| (https?\:\/\/.*\/)torrents\/(\d+) \| Uploader: (.+)'
+        pattern: 'Neuer Upload: (.+) \[Kategorie: (.+)\]\[Typ: (.+)\]\[Auflösung: (.+)\]\[Größe: (.+)\]\[FL: (.+)%\](?:\[(Vorgestellt)\])? \| (https?\:\/\/.*\/)torrents\/(\d+) \| Uploader: (.+)'
         vars:
           - torrentName
           - category

--- a/internal/indexer/definitions/animeworld.yaml
+++ b/internal/indexer/definitions/animeworld.yaml
@@ -70,6 +70,7 @@ irc:
             resolution: 1080p
             torrentSize: 17.28 GiB
             freeleechPercent: 100
+            tags: "[Vorgestellt]"
             baseUrl: https://animeworld.cx/
             torrentId: "00000"
             uploader: Anonym
@@ -81,6 +82,7 @@ irc:
             resolution: 1080p
             torrentSize: 3.45 GiB
             freeleechPercent: 0
+            tags: ""
             baseUrl: https://animeworld.cx/
             torrentId: "00000"
             uploader: Anonym
@@ -92,6 +94,7 @@ irc:
             resolution: No Res
             torrentSize: 673.21 MiB
             freeleechPercent: 0
+            tags: ""
             baseUrl: https://animeworld.cx/
             torrentId: "00000"
             uploader: Anonym

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -371,8 +371,8 @@ export function IndexerAddForm({ isOpen, toggle }: AddProps) {
       const channels: IrcChannel[] = [];
       if (ind.irc?.channels.length) {
         let channelPass = "";
-        if (formData.channels?.password !== "") {
-          channelPass = formData.channels.password;
+        if (formData.irc.channels?.password !== "") {
+          channelPass = formData.irc.channels.password;
         }
 
         ind.irc.channels.forEach(element => {


### PR DESCRIPTION
# Indexer request

-  Do they have irc announce? Yes
- Indexer name: AnimeWorld
- Short name: AW
- URL: https://animeworld.cx
- Download link example: https://animeworld.cx/torrent/download/00000.{rss_key}

## Announce examples

(Release names slightly modified to not use any real but very similar releasenames)

- `Neuer Upload: Magic.S02E10.Ger.Eng.Sub.AAC.1080p.WEB.h264-ABC [Kategorie: Anime Serien][Typ: WebDL][Auflösung: 1080p][Größe: 1.35 GB][FL: 100%] | https://animeworld.cx/torrents/00000 | Uploader: NotAnonymous`
- `Neuer Upload: The.Zero.S04.German.DL.DTS.1080p.BluRay.10bit.x265.Repack-ABC [Kategorie: Anime Serien][Typ: Encode][Auflösung: 1080p][Größe: 17.28 GiB][FL: 100%][Vorgestellt] | https://animeworld.cx/torrents/00000 | Uploader: Anonym`
- `Neuer Upload: How.to.Train.2010.German.DL.AC3.1080p.BluRay.x264-ABC [Kategorie: Cartoon Filme][Typ: Encode][Auflösung: 1080p][Größe: 3.45 GiB][FL: 0%] | https://animeworld.cx/torrents/00000 | Uploader: Anonym`
- `Neuer Upload: Irgendein Testrelease ohne Schema [Kategorie: H-Manga / Doujinshi][Typ: Digital][Auflösung: No Res][Größe: 673.21 MiB][FL: 0%] | https://animeworld.cx/torrents/00000 | Uploader: Anonym`

## IRC Network

- Network name: Rizon
- Network address: irc.rizon.net
- Port: 6697
- SSL/TLS: Yes
- NickServ registration required? Yes
- Is there a required format for the nick? Username|Bot or Username_Bot
- Invite command: None, currently only with a global channel password
(Its possible to add a required password in the settings of the irc network - should that be used or `/join #animeworld password` as an "invite" command instead?)

## Bonus

### Categories:
- Anime Filme
- Anime Serien
- Anime Musik / OSTs
- Anime Spiele
- Anime Hentai
- Software
- Sonstiges
- Filme
- Serien
- Spiele
- Musik
- Manga
- Cartoon Filme
- Cartoon Serie
- H-Manga / Doujinshi

### Types:
- Untouched
- Remux
- Encode
- WebDL
- WebRip
- HDTV
- TVRip
- Lossless Audio
- Lossy Audio
- Scans
- Digital
- Windows
- Mac
- Linux
- Konsole