### PR TITLE
fix(indexers): could not create

### DIFF
--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -371,7 +371,7 @@ export function IndexerAddForm({ isOpen, toggle }: AddProps) {
       const channels: IrcChannel[] = [];
       if (ind.irc?.channels.length) {
         let channelPass = "";
-        if (formData.irc.channels?.password !== "") {
+        if (formData.irc && formData.irc.channels && formData.irc?.channels?.password !== "") {
           channelPass = formData.irc.channels.password;
         }
 
@@ -412,6 +412,8 @@ export function IndexerAddForm({ isOpen, toggle }: AddProps) {
           network.auth.password = formData.irc.auth.password;
         }
       }
+
+      console.log("network: ", network)
 
       mutation.mutate(formData as Indexer, {
         onSuccess: () => {

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -413,8 +413,6 @@ export function IndexerAddForm({ isOpen, toggle }: AddProps) {
         }
       }
 
-      console.log("network: ", network)
-
       mutation.mutate(formData as Indexer, {
         onSuccess: () => {
           ircMutation.mutate(network);


### PR DESCRIPTION
Fix for creating indexers that does not have the `channels.password` setting, which is all but 2.

Fixes #1478 