### PR TITLE
fix(docker): update deprecated LABEL format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISIO
 # build runner
 FROM alpine:latest
 
-LABEL org.opencontainers.image.source = "https://github.com/autobrr/autobrr"
+LABEL org.opencontainers.image.source="https://github.com/autobrr/autobrr"
 
 ENV HOME="/config" \
     XDG_CONFIG_HOME="/config" \

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -15,7 +15,9 @@ COPY . ./
 ARG VERSION=dev
 ARG REVISION=dev
 ARG BUILDTIME
-ARG TARGETOS TARGETARCH TARGETVARIANT
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 RUN --network=none --mount=target=. \
 export GOOS=$TARGETOS; \
@@ -30,9 +32,9 @@ go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -
 # build runner
 FROM alpine:latest AS runner
 
-LABEL org.opencontainers.image.source = "https://github.com/autobrr/autobrr"
-LABEL org.opencontainers.image.licenses = "GPL-2.0-or-later"
-LABEL org.opencontainers.image.base.name = "alpine:latest"
+LABEL org.opencontainers.image.source="https://github.com/autobrr/autobrr"
+LABEL org.opencontainers.image.licenses="GPL-2.0-or-later"
+LABEL org.opencontainers.image.base.name="alpine:latest"
 
 ENV HOME="/config" \
     XDG_CONFIG_HOME="/config" \

--- a/goreleaser.Dockerfile
+++ b/goreleaser.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-LABEL org.opencontainers.image.source = "https://github.com/autobrr/autobrr"
+LABEL org.opencontainers.image.source="https://github.com/autobrr/autobrr"
 
 ENV HOME="/config" \
 XDG_CONFIG_HOME="/config" \


### PR DESCRIPTION
Fix for https://docs.docker.com/reference/build-checks/legacy-key-value-format/