### PR TITLE
feat(web): update meta-theme color

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,6 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#141415" />
     <meta name="description" content="autobrr" />
     <link rel="preload" href="/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin="use-credentials">
     <link rel="apple-touch-icon" href="/logo192.png" />

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -111,9 +111,28 @@ export const SettingsContext = newRidgeState<SettingsType>(
     onSet: (newState, prevState) => {
       document.documentElement.classList.toggle("dark", newState.darkTheme);
       DefaultSetter(SettingsKey, newState, prevState);
+      updateMetaThemeColor(newState.darkTheme);
     }
   }
 );
+
+/**
+ * Updates the meta theme color based on the current theme state.
+ * Used by Safari to color the compact tab bar on both iOS and MacOS.
+ */
+const updateMetaThemeColor = (_darkTheme: boolean) => {
+  const root = document.documentElement;
+  const color = getComputedStyle(root).getPropertyValue('--rmsc-bg').trim();
+
+  let metaThemeColor: HTMLMetaElement | null = document.querySelector('meta[name="theme-color"]');
+  if (!metaThemeColor) {
+    metaThemeColor = document.createElement('meta') as HTMLMetaElement;
+    metaThemeColor.name = "theme-color";
+    document.head.appendChild(metaThemeColor);
+  }
+
+  metaThemeColor.content = color;
+};
 
 export const FilterListContext = newRidgeState<FilterListState>(
   FilterListContextDefaults,


### PR DESCRIPTION
Used by Safari for its colored compact tab bar

![CleanShot 2024-05-08 at 11 58 08@2x](https://github.com/autobrr/autobrr/assets/18177310/f87e0b69-3975-492c-9d22-10df16cbfa7a)
![CleanShot 2024-05-08 at 11 56 52@2x](https://github.com/autobrr/autobrr/assets/18177310/a2679d13-7fd6-414c-8b54-585e51d95ade)