### PR TITLE
fix(web): activity/release table cell widths

### DIFF
--- a/web/src/components/data-table/Cells.tsx
+++ b/web/src/components/data-table/Cells.tsx
@@ -29,7 +29,7 @@ export const NameCell = (props: CellProps<Release>) => (
   <div
     className={classNames(
       "flex justify-between items-center py-2 text-sm font-medium box-content text-gray-900 dark:text-gray-300",
-      "max-w-[82px] sm:max-w-[160px] md:max-w-[290px] lg:max-w-[535px] xl:max-w-[775px]"
+      "max-w-[82px] sm:max-w-[130px] md:max-w-[260px] lg:max-w-[500px] xl:max-w-[760px]"
     )}
   >
     <div className="flex flex-col truncate">


### PR DESCRIPTION
With the recent changes from #1706 the table now overflows in rare cases due to the indexer names being longer.
This PR shortens the max widths of the **release name cells** in order for the table rows not to overflow the body.

I tested this PR with quite a few of my gathered examples but i would appreciate if someone can verify my changes 
with their examples so that we can make sure that the table won't overflow in other cases aswell.

Old behaviour at 2560x1600:
![image](https://github.com/user-attachments/assets/d0b07957-12ef-4f6f-950c-96fe09bf9f20)
New behaviour at 2560x1600:
![image](https://github.com/user-attachments/assets/6e2d0d8d-ed13-4388-8ea4-1413b2f2ae11)

Comparison between old and new behaviour at 1280x1600
![image](https://github.com/user-attachments/assets/ffefa429-1dfe-4a48-8b2b-bdaadd1deb91)
