### PR TITLE
fix(macros): `TorrentHash` empty

### DIFF
--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -149,12 +149,9 @@ func (s *service) CheckActionPreconditions(ctx context.Context, action *domain.A
 	}
 
 	if action.CheckMacrosNeedRawDataBytes(release) {
-		tmpFile, err := os.ReadFile(release.TorrentTmpFile)
-		if err != nil {
-			return errors.Wrap(err, "could not read torrent file: %v", release.TorrentTmpFile)
+		if err := release.OpenTorrentFile(); err != nil {
+			return errors.Wrap(err, "could not open torrent file for release: %s", release.TorrentName)
 		}
-
-		release.TorrentDataRawBytes = tmpFile
 	}
 
 	return nil

--- a/internal/domain/action.go
+++ b/internal/domain/action.go
@@ -64,9 +64,12 @@ func (a *Action) CheckMacrosNeedTorrentTmpFile(release *Release) bool {
 	if release.TorrentTmpFile == "" &&
 		(strings.Contains(a.ExecArgs, "TorrentPathName") ||
 			strings.Contains(a.ExecArgs, "TorrentDataRawBytes") ||
+			strings.Contains(a.ExecArgs, "TorrentHash") ||
 			strings.Contains(a.WebhookData, "TorrentPathName") ||
 			strings.Contains(a.WebhookData, "TorrentDataRawBytes") ||
+			strings.Contains(a.WebhookData, "TorrentHash") ||
 			strings.Contains(a.SavePath, "TorrentPathName") ||
+			strings.Contains(a.SavePath, "TorrentHash") ||
 			a.Type == ActionTypeWatchFolder) {
 		return true
 	}

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -186,6 +186,22 @@ type FilterExternal struct {
 	FilterId                 int                `json:"-"`
 }
 
+func (f FilterExternal) NeedTorrentDownloaded() bool {
+	if strings.Contains(f.ExecArgs, "TorrentHash") || strings.Contains(f.WebhookData, "TorrentHash") {
+		return true
+	}
+
+	if strings.Contains(f.ExecArgs, "TorrentPathName") || strings.Contains(f.WebhookData, "TorrentPathName") {
+		return true
+	}
+
+	if strings.Contains(f.WebhookData, "TorrentDataRawBytes") {
+		return true
+	}
+
+	return false
+}
+
 type FilterExternalType string
 
 const (

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -426,6 +426,17 @@ func (r *Release) ParseSizeBytesString(size string) {
 	}
 }
 
+func (r *Release) OpenTorrentFile() error {
+	tmpFile, err := os.ReadFile(r.TorrentTmpFile)
+	if err != nil {
+		return errors.Wrap(err, "could not read torrent file: %v", r.TorrentTmpFile)
+	}
+
+	r.TorrentDataRawBytes = tmpFile
+
+	return nil
+}
+
 func (r *Release) DownloadTorrentFileCtx(ctx context.Context) error {
 	return r.downloadTorrentFile(ctx)
 }


### PR DESCRIPTION
Fix for `TorrentHash` in Macros being empty if torrent has not already been downloaded for parsing.

Fixes #1122 