### PR TITLE
fix(web): root pending component placement

### DIFF
--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -337,8 +337,10 @@ export const RootRoute = createRootRouteWithContext<{
   component: RootComponent,
   notFoundComponent: NotFound,
   pendingComponent: () => (
-    <div className="flex flex-grow items-center justify-center h-screen">
-      <RingResizeSpinner className="text-blue-500 size-24"/>
+    <div className="h-screen">
+      <div className="flex flex-grow items-center justify-center h-screen sm:h-3/5">
+        <RingResizeSpinner className="text-blue-500 size-24"/>
+      </div>
     </div>
   ),
 });

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -336,6 +336,11 @@ export const RootRoute = createRootRouteWithContext<{
 }>()({
   component: RootComponent,
   notFoundComponent: NotFound,
+  pendingComponent: () => (
+    <div className="flex flex-grow items-center justify-center h-screen">
+      <RingResizeSpinner className="text-blue-500 size-24"/>
+    </div>
+  ),
 });
 
 const filterRouteTree = FiltersRoute.addChildren([FilterIndexRoute, FilterGetByIdRoute.addChildren([FilterGeneralRoute, FilterMoviesTvRoute, FilterMusicRoute, FilterAdvancedRoute, FilterExternalRoute, FilterActionsRoute])])


### PR DESCRIPTION
This PR sets the root pending component for desktop to 30% height and centers it for mobile.
Before the root pending component was stuck at the top of the screen.
Other pending components are not affected by this change.

Old:
![2024-05-09_08-02](https://github.com/autobrr/autobrr/assets/35452459/18e15b6d-eed1-4f0a-85c9-40f56b5250de)

New:
![2024-05-09_08-48](https://github.com/autobrr/autobrr/assets/35452459/3e36b690-d711-4531-9968-ab41ab673e32)

