### PR TITLE
fix(indexers): irc baseurl override for links

### DIFF
--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -336,7 +336,14 @@ func (p *IndexerIRCParse) Parse(def *IndexerDefinition, vars map[string]string, 
 		return errors.Wrap(err, "could not map variables for release")
 	}
 
-	baseUrl := def.URLS[0]
+	baseUrl := def.BaseURL
+	if baseUrl == "" {
+		if len(def.URLS) == 0 {
+			return errors.New("could not find a valid indexer baseUrl")
+		}
+
+		baseUrl = def.URLS[0]
+	}
 
 	// merge vars from regex captures on announce and vars from settings
 	mergedVars := mergeVars(vars, def.SettingsMap)


### PR DESCRIPTION
Fixes an issue where using an alternative URL for the indexer links would not actually update new links for IRC indexers.