### PR TITLE
feat(indexers): Nyaa add trusted, remake and batch tags

### DIFF
--- a/internal/indexer/definitions/nyaa.yaml
+++ b/internal/indexer/definitions/nyaa.yaml
@@ -44,28 +44,37 @@ irc:
     type: single
     lines:
       - tests:
-          - line: '[Live Action - Raw] - 見て、お母さん、私は日本語が書けます！ - (220.30MiB) - https://nyaa.si/view/000000/torrent'
+          - line: "[Live Action - Raw] - 見て、お母さん、私は日本語が書けます！ - (220.30MiB) - https://nyaa.si/view/000000/torrent"
             expect:
               category: Live Action - Raw
-              torrentName: '見て、お母さん、私は日本語が書けます！'
+              torrentName: "見て、お母さん、私は日本語が書けます！"
               torrentSize: 220.30MiB
               baseUrl: https://nyaa.si/
-              torrentId: '000000'
-              
-          - line: '[Anime - English-translated] - [GROUP] Woah [1080p BD AV1] - (3.60GiB) - https://nyaa.si/view/000001/torrent'
+              torrentId: "000000"
+          - line: "[Anime - English-translated] - [GROUP] Woah [1080p BD AV1] - (3.60GiB) - https://nyaa.si/view/000001/torrent"
             expect:
-              category: Anime - English-translated 
-              torrentName: '[GROUP] Woah [1080p BD AV1]'
+              category: Anime - English-translated
+              torrentName: "[GROUP] Woah [1080p BD AV1]"
               torrentSize: 3.60GiB
               baseUrl: https://nyaa.si/
-              torrentId: '000001'
-        pattern: '\[(.*)\] - (.*) - \((\d+\.?\d*[KMGTP]?iB)\) - (https?:\/\/.*\/)view\/(\d+)\/torrent'
+              torrentId: "000001"
+          - line: "[Anime - English-translated] - [GROUP] Woah [1080p x265] - (123.23GiB) - https://nyaa.si/view/000002/torrent trusted"
+            expect:
+              category: Anime - English-translated
+              torrentName: "[GROUP] Woah [1080p x265]"
+              torrentSize: 123.23GiB
+              baseUrl: https://nyaa.si/
+              torrentId: "000002"
+              tags: trusted
+
+        pattern: '\[(.*)\] - (.*) - \((\d+\.?\d*[KMGTP]?iB)\) - (https?:\/\/.*\/)view\/(\d+)\/torrent\s*(trusted|remake|batch)?'
         vars:
           - category
           - torrentName
           - torrentSize
           - baseUrl
           - torrentId
+          - tags
 
     match:
       infourl: "/view/{{ .torrentId }}"

--- a/internal/indexer/definitions/nyaa.yaml
+++ b/internal/indexer/definitions/nyaa.yaml
@@ -51,6 +51,7 @@ irc:
               torrentSize: 220.30MiB
               baseUrl: https://nyaa.si/
               torrentId: "000000"
+              tags: ""
           - line: "[Anime - English-translated] - [GROUP] Woah [1080p BD AV1] - (3.60GiB) - https://nyaa.si/view/000001/torrent"
             expect:
               category: Anime - English-translated
@@ -58,6 +59,7 @@ irc:
               torrentSize: 3.60GiB
               baseUrl: https://nyaa.si/
               torrentId: "000001"
+              tags: ""
           - line: "[Anime - English-translated] - [GROUP] Woah [1080p x265] - (123.23GiB) - https://nyaa.si/view/000002/torrent trusted"
             expect:
               category: Anime - English-translated


### PR DESCRIPTION
The NekoNeko announcer for Nyaa now appends trusted/remake/batch to the end of the announcement line, this PR catches these as tags for use in filters.

While the batch tag is not used on Nyaa, it's mentioned in the FAQ so the addition is there.

**Tags added**:
 - trusted
 - remake
 - batch