### PR TITLE
fix(indexers): OPS log score parsing

### DIFF
--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -207,8 +207,12 @@ func (p IRCParserOrpheus) Parse(rls *Release, vars map[string]string) error {
 	year := vars["year"]
 	releaseTagsString := vars["releaseTags"]
 
-	//cleanTags := strings.ReplaceAll(releaseTagsString, "/", " ")
-	cleanTags := CleanReleaseTags(releaseTagsString)
+	cleanTags := CleanReleaseTags(strings.ReplaceAll(releaseTagsString, "/", " "))
+	splittedTags := strings.Split(cleanTags, " ")
+	// Check and replace "100" with "100%" if it's the last tag
+	if len(splittedTags) > 0 && splittedTags[len(splittedTags)-1] == "100" {
+		splittedTags[len(splittedTags)-1] = "100%"
+	}
 
 	tags := ParseReleaseTagString(cleanTags)
 	rls.ReleaseTags = cleanTags

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -207,11 +207,12 @@ func (p IRCParserOrpheus) Parse(rls *Release, vars map[string]string) error {
 	year := vars["year"]
 	releaseTagsString := vars["releaseTags"]
 
-	cleanTags := CleanReleaseTags(strings.ReplaceAll(releaseTagsString, "/", " "))
-	splittedTags := strings.Split(cleanTags, " ")
+	cleanTags := CleanReleaseTags(releaseTagsString)
+	splittedTags := strings.Split(cleanTags, "/")
 	// Check and replace "100" with "100%" if it's the last tag
 	if len(splittedTags) > 0 && splittedTags[len(splittedTags)-1] == "100" {
 		splittedTags[len(splittedTags)-1] = "100%"
+		strings.Join(splittedTags, " ")
 	}
 
 	tags := ParseReleaseTagString(cleanTags)

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -79,7 +79,7 @@ func TestIndexersParseAndFilter(t *testing.T) {
 				{
 					name: "announce_2",
 					args: args{
-						announceLines: []string{"TORRENT: Dirty Dike – Bogies & Alcohol – [2024] [EP] CD/FLAC/Lossless – hip.hop,uk.hip.hop,united.kingdom – https://orpheus.network/torrents.php?id=0000000 – https://orpheus.network/torrents.php?id=0000000&torrentid=0000000&action=download"},
+						announceLines: []string{"TORRENT: Dirty Dike – Bogies & Alcohol – [2024] [EP] CD/FLAC/Lossless/Cue/Log/100 – hip.hop,uk.hip.hop,united.kingdom – https://orpheus.network/torrents.php?id=0000000 – https://orpheus.network/torrents.php?id=0000000&torrentid=0000000&action=download"},
 						filters: []filterTest{
 							{
 								filter: &domain.Filter{
@@ -89,6 +89,22 @@ func TestIndexersParseAndFilter(t *testing.T) {
 									Quality:         []string{"Lossless"},
 									Sources:         []string{"CD"},
 									Formats:         []string{"FLAC"},
+									Artists:         "Dirty Dike",
+									Albums:          "Bogies & Alcohol",
+								},
+								match: true,
+							},
+							{
+								filter: &domain.Filter{
+									Name:            "filter_1",
+									MatchCategories: "EP,Album",
+									Years:           "2024",
+									Quality:         []string{"Lossless"},
+									Sources:         []string{"CD"},
+									Formats:         []string{"FLAC"},
+									Log:             true,
+									LogScore:        100,
+									PerfectFlac:     true,
 									Artists:         "Dirty Dike",
 									Albums:          "Bogies & Alcohol",
 								},
@@ -106,6 +122,30 @@ func TestIndexersParseAndFilter(t *testing.T) {
 								},
 								match:      false,
 								rejections: []string{"albums not matching. got: Bogies & Alcohol want: Best album", "quality not matching. got: [FLAC Lossless] want: [24bit Lossless]"},
+							},
+						},
+					},
+					match: false,
+				},
+				{
+					name: "announce_3",
+					args: args{
+						announceLines: []string{"TORRENT: Dirty Dike – Bogies & Alcohol – [2024] [EP] CD/FLAC/Lossless/Cue/Log/80 – hip.hop,uk.hip.hop,united.kingdom – https://orpheus.network/torrents.php?id=0000000 – https://orpheus.network/torrents.php?id=0000000&torrentid=0000000&action=download"},
+						filters: []filterTest{
+							{
+								filter: &domain.Filter{
+									Name:            "filter_1",
+									MatchCategories: "EP,Album",
+									Years:           "2024",
+									Quality:         []string{"24bit Lossless"},
+									Sources:         []string{"CD"},
+									Formats:         []string{"FLAC"},
+									Log:             true,
+									LogScore:        100,
+									Albums:          "Best album",
+								},
+								match:      false,
+								rejections: []string{"albums not matching. got: Bogies & Alcohol want: Best album", "quality not matching. got: [Cue FLAC Lossless Log80 Log] want: [24bit Lossless]", "log score. got 80 want: 100"},
 							},
 						},
 					},


### PR DESCRIPTION
The message from OPS Announce does not contain a % sign and that seemed to break it. This is probably not the best fix but it is something.

> CD/FLAC/Lossless/Cue/Log/100

#1535 Attemping to fix this issue.