### PR TITLE
docs: add note that postgres tests require UTC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,12 @@ Then run all tests:
 go test ./... -tags=integration
 ```
 
+NOTE: The `test_postgres` container runs in timezone UTC.  If your host is not configured in timezone UTC, then the tests will fail.  To configure an Ubuntu host, execute:
+
+```shell
+sudo timedatectl set-timezone Etc/UTC
+```
+
 ## Build Docker image
 
 To build a Docker image, run:
@@ -186,4 +192,3 @@ go run test/mockindexer/main.go
 * Go to Settings -> IRC and toggle the IRC network `Mock Indexer`
 * Add a new Filter or add the indexer to an existing filter
 * Open a new tab and navigate to [http://localhost:3999](http://localhost:3999) and put the example announce in the input then hit enter
-


### PR DESCRIPTION
The tests fail if the host is not configured for UTC.  A note in the CONTRIBUTING doc would have saved me hours debugging the failed test.

```
$ sudo timedatectl set-timezone America/New_York
$ go clean -testcache
$ go test ./internal/database -tags=integration
...
--- FAIL: TestFilterRepo_GetDownloadsByFilterId (0.03s)
    --- FAIL: TestFilterRepo_GetDownloadsByFilterId/GetDownloadsByFilterId_Succeeds_[postgres] (0.02s)
        filter_test.go:817:
                Error Trace:    /home/kenstir/opensource/autobrr/internal/database/filter_test.go:817
                Error:          Not equal:
                                expected: &domain.FilterDownloads{HourCount:0, DayCount:0, WeekCount:1, MonthCount:1, TotalCount:1}
                                actual  : &domain.FilterDownloads{HourCount:1, DayCount:1, WeekCount:1, MonthCount:1, TotalCount:1}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,4 +1,4 @@
                                 (*domain.FilterDownloads)({
                                - HourCount: (int) 0,
                                - DayCount: (int) 0,
                                + HourCount: (int) 1,
                                + DayCount: (int) 1,
                                  WeekCount: (int) 1,
                Test:           TestFilterRepo_GetDownloadsByFilterId/GetDownloadsByFilterId_Succeeds_[postgres]
FAIL
FAIL    github.com/autobrr/autobrr/internal/database    1.513s
```

If you change to UTC, they pass:
```
$ sudo timedatectl set-timezone Etc/UTC
$ go clean -testcache
$ go test ./internal/database -tags=integration
ok      github.com/autobrr/autobrr/internal/database    1.505s
```
