### PR TITLE
fix(web): disable pnpm strict version check

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,1 @@
+package-manager-strict=false


### PR DESCRIPTION
```console
soup ➜  web git:(develop) ✗ pnpm install
 ERR_PNPM_BAD_PM_VERSION  This project is configured to use v9.0.2 of pnpm. Your current pnpm is v9.0.4

If you want to bypass this version check, you can set the "package-manager-strict" configuration to "false" or set the "COREPACK_ENABLE_STRICT" environment variable to "0"
```

pnpm install fails without this or `export COREPACK_ENABLE_STRICT=0`