### PR TITLE
fix(web): use absolute paths for router links

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -40,7 +40,7 @@
     "@tailwindcss/forms": "^0.5.7",
     "@tanstack/react-query": "^5.29.2",
     "@tanstack/react-query-devtools": "^5.29.2",
-    "@tanstack/react-router": "1.31.0",
+    "@tanstack/react-router": "^1.31.6",
     "@types/node": "^20.12.7",
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@microsoft/eslint-formatter-sarif": "^3.1.0",
     "@rollup/wasm-node": "^4.14.3",
-    "@tanstack/router-devtools": "1.31.0",
+    "@tanstack/router-devtools": "^1.31.6",
     "@types/node": "^20.12.2",
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.23",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^5.29.2
         version: 5.29.2(@tanstack/react-query@5.29.2(react@18.2.0))(react@18.2.0)
       '@tanstack/react-router':
-        specifier: 1.31.0
-        version: 1.31.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^1.31.6
+        version: 1.31.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/node':
         specifier: ^20.12.7
         version: 20.12.7
@@ -141,8 +141,8 @@ importers:
         specifier: ^4.14.3
         version: 4.14.3
       '@tanstack/router-devtools':
-        specifier: 1.31.0
-        version: 1.31.0(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^1.31.6
+        version: 1.31.6(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -175,7 +175,7 @@ importers:
         version: 0.19.8(vite@5.2.9(@types/node@20.12.7)(terser@5.30.1))(workbox-build@7.0.0)(workbox-window@7.0.0)
       vite-plugin-svgr:
         specifier: ^4.2.0
-        version: 4.2.0(@rollup/wasm-node@4.17.0)(typescript@5.4.5)(vite@5.2.9(@types/node@20.12.7)(terser@5.30.1))
+        version: 4.2.0(@rollup/wasm-node@4.17.2)(typescript@5.4.5)(vite@5.2.9(@types/node@20.12.7)(terser@5.30.1))
 
 packages:
 
@@ -1163,8 +1163,8 @@ packages:
     resolution: {integrity: sha512-UyFUQV/iAu/Wt6rY6uQMYBQlfTMsynzYVIz6i7s9ySwjoG9WDNgtkK1TrazCSrUFbmuPZi2gbJm6VWdJCVw2yA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
 
-  '@rollup/wasm-node@4.17.0':
-    resolution: {integrity: sha512-EOKrg8I26cw7+M8mn5PDWfq4TIyJ7OGeZuaK7Pm3wn5nLJYfRH7CQV/IT+j9MpaVW84JPRp2FGqePdyF8FkTEQ==}
+  '@rollup/wasm-node@4.17.2':
+    resolution: {integrity: sha512-4F6C3XaUn02XY/GJMQTXncWrLyCkRHdRZe4OyWuQUprWKmU2u+esISOtCYdr3Bp9AqCIo/X3So2Ik7N9dNDwow==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -1340,8 +1340,8 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
-  '@tanstack/react-router@1.31.0':
-    resolution: {integrity: sha512-WrKyJ7iG2FFzKmVIDAvTsXPwd/8cQZgTl3C/gSgbZ3awS5VtHJBcy69rYV2o7qBNa9JBSpu3X/BVcppDvbXIWg==}
+  '@tanstack/react-router@1.31.6':
+    resolution: {integrity: sha512-Al8IwmZQk0km4p/8KKI8dO6bytZfAnw7ukmP2PMSZX0fEFA3sd9gPbnqBZTA/dHdl4qTLPnbdKWUTz8D4BLoyA==}
     engines: {node: '>=12'}
     peerDependencies:
       react: ^18.2.0
@@ -1359,8 +1359,8 @@ packages:
       react: ^18.2.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
 
-  '@tanstack/router-devtools@1.31.0':
-    resolution: {integrity: sha512-LS1FbqLXa6UddMiD7zXVnw1+u/nlO2A347GJXiz7CbCYZfa+n5G9VHve9IK0mWNG1P8NpKR8I1BTidsJWHfhZQ==}
+  '@tanstack/router-devtools@1.31.6':
+    resolution: {integrity: sha512-vtlEk8uu0eiEjGQVN7okE0ly9XJQ1HZO8e2CwTm4nymUn1N+RRHarbVJcSn9Sh3Hynn7MyqrVquo7VDFT6bzGQ==}
     engines: {node: '>=12'}
     peerDependencies:
       react: ^18.2.0
@@ -4592,43 +4592,43 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.24.3)(@rollup/wasm-node@4.17.0)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.24.3)(@rollup/wasm-node@4.17.2)':
     dependencies:
       '@babel/core': 7.24.3
       '@babel/helper-module-imports': 7.24.3
-      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.17.0)
-      rollup: '@rollup/wasm-node@4.17.0'
+      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.17.2)
+      rollup: '@rollup/wasm-node@4.17.2'
 
-  '@rollup/plugin-node-resolve@11.2.1(@rollup/wasm-node@4.17.0)':
+  '@rollup/plugin-node-resolve@11.2.1(@rollup/wasm-node@4.17.2)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.17.0)
+      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.17.2)
       '@types/resolve': 1.17.1
       builtin-modules: 3.3.0
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.8
-      rollup: '@rollup/wasm-node@4.17.0'
+      rollup: '@rollup/wasm-node@4.17.2'
 
-  '@rollup/plugin-replace@2.4.2(@rollup/wasm-node@4.17.0)':
+  '@rollup/plugin-replace@2.4.2(@rollup/wasm-node@4.17.2)':
     dependencies:
-      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.17.0)
+      '@rollup/pluginutils': 3.1.0(@rollup/wasm-node@4.17.2)
       magic-string: 0.25.9
-      rollup: '@rollup/wasm-node@4.17.0'
+      rollup: '@rollup/wasm-node@4.17.2'
 
-  '@rollup/pluginutils@3.1.0(@rollup/wasm-node@4.17.0)':
+  '@rollup/pluginutils@3.1.0(@rollup/wasm-node@4.17.2)':
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.3.1
-      rollup: '@rollup/wasm-node@4.17.0'
+      rollup: '@rollup/wasm-node@4.17.2'
 
-  '@rollup/pluginutils@5.1.0(@rollup/wasm-node@4.17.0)':
+  '@rollup/pluginutils@5.1.0(@rollup/wasm-node@4.17.2)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: '@rollup/wasm-node@4.17.0'
+      rollup: '@rollup/wasm-node@4.17.2'
 
   '@rollup/wasm-node@4.14.3':
     dependencies:
@@ -4636,7 +4636,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@rollup/wasm-node@4.17.0':
+  '@rollup/wasm-node@4.17.2':
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
@@ -4791,7 +4791,7 @@ snapshots:
       '@tanstack/query-core': 5.29.0
       react: 18.2.0
 
-  '@tanstack/react-router@1.31.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@tanstack/react-router@1.31.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tanstack/history': 1.28.9
       '@tanstack/react-store': 0.2.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -4813,9 +4813,9 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@tanstack/router-devtools@1.31.0(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@tanstack/router-devtools@1.31.6(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tanstack/react-router': 1.31.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/react-router': 1.31.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       clsx: 2.1.0
       date-fns: 2.30.0
       goober: 2.1.14(csstype@3.1.2)
@@ -6643,11 +6643,11 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup-plugin-terser@7.0.2(@rollup/wasm-node@4.17.0):
+  rollup-plugin-terser@7.0.2(@rollup/wasm-node@4.17.2):
     dependencies:
       '@babel/code-frame': 7.24.2
       jest-worker: 26.6.2
-      rollup: '@rollup/wasm-node@4.17.0'
+      rollup: '@rollup/wasm-node@4.17.2'
       serialize-javascript: 4.0.0
       terser: 5.30.1
 
@@ -7065,9 +7065,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-svgr@4.2.0(@rollup/wasm-node@4.17.0)(typescript@5.4.5)(vite@5.2.9(@types/node@20.12.7)(terser@5.30.1)):
+  vite-plugin-svgr@4.2.0(@rollup/wasm-node@4.17.2)(typescript@5.4.5)(vite@5.2.9(@types/node@20.12.7)(terser@5.30.1)):
     dependencies:
-      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.17.0)
+      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.17.2)
       '@svgr/core': 8.1.0(typescript@5.4.5)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.4.5))
       vite: 5.2.9(@types/node@20.12.7)(terser@5.30.1)
@@ -7080,7 +7080,7 @@ snapshots:
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
-      rollup: '@rollup/wasm-node@4.17.0'
+      rollup: '@rollup/wasm-node@4.17.2'
     optionalDependencies:
       '@types/node': 20.12.7
       fsevents: 2.3.3
@@ -7155,9 +7155,9 @@ snapshots:
       '@babel/core': 7.24.3
       '@babel/preset-env': 7.24.3(@babel/core@7.24.3)
       '@babel/runtime': 7.24.1
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.24.3)(@rollup/wasm-node@4.17.0)
-      '@rollup/plugin-node-resolve': 11.2.1(@rollup/wasm-node@4.17.0)
-      '@rollup/plugin-replace': 2.4.2(@rollup/wasm-node@4.17.0)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.24.3)(@rollup/wasm-node@4.17.2)
+      '@rollup/plugin-node-resolve': 11.2.1(@rollup/wasm-node@4.17.2)
+      '@rollup/plugin-replace': 2.4.2(@rollup/wasm-node@4.17.2)
       '@surma/rollup-plugin-off-main-thread': 2.2.3
       ajv: 8.12.0
       common-tags: 1.8.2
@@ -7166,8 +7166,8 @@ snapshots:
       glob: 7.2.3
       lodash: 4.17.21
       pretty-bytes: 5.6.0
-      rollup: '@rollup/wasm-node@4.17.0'
-      rollup-plugin-terser: 7.0.2(@rollup/wasm-node@4.17.0)
+      rollup: '@rollup/wasm-node@4.17.2'
+      rollup-plugin-terser: 7.0.2(@rollup/wasm-node@4.17.2)
       source-map: 0.8.0-beta.0
       stringify-object: 3.3.0
       strip-comments: 2.0.1

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -135,16 +135,9 @@ export const FilterActionsRoute = createRoute({
   component: Actions
 });
 
-const ReleasesRoute = createRoute({
+export const ReleasesRoute = createRoute({
   getParentRoute: () => AuthIndexRoute,
-  path: 'releases'
-});
-
-// type ReleasesSearch = z.infer<typeof releasesSearchSchema>
-
-export const ReleasesIndexRoute = createRoute({
-  getParentRoute: () => ReleasesRoute,
-  path: '/',
+  path: 'releases',
   component: Releases,
   validateSearch: (search) => z.object({
     offset: z.number().optional(),
@@ -347,7 +340,7 @@ export const RootRoute = createRootRouteWithContext<{
 
 const filterRouteTree = FiltersRoute.addChildren([FilterIndexRoute, FilterGetByIdRoute.addChildren([FilterGeneralRoute, FilterMoviesTvRoute, FilterMusicRoute, FilterAdvancedRoute, FilterExternalRoute, FilterActionsRoute])])
 const settingsRouteTree = SettingsRoute.addChildren([SettingsIndexRoute, SettingsLogRoute, SettingsIndexersRoute, SettingsIrcRoute, SettingsFeedsRoute, SettingsClientsRoute, SettingsNotificationsRoute, SettingsApiRoute, SettingsReleasesRoute, SettingsAccountRoute])
-const authenticatedTree = AuthRoute.addChildren([AuthIndexRoute.addChildren([DashboardRoute, filterRouteTree, ReleasesRoute.addChildren([ReleasesIndexRoute]), settingsRouteTree, LogsRoute])])
+const authenticatedTree = AuthRoute.addChildren([AuthIndexRoute.addChildren([DashboardRoute, filterRouteTree, ReleasesRoute, settingsRouteTree, LogsRoute])])
 const routeTree = RootRoute.addChildren([
   authenticatedTree,
   LoginRoute,

--- a/web/src/screens/Settings.tsx
+++ b/web/src/screens/Settings.tsx
@@ -26,16 +26,16 @@ interface NavTabType {
 }
 
 const subNavigation: NavTabType[] = [
-  { name: "Application", href: ".", icon: CogIcon, exact: true },
-  { name: "Logs", href: "logs", icon: Square3Stack3DIcon },
-  { name: "Indexers", href: "indexers", icon: KeyIcon },
-  { name: "IRC", href: "irc", icon: ChatBubbleLeftRightIcon },
-  { name: "Feeds", href: "feeds", icon: RssIcon },
-  { name: "Clients", href: "clients", icon: FolderArrowDownIcon },
-  { name: "Notifications", href: "notifications", icon: BellIcon },
-  { name: "API keys", href: "api", icon: KeyIcon },
-  { name: "Releases", href: "releases", icon: RectangleStackIcon },
-  { name: "Account", href: "account", icon: UserCircleIcon }
+  { name: "Application", href: "/settings", icon: CogIcon, exact: true },
+  { name: "Logs", href: "/settings/logs", icon: Square3Stack3DIcon },
+  { name: "Indexers", href: "/settings/indexers", icon: KeyIcon },
+  { name: "IRC", href: "/settings/irc", icon: ChatBubbleLeftRightIcon },
+  { name: "Feeds", href: "/settings/feeds", icon: RssIcon },
+  { name: "Clients", href: "/settings/clients", icon: FolderArrowDownIcon },
+  { name: "Notifications", href: "/settings/notifications", icon: BellIcon },
+  { name: "API keys", href: "/settings/api", icon: KeyIcon },
+  { name: "Releases", href: "/settings/releases", icon: RectangleStackIcon },
+  { name: "Account", href: "/settings/account", icon: UserCircleIcon }
   // {name: 'Regex Playground', href: 'regex-playground', icon: CogIcon, current: false}
   // {name: 'Rules', href: 'rules', icon: ClipboardCheckIcon, current: false},
 ];

--- a/web/src/screens/filters/Details.tsx
+++ b/web/src/screens/filters/Details.tsx
@@ -33,12 +33,12 @@ interface tabType {
 }
 
 const tabs: tabType[] = [
-  { name: "General", href: ".", exact: true },
-  { name: "Movies and TV", href: "movies-tv" },
-  { name: "Music", href: "music" },
-  { name: "Advanced", href: "advanced" },
-  { name: "External", href: "external" },
-  { name: "Actions", href: "actions" }
+  { name: "General", href: "/filters/$filterId", exact: true },
+  { name: "Movies and TV", href: "/filters/$filterId/movies-tv" },
+  { name: "Music", href: "/filters/$filterId/music" },
+  { name: "Advanced", href: "/filters/$filterId/advanced" },
+  { name: "External", href: "/filters/$filterId/external" },
+  { name: "Actions", href: "/filters/$filterId/actions" }
 ];
 
 export interface NavLinkProps {

--- a/web/src/screens/releases/ReleaseTable.tsx
+++ b/web/src/screens/releases/ReleaseTable.tsx
@@ -16,7 +16,7 @@ import {
   EyeSlashIcon
 } from "@heroicons/react/24/solid";
 
-import { ReleasesIndexRoute } from "@app/routes";
+import { ReleasesRoute } from "@app/routes";
 import { ReleasesListQueryOptions } from "@api/queries";
 import { RandomLinuxIsos } from "@utils";
 
@@ -94,7 +94,7 @@ const EmptyReleaseList = () => (
 );
 
 export const ReleaseTable = () => {
-  const search = ReleasesIndexRoute.useSearch()
+  const search = ReleasesRoute.useSearch()
 
   const columns = React.useMemo(() => [
     {


### PR DESCRIPTION
This PR branches off the branch of #1527 

Due to fixes in `"@tanstack/router-devtools": "^1.31.1"`  
the routes in the arrays for the settings and the filter pages had to be adapted.

During fixing the routes i saw that we had a `ReleasesIndexRoute` that couldn't be accessed  
and that isn't in use for some other part from what i can tell.  
So took the freedom and removed it and moved the component into the parent route `ReleasesRoute`