### PR TITLE
fix(irc): reintroduce security for announces

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -762,7 +762,7 @@ func (h *Handler) onNames(msg ircmsg.Message) {
 
 	channel := msg.Params[2]
 	if !h.isValidChannel(channel) {
-		h.log.Error().Msgf("Ignoring invalid channel %s", channel)
+		h.log.Trace().Msgf("names ignoring extra channel %s", channel)
 		return
 	}
 

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -755,7 +755,7 @@ func (h *Handler) onMessage(msg ircmsg.Message) {
 }
 
 // onNames handles NAMES events
-// network = channel nick1 nick2 nick3
+// network nick = channel nick1 nick2 nick3
 func (h *Handler) onNames(msg ircmsg.Message) {
 	if len(msg.Params) < 3 || !h.isOurCurrentNick(msg.Params[0]) {
 		return

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -780,7 +780,7 @@ func (h *Handler) onNames(msg ircmsg.Message) {
 		}
 	}
 
-	h.log.Error().Msgf("announcer is missing on %s", h.network.Name)
+	h.log.Warn().Msgf("announcer is missing on %s", h.network.Name)
 	h.insecureAnnounce = true
 }
 
@@ -838,6 +838,7 @@ func (h *Handler) JoinChannel(channel string, password string) error {
 func (h *Handler) handlePart(msg ircmsg.Message) {
 	if !h.isOurCurrentNick(msg.Nick()) {
 		if !h.insecureAnnounce && h.isValidAnnouncer(msg.Nick(), true) {
+			h.log.Warn().Msgf("%s has left on %s", msg.Nick(), h.network.Name)
 			h.insecureAnnounce = true
 		}
 
@@ -1029,7 +1030,7 @@ func (h *Handler) handleMode(msg ircmsg.Message) {
 	}
 
 	if h.insecureAnnounce && h.isValidAnnouncer(msg.Params[0], true) {
-		h.log.Debug().Msgf("announcer returned: %s", msg.Params[0])
+		h.log.Warn().Msgf("announcer returned: %s", msg.Params[0])
 		h.insecureAnnounce = false
 	}
 

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -755,6 +755,7 @@ func (h *Handler) onMessage(msg ircmsg.Message) {
 }
 
 // onNames handles NAMES events
+// network = channel nick1 nick2 nick3
 func (h *Handler) onNames(msg ircmsg.Message) {
 	if len(msg.Params) < 3 || !h.isOurCurrentNick(msg.Params[0]) {
 		return
@@ -769,7 +770,7 @@ func (h *Handler) onNames(msg ircmsg.Message) {
 	for i := 3; i < len(msg.Params); i++ {
 		users := strings.Split(msg.Params[i], " ")
 		for _, name := range users {
-			if len(name) > 1 && name[0] == '@' || name[0] == '+' || name[0] == '&' {
+			if len(name) > 0 && (name[0] == '@' || name[0] == '+' || name[0] == '&') {
 				name = name[1:]
 			}
 

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -780,7 +780,7 @@ func (h *Handler) onNames(msg ircmsg.Message) {
 		}
 	}
 
-	h.log.Warn().Msgf("announcer is missing on %s", h.network.Name)
+	h.log.Warn().Msgf("announcer is missing on %s/%s", h.network.Name, channel)
 	h.insecureAnnounce = true
 }
 


### PR DESCRIPTION
big sigh.

this entire handler thing should be rewritten to glue announcers to channels. this makes it a bit more secure for single channel networks.

https://github.com/autobrr/autobrr/pull/1322