### PR TITLE
feat(filters): add SLOVAK language option

### DIFF
--- a/web/src/domain/constants.ts
+++ b/web/src/domain/constants.ts
@@ -206,6 +206,7 @@ export const languageOptions = [
   "PORTUGUESE",
   "ROMANiAN",
   "RUSSiAN",
+  "SLOVAK",
   "SPANiSH",
   "SUBBED",
   "SUBFORCED",


### PR DESCRIPTION
This PR adds `SLOVAK` as an language option in the advanced filters which has previously been missing.