### PR TITLE
fix(auth): show correct error when providing wrong current password at credential change

### DIFF
--- a/web/src/screens/settings/Account.tsx
+++ b/web/src/screens/settings/Account.tsx
@@ -61,6 +61,11 @@ function Credentials() {
 
   const updateUserMutation = useMutation({
     mutationFn: (data: UserUpdate) => APIClient.auth.updateUser(data),
+    onError: () => {
+      toast.custom((t) => (
+        <Toast type="error" body="Error updating credentials. Did you provide the correct current password?" t={t} />
+      ));
+    },
     onSuccess: () => {
       logoutMutation.mutate();
     }


### PR DESCRIPTION
Due to PR #1527, when changing credentials in the account settings,
there is now an incorrect error when providing no or an incorrect current password.

Correct me if i am wrong, but the since the only thing that can go wrong here,   
is that either no or an invalid password has been provided we can just catch the error on the `updateUserMutation`
and return the correct error message in a toast.

Mea culpa, should've caught that beforehand.