### PR TITLE
fix(web): remove unused `checkForUpdates` JSON object

### DIFF
--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -8,7 +8,6 @@ import { newRidgeState } from "react-ridge-state";
 
 interface SettingsType {
   debug: boolean;
-  checkForUpdates: boolean;
   darkTheme: boolean;
   scrollOnNewLog: boolean;
   indentLogLines: boolean;
@@ -34,7 +33,6 @@ const AuthContextDefaults: AuthInfo = {
 
 const SettingsContextDefaults: SettingsType = {
   debug: false,
-  checkForUpdates: true,
   darkTheme: window.matchMedia('(prefers-color-scheme: dark)').matches,
   scrollOnNewLog: false,
   indentLogLines: false,


### PR DESCRIPTION
This PR remove the `checkForUpdates` JSON object from the `autobrr_settings` key
which seems not to be used.

https://github.com/autobrr/autobrr/blob/34d6e0cf609e225fa22261177d4b43c258f03566/web/src/screens/settings/Application.tsx#L141

The checkbox for it just writes to the config file upon triggering but doesn't change the JSON object.
So i feel list this can be removed?