### PR TITLE
feat(web): add theme toggle to navbar

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import { useEffect } from "react";
 import { RouterProvider } from "@tanstack/react-router"
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "react-hot-toast";
@@ -10,7 +11,7 @@ import { Portal } from "react-portal";
 import { Router } from "@app/routes";
 import { routerBasePath } from "@utils";
 import { queryClient } from "@api/QueryClient";
-import { AuthContext } from "@utils/Context";
+import { AuthContext, SettingsContext } from "@utils/Context";
 
 declare module '@tanstack/react-router' {
   interface Register {
@@ -19,6 +20,18 @@ declare module '@tanstack/react-router' {
 }
 
 export function App() {
+  const [_, setSettings] = SettingsContext.use();
+
+  useEffect(() => {
+    const themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleThemeChange = (e: MediaQueryListEvent) => {
+      setSettings(prevState => ({ ...prevState, darkTheme: e.matches }));
+    };
+
+    themeMediaQuery.addEventListener('change', handleThemeChange);
+    return () => themeMediaQuery.removeEventListener('change', handleThemeChange);
+  }, [setSettings]);
+
   return (
       <QueryClientProvider client={queryClient}>
         <Portal>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,7 +20,7 @@ declare module '@tanstack/react-router' {
 }
 
 export function App() {
-  const [_, setSettings] = SettingsContext.use();
+  const [ settings, setSettings] = SettingsContext.use();
 
   useEffect(() => {
     const themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,7 +20,7 @@ declare module '@tanstack/react-router' {
 }
 
 export function App() {
-  const [ settings, setSettings] = SettingsContext.use();
+  const [ , setSettings] = SettingsContext.use();
 
   useEffect(() => {
     const themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');

--- a/web/src/components/header/RightNav.tsx
+++ b/web/src/components/header/RightNav.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Fragment, useEffect, useState } from "react";
+import { Fragment } from "react";
 import { UserIcon } from "@heroicons/react/24/solid";
 import { Menu, Transition } from "@headlessui/react";
 
@@ -17,32 +17,6 @@ import { SettingsContext } from "@utils/Context";
 
 export const RightNav = (props: RightNavProps) => {
   const [settings, setSettings] = SettingsContext.use();
-  const [osTheme, setOsTheme] = useState(window.matchMedia('(prefers-color-scheme: dark)').matches);
-
-  useEffect(() => {
-    const themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const handleThemeChange = (e: MediaQueryListEvent) => {
-      setOsTheme(e.matches);
-      // update settings based on OS preference
-      setSettings(prevState => ({ ...prevState, darkTheme: e.matches }));
-    };
-
-    themeMediaQuery.addEventListener('change', handleThemeChange);
-    return () => themeMediaQuery.removeEventListener('change', handleThemeChange);
-  }, [setSettings]);
-
-  useEffect(() => {
-    // load theme from local storage on initial load
-    const savedSettings = localStorage.getItem('settings');
-    if (savedSettings) {
-      const parsedSettings = JSON.parse(savedSettings);
-      setSettings(parsedSettings);
-    }
-  }, [setSettings]);
-
-  useEffect(() => {
-    localStorage.setItem('settings', JSON.stringify(settings));
-  }, [settings]);
 
   const toggleTheme = () => {
     setSettings(prevState => ({
@@ -51,7 +25,7 @@ export const RightNav = (props: RightNavProps) => {
     }));
   };
 
-  const themeIcon = settings.darkTheme !== undefined ? settings.darkTheme : osTheme;
+  const themeIcon = settings.darkTheme;
 
 
   return (

--- a/web/src/components/header/RightNav.tsx
+++ b/web/src/components/header/RightNav.tsx
@@ -25,9 +25,6 @@ export const RightNav = (props: RightNavProps) => {
     }));
   };
 
-  const themeIcon = settings.darkTheme;
-
-
   return (
     <div className="hidden sm:block">
       <div className="ml-4 flex items-center sm:ml-6">
@@ -35,7 +32,7 @@ export const RightNav = (props: RightNavProps) => {
           <button
             onClick={toggleTheme}
             className="p-1 rounded-full focus:outline-none focus:none transition duration-100 ease-out transform hover:bg-gray-200 dark:hover:bg-gray-800 hover:scale-100">
-            {themeIcon ? (
+            {settings.darkTheme ? (
               <MoonIcon className="h-4 w-4 text-gray-500 transition duration-100 ease-out transform" aria-hidden="true" />
             ) : (
               <SunIcon className="h-4 w-4 text-gray-600" aria-hidden="true" />

--- a/web/src/components/header/RightNav.tsx
+++ b/web/src/components/header/RightNav.tsx
@@ -3,21 +3,72 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Fragment } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { UserIcon } from "@heroicons/react/24/solid";
 import { Menu, Transition } from "@headlessui/react";
 
 import { classNames } from "@utils";
 
 import { RightNavProps } from "./_shared";
-import { Cog6ToothIcon, ArrowLeftOnRectangleIcon } from "@heroicons/react/24/outline";
-import {Link} from "@tanstack/react-router";
+
+import { Cog6ToothIcon, ArrowLeftOnRectangleIcon, MoonIcon, SunIcon } from "@heroicons/react/24/outline";
+import { Link } from "@tanstack/react-router";
+import { SettingsContext } from "@utils/Context";
 
 export const RightNav = (props: RightNavProps) => {
+  const [settings, setSettings] = SettingsContext.use();
+  const [osTheme, setOsTheme] = useState(window.matchMedia('(prefers-color-scheme: dark)').matches);
+
+  useEffect(() => {
+    const themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleThemeChange = (e: MediaQueryListEvent) => {
+      setOsTheme(e.matches);
+      // update settings based on OS preference
+      setSettings(prevState => ({ ...prevState, darkTheme: e.matches }));
+    };
+
+    themeMediaQuery.addEventListener('change', handleThemeChange);
+    return () => themeMediaQuery.removeEventListener('change', handleThemeChange);
+  }, [setSettings]);
+
+  useEffect(() => {
+    // load theme from local storage on initial load
+    const savedSettings = localStorage.getItem('settings');
+    if (savedSettings) {
+      const parsedSettings = JSON.parse(savedSettings);
+      setSettings(parsedSettings);
+    }
+  }, [setSettings]);
+
+  useEffect(() => {
+    localStorage.setItem('settings', JSON.stringify(settings));
+  }, [settings]);
+
+  const toggleTheme = () => {
+    setSettings(prevState => ({
+      ...prevState,
+      darkTheme: !prevState.darkTheme
+    }));
+  };
+
+  const themeIcon = settings.darkTheme !== undefined ? settings.darkTheme : osTheme;
+
+
   return (
     <div className="hidden sm:block">
       <div className="ml-4 flex items-center sm:ml-6">
-        <Menu as="div" className="ml-3 relative">
+        <div className="mt-1 items-center">
+          <button
+            onClick={toggleTheme}
+            className="p-1 rounded-full focus:outline-none focus:none transition duration-100 ease-out transform hover:bg-gray-200 dark:hover:bg-gray-800 hover:scale-100">
+            {themeIcon ? (
+              <MoonIcon className="h-4 w-4 text-gray-500 transition duration-100 ease-out transform" aria-hidden="true" />
+            ) : (
+              <SunIcon className="h-4 w-4 text-gray-600" aria-hidden="true" />
+            )}
+          </button>
+        </div>
+        <Menu as="div" className="ml-2 relative">
           {({ open }) => (
             <>
               <Menu.Button

--- a/web/src/components/header/RightNav.tsx
+++ b/web/src/components/header/RightNav.tsx
@@ -31,7 +31,9 @@ export const RightNav = (props: RightNavProps) => {
         <div className="mt-1 items-center">
           <button
             onClick={toggleTheme}
-            className="p-1 rounded-full focus:outline-none focus:none transition duration-100 ease-out transform hover:bg-gray-200 dark:hover:bg-gray-800 hover:scale-100">
+            className="p-1 rounded-full focus:outline-none focus:none transition duration-100 ease-out transform hover:bg-gray-200 dark:hover:bg-gray-800 hover:scale-100"
+            title={settings.darkTheme ? "Switch to light mode (currently dark mode)" : "Switch to dark mode (currently light mode)"}
+          >
             {settings.darkTheme ? (
               <MoonIcon className="h-4 w-4 text-gray-500 transition duration-100 ease-out transform" aria-hidden="true" />
             ) : (

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -35,7 +35,7 @@ export type FilterListState = {
 const SettingsContextDefaults: SettingsType = {
   debug: false,
   checkForUpdates: true,
-  darkTheme: true,
+  darkTheme: window.matchMedia('(prefers-color-scheme: dark)').matches,
   scrollOnNewLog: false,
   indentLogLines: false,
   hideWrappedText: false
@@ -77,19 +77,9 @@ const FilterListKey = "autobrr_filter_list";
 
 export const InitializeGlobalContext = () => {
   // ContextMerger<AuthInfo>(localStorageUserKey, AuthContextDefaults, AuthContextt);
-  const storedSettings = localStorage.getItem(SettingsKey);
-  let initialSettings: SettingsType;
-
-  if (storedSettings) {
-    initialSettings = JSON.parse(storedSettings);
-  } else {
-    // Fallback to OS theme preference if no settings are stored
-    const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    initialSettings = { ...SettingsContextDefaults, darkTheme: prefersDarkMode };
-  };
   ContextMerger<SettingsType>(
     SettingsKey,
-    initialSettings,
+    SettingsContextDefaults,
     SettingsContext
   );
   ContextMerger<FilterListState>(

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -77,9 +77,19 @@ const FilterListKey = "autobrr_filter_list";
 
 export const InitializeGlobalContext = () => {
   // ContextMerger<AuthInfo>(localStorageUserKey, AuthContextDefaults, AuthContextt);
+  const storedSettings = localStorage.getItem(SettingsKey);
+  let initialSettings: SettingsType;
+
+  if (storedSettings) {
+    initialSettings = JSON.parse(storedSettings);
+  } else {
+    // Fallback to OS theme preference if no settings are stored
+    const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    initialSettings = { ...SettingsContextDefaults, darkTheme: prefersDarkMode };
+  };
   ContextMerger<SettingsType>(
     SettingsKey,
-    SettingsContextDefaults,
+    initialSettings,
     SettingsContext
   );
   ContextMerger<FilterListState>(


### PR DESCRIPTION
Added a dynamic theme switcher to the navbar for light/dark mode toggling.

Additionally, it now listens for system-level theme changes, and defaults to system-preferred theme when localstorage is empty.

![CleanShot 2024-05-06 at 15 47 08@2x](https://github.com/autobrr/autobrr/assets/18177310/8edf573e-0b48-4083-8a2e-f9e2a7ec5592)
![CleanShot 2024-05-06 at 15 46 59@2x](https://github.com/autobrr/autobrr/assets/18177310/fbd8c5e3-d4f6-46fc-80ed-aaeb78611834)
