### PR TITLE
fix(auth): correct redirect on bad session cookie

### DIFF
--- a/web/src/api/QueryClient.tsx
+++ b/web/src/api/QueryClient.tsx
@@ -6,6 +6,7 @@
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { toast } from "react-hot-toast";
 import Toast from "@components/notifications/Toast";
+import { baseUrl } from "@utils";
 
 const MAX_RETRIES = 6;
 const HTTP_STATUS_TO_NOT_RETRY = [400, 401, 403, 404];
@@ -22,7 +23,7 @@ export const queryClient = new QueryClient({
         // @ts-expect-error TS2339: Property status does not exist on type Error
         console.error("bad status, redirect to login", error?.status)
         // Redirect to login page
-        window.location.href = "/login";
+        window.location.href = baseUrl()+"login";
 
         return
       }


### PR DESCRIPTION
Speculative fix for broken redirect to /login when using baseurl. 