### PR TITLE
fix(web): filter dropdown cut off

### DIFF
--- a/web/src/screens/filters/List.tsx
+++ b/web/src/screens/filters/List.tsx
@@ -396,7 +396,8 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
         leaveTo="transform opacity-0 scale-95"
       >
         <Menu.Items
-          className="absolute right-0 w-56 mt-2 origin-top-right bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
+          anchor={{ to: 'bottom end', padding: '8px' }} // padding: '8px' === m-2
+          className="absolute w-56 bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
         >
           <div className="px-1 py-1">
             <Menu.Item>


### PR DESCRIPTION
This PR fixes the filter dropdowns being cutoff when there is not enough space towards the bottom edge of the viewport.

There is still *some* weird behaviour when there isn't enough space towards the bottom and the top.
In this case a scrollbar will appear for the dropdown but
you still won't be able to scroll to all the entries on viewports with very low height.
However, the case that there isn't enough space towards the bottom and the top feels very unprobable.

fixes #1597 