### PR TITLE
fix(web): qbittorrent action rules spacing

### DIFF
--- a/web/src/components/inputs/select.tsx
+++ b/web/src/components/inputs/select.tsx
@@ -277,7 +277,7 @@ export const Select = ({
     <div
       className={classNames(
         className ?? "col-span-12",
-        columns? `sm:col-span-${columns}` : "",
+        columns ? `sm:col-span-${columns}` : ""
       )}
     >
       <Field name={name} type="select">

--- a/web/src/components/inputs/select.tsx
+++ b/web/src/components/inputs/select.tsx
@@ -261,6 +261,7 @@ export interface SelectFieldProps {
   options: SelectFieldOption[];
   columns?: COL_WIDTHS;
   tooltip?: JSX.Element;
+  className?: string;
 }
 
 export const Select = ({
@@ -269,13 +270,14 @@ export const Select = ({
   tooltip,
   optionDefaultText,
   options,
-  columns = 6
+  columns = 6,
+  className
 }: SelectFieldProps) => {
   return (
     <div
       className={classNames(
-        "col-span-12",
-        columns ? `sm:col-span-${columns}` : ""
+        className ?? "col-span-12",
+        columns? `sm:col-span-${columns}` : "",
       )}
     >
       <Field name={name} type="select">

--- a/web/src/screens/filters/sections/action_components/ActionQBittorrent.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionQBittorrent.tsx
@@ -95,6 +95,18 @@ export const QBittorrent = ({ idx, action, clients }: ClientActionProps) => (
             label="Content Layout"
             optionDefaultText="Select content layout"
             options={ActionContentLayoutOptions}
+            className="py-2 pb-4"
+          />
+          <Input.Select
+            name={`actions.${idx}.priority`}
+            label="Priority"
+            optionDefaultText="Disabled"
+            options={ActionPriorityOptions}
+            tooltip={
+              <div>
+                <p>Torrent Queueing will be enabled for you if it is disabled. Ensure you set your preferred limits for it in your client.</p>
+              </div>
+            }
           />
         </FilterSection.HalfRow>
 
@@ -108,24 +120,13 @@ export const QBittorrent = ({ idx, action, clients }: ClientActionProps) => (
             name={`actions.${idx}.skip_hash_check`}
             label="Skip hash check"
             description="Add torrent and skip hash check"
+            className="pt-4 sm:pt-4"
           />
           <Input.SwitchGroup
             name={`actions.${idx}.first_last_piece_prio`}
             label="Download first and last pieces first"
             description="Add torrent and download first and last pieces first"
-          />
-        </FilterSection.HalfRow>
-        <FilterSection.HalfRow>
-        <Input.Select
-            name={`actions.${idx}.priority`}
-            label="Priority"
-            optionDefaultText="Disabled"
-            options={ActionPriorityOptions}
-            tooltip={
-              <div>
-                <p>Torrent Queueing will be enabled for you if it is disabled. Ensure you set your preferred limits for it in your client.</p>
-              </div>
-            }
+            className="pt-6 sm:pt-10"
           />
         </FilterSection.HalfRow>
       </CollapsibleSection>


### PR DESCRIPTION
This PR fixes the spacing between the input field of the qbittorrent action rules in 1.42.0-rc1
Left is old - right is new.

![2024-05-08_17-00](https://github.com/autobrr/autobrr/assets/35452459/16a13631-7196-4a71-b1aa-bb7b9e316852)

![2024-05-08_17-02](https://github.com/autobrr/autobrr/assets/35452459/e85acb11-da96-45ed-bb78-aefebf662586)
