### PR TITLE
fix(web): root pending component placement

### DIFF
--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -319,7 +319,7 @@ export const AuthIndexRoute = createRoute({
 export const RootComponent = () => {
   const settings = SettingsContext.useValue();
   return (
-    <div className="min-h-screen">
+    <div className="flex flex-col min-h-screen">
       <Outlet/>
       {settings.debug ? (
         <>
@@ -350,7 +350,7 @@ const routeTree = RootRoute.addChildren([
 export const Router = createRouter({
   routeTree,
   defaultPendingComponent: () => (
-    <div className="flex flex-grow items-center justify-center col-span-9 h-full">
+    <div className="flex flex-grow items-center justify-center col-span-9">
       <RingResizeSpinner className="text-blue-500 size-24"/>
     </div>
   ),


### PR DESCRIPTION
This PR centers the pending component on the RootRoute vertically again.

I don't know which change I made, caused that regression (and i couldn't be bothered to check) 
but this PR fixes it again and the placement of the pending component in other places such as:
- Dashboard
- Filters
- Release
- Submenus of Settings

are still centered aswell.