### PR TITLE
feat(notifications): add support for custom Telegram api url

### DIFF
--- a/internal/notification/telegram.go
+++ b/internal/notification/telegram.go
@@ -73,7 +73,15 @@ func (s *telegramSender) Send(event domain.NotificationEvent, payload domain.Not
 		return errors.Wrap(err, "could not marshal data: %+v", m)
 	}
 
-	url := fmt.Sprintf("https://api.telegram.org/bot%v/sendMessage", s.Settings.Token)
+	var host string
+
+	if s.Settings.Host == "" {
+		host = "https://api.telegram.org"
+	} else {
+		host = s.Settings.Host
+	}
+
+	url := fmt.Sprintf("%v/bot%v/sendMessage", host, s.Settings.Token)
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(jsonData))
 	if err != nil {

--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -132,6 +132,12 @@ function FormFieldsTelegram() {
         label="Message Thread ID"
         help="Message Thread (topic) of a Supergroup"
       />
+      <TextFieldWide
+        name="host"
+        label="Telegram Api Proxy"
+        help="Reverse proxy domain for api.telegram.org, only needs to be specified if the network you are using has blocked the Telegram API."
+        placeholder="http(s)://ip:port"
+      />
     </div>
   );
 }


### PR DESCRIPTION
Telegram API is blocked in some places. Therefore, I added the feature to allow customizing Telegram API domain name. Very few changes were made. If not specified, it directly uses "https://api.telegram.org/" itself.