### PR TITLE
fix(database-converter): use string concat instead of var substitution

### DIFF
--- a/internal/database/tools/convert.go
+++ b/internal/database/tools/convert.go
@@ -93,7 +93,7 @@ func GetTables() []string {
 func (c *SqliteToPostgresConverter) migrateTable(sqliteDB, postgresDB *sql.DB, table string) []string {
 	var fkViolationMessages []string
 
-	rows, err := sqliteDB.Query("SELECT * FROM ?", table)
+	rows, err := sqliteDB.Query("SELECT * FROM " + table)
 	if err != nil {
 		log.Fatalf("Failed to query SQLite table '%s': %v", table, err)
 	}


### PR DESCRIPTION
We don't need to sanitize the input as it doesn't come from the user and this is simply not allowed in any sql database: https://stackoverflow.com/questions/20678725/how-to-set-table-name-in-dynamic-sql-query

Will test on my local to see if there are other migration issues