### PR TITLE
feat(web): manage initial focus for force run modal and filter add form

### DIFF
--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -4,7 +4,7 @@
  */
 
 
-import { FC, Fragment, MutableRefObject, useState } from "react";
+import { FC, Fragment, MutableRefObject, useRef, useState } from "react";
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 
@@ -125,6 +125,7 @@ export const DeleteModal: FC<DeleteModalProps> = (props: DeleteModalProps) => (
 export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps) => {
   const [inputValue, setInputValue] = useState("");
   const isInputCorrect = inputValue.trim().toLowerCase() === "i understand";
+  const inputRef = useRef(null)
 
   // A function to reset the input and handle any necessary cleanup
   const resetAndClose = () => {
@@ -163,7 +164,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
         as="div"
         static
         className="fixed z-10 inset-0 overflow-y-auto"
-        initialFocus={props.buttonRef}
+        initialFocus={inputRef}
         open={props.isOpen}
         onClose={handleClose}
       >
@@ -183,6 +184,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
               <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 flex justify-center">
                 <input
                   type="text"
+                  ref={inputRef}
                   className="w-96 shadow-sm sm:text-sm rounded-md border py-2.5 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 border-gray-400 dark:border-gray-700 bg-gray-100 dark:bg-gray-900 dark:text-gray-100"
                   placeholder="Type 'I understand' to enable the button"
                   value={inputValue}

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -4,7 +4,7 @@
  */
 
 
-import { FC, Fragment, MutableRefObject, useRef, useState } from "react";
+import { FC, Fragment, MutableRefObject, useState } from "react";
 import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 
@@ -125,7 +125,6 @@ export const DeleteModal: FC<DeleteModalProps> = (props: DeleteModalProps) => (
 export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps) => {
   const [inputValue, setInputValue] = useState("");
   const isInputCorrect = inputValue.trim().toLowerCase() === "i understand";
-  const inputRef = useRef(null)
 
   // A function to reset the input and handle any necessary cleanup
   const resetAndClose = () => {
@@ -164,7 +163,6 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
         as="div"
         static
         className="fixed z-10 inset-0 overflow-y-auto"
-        initialFocus={inputRef}
         open={props.isOpen}
         onClose={handleClose}
       >
@@ -184,7 +182,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
               <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 flex justify-center">
                 <input
                   type="text"
-                  ref={inputRef}
+                  data-autofocus
                   className="w-96 shadow-sm sm:text-sm rounded-md border py-2.5 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 border-gray-400 dark:border-gray-700 bg-gray-100 dark:bg-gray-900 dark:text-gray-100"
                   placeholder="Type 'I understand' to enable the button"
                   value={inputValue}

--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Fragment } from "react";
+import { Fragment, useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "react-hot-toast";
@@ -24,6 +24,7 @@ interface filterAddFormProps {
 }
 
 export function FilterAddForm({ isOpen, toggle }: filterAddFormProps) {
+  const inputRef = useRef(null)
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const mutation = useMutation({
@@ -51,7 +52,7 @@ export function FilterAddForm({ isOpen, toggle }: filterAddFormProps) {
 
   return (
     <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" static className="absolute inset-0 overflow-hidden" open={isOpen} onClose={toggle}>
+      <Dialog as="div" static className="absolute inset-0 overflow-hidden" open={isOpen} onClose={toggle} initialFocus={inputRef}>
         <div className="absolute inset-0 overflow-hidden">
           <DialogPanel className="absolute inset-y-0 right-0 pl-10 max-w-full flex sm:pl-16">
             <TransitionChild
@@ -127,6 +128,7 @@ export function FilterAddForm({ isOpen, toggle }: filterAddFormProps) {
                                     type="text"
                                     data-1p-ignore
                                     autoComplete="off"
+                                    ref={inputRef}
                                     className="block w-full shadow-sm sm:text-sm rounded-md border py-2.5 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-815 dark:text-gray-100"
                                   />
 


### PR DESCRIPTION
This PR sets the initial focus on the input field for the force run modal and the filter add form,
so that you don't have to click into the fields and you can just begin to type and hit ENTER.

The initial focus handling needed two different approaches since using `data-autofocus` in the filter add form
breaks the CSS transition of it by it just popping up and not sliding in.

In case the individuals reviewing this PR can think of other elements where this would be beneficial,
please feel free to add a suggestion by commenting here.