### PR TITLE
fix(diagnostics): profiling config flags

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,7 +88,7 @@ sessionSecret = "{{ .sessionSecret }}"
 
 # Golang pprof profiling and tracing
 #
-#profiling = false
+#profilingEnabled = false
 #
 #profilingHost = "127.0.0.1"
 #
@@ -315,7 +315,7 @@ func (c *AppConfig) loadFromEnv() {
 		c.Config.PostgresExtraParams = v
 	}
 
-	if v := os.Getenv(prefix + "PROFILING"); v != "" {
+	if v := os.Getenv(prefix + "PROFILING_ENABLED"); v != "" {
 		c.Config.ProfilingEnabled = strings.EqualFold(strings.ToLower(v), "true")
 	}
 

--- a/internal/diagnostics/profiling.go
+++ b/internal/diagnostics/profiling.go
@@ -16,11 +16,11 @@ func SetupProfiling(enabled bool, host string, port int) {
 	if enabled {
 		go func() {
 			// pprof has an init method which adds the following endpoints
-			// http.HandleFunc(prefix+"/debug/pprof/", Index)
-			// http.HandleFunc(prefix+"/debug/pprof/cmdline", Cmdline)
-			// http.HandleFunc(prefix+"/debug/pprof/profile", Profile)
-			// http.HandleFunc(prefix+"/debug/pprof/symbol", Symbol)
-			// http.HandleFunc(prefix+"/debug/pprof/trace", Trace)
+			// GET /debug/pprof/
+			// GET /debug/pprof/cmdline
+			// GET /debug/pprof/profile
+			// GET /debug/pprof/symbol
+			// GET /debug/pprof/trace
 			err := http.ListenAndServe(fmt.Sprintf("%s:%d", host, port), nil)
 			if err != nil {
 				log.Printf("Error starting profiling server: %v", err)

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	PostgresPass        string `toml:"postgresPass"`
 	PostgresSSLMode     string `toml:"postgresSSLMode"`
 	PostgresExtraParams string `toml:"postgresExtraParams"`
-	ProfilingEnabled    bool   `toml:"profiling"`
+	ProfilingEnabled    bool   `toml:"profilingEnabled"`
 	ProfilingHost       string `toml:"profilingHost"`
 	ProfilingPort       int    `toml:"profilingPort"`
 }


### PR DESCRIPTION
Fix for reading enabled flag for profiling in config file.