### PR TITLE
fix(indexers): new IPT announce bot name

### DIFF
--- a/internal/indexer/definitions/iptorrents.yaml
+++ b/internal/indexer/definitions/iptorrents.yaml
@@ -38,6 +38,7 @@ irc:
     - "#ipt.announce"
   announcers:
     - IPT
+    - IPT_Announce
     - FunTimes
   settings:
     - name: nick


### PR DESCRIPTION
In case this won't be a permanent change on their side, just close this PR.