### PR TITLE
feat(auth): improved error handling during login

### DIFF
--- a/web/src/screens/auth/Login.tsx
+++ b/web/src/screens/auth/Login.tsx
@@ -45,9 +45,9 @@ export const Login = () => {
       auth.login(variables.username)
       router.invalidate()
     },
-    onError: () => {
+    onError: (error) => {
       toast.custom((t) => (
-        <Toast type="error" body="Wrong password or username!" t={t} />
+        <Toast type="error" body={error.message || "An error occurred!"} t={t} />
       ));
     }
   });


### PR DESCRIPTION
`onError` now accepts an error object as its argument.

This will help in cases the backend is unreachable. The current version displays a "bad credentials" regardless of error.

![image](https://github.com/autobrr/autobrr/assets/18177310/e510fd6e-57b0-47b3-be52-feda2b371d1d)
![image](https://github.com/autobrr/autobrr/assets/18177310/8d8b1cde-dfed-4b24-b313-dbc6171c80a8)

Thanks for the help Ghost!