### PR TITLE
fix(web): add notification panel

### DIFF
--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -355,9 +355,7 @@ export function NotificationAddForm({ isOpen, toggle }: AddProps) {
         onClose={toggle}
       >
         <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-0" />
-
-          <div className="absolute inset-y-0 right-0 pl-10 max-w-full flex sm:pl-16">
+          <DialogPanel className="absolute inset-y-0 right-0 pl-10 max-w-full flex sm:pl-16">
             <TransitionChild
               as={Fragment}
               enter="transform transition ease-in-out duration-500 sm:duration-700"
@@ -524,7 +522,7 @@ export function NotificationAddForm({ isOpen, toggle }: AddProps) {
                 </Formik>
               </div>
             </TransitionChild>
-          </div>
+          </DialogPanel>
         </div>
       </Dialog>
     </Transition>


### PR DESCRIPTION
During the headlessUI v2 refactor the notification settings form slideover slipped through my fingers,
resulting in it not being clickable. Instead it will just close again.
This PR fixes this unwanted behaviour.

Mea culpa for this oversight on my part!