### PR TITLE
fix(downloadclient): Deluge push error

### DIFF
--- a/internal/action/deluge.go
+++ b/internal/action/deluge.go
@@ -23,6 +23,7 @@ func (s *service) deluge(ctx context.Context, action *domain.Action, release dom
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)
@@ -30,7 +31,7 @@ func (s *service) deluge(ctx context.Context, action *domain.Action, release dom
 
 	var rejections []string
 
-	switch action.Client.Type {
+	switch client.Type {
 	case "DELUGE_V1":
 		rejections, err = s.delugeV1(ctx, client, action, release)
 

--- a/internal/action/lidarr.go
+++ b/internal/action/lidarr.go
@@ -21,6 +21,7 @@ func (s *service) lidarr(ctx context.Context, action *domain.Action, release dom
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)

--- a/internal/action/porla.go
+++ b/internal/action/porla.go
@@ -22,6 +22,7 @@ func (s *service) porla(ctx context.Context, action *domain.Action, release doma
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)

--- a/internal/action/qbittorrent.go
+++ b/internal/action/qbittorrent.go
@@ -21,6 +21,7 @@ func (s *service) qbittorrent(ctx context.Context, action *domain.Action, releas
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)

--- a/internal/action/radarr.go
+++ b/internal/action/radarr.go
@@ -21,6 +21,7 @@ func (s *service) radarr(ctx context.Context, action *domain.Action, release dom
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)

--- a/internal/action/readarr.go
+++ b/internal/action/readarr.go
@@ -21,6 +21,7 @@ func (s *service) readarr(ctx context.Context, action *domain.Action, release do
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)

--- a/internal/action/rtorrent.go
+++ b/internal/action/rtorrent.go
@@ -20,6 +20,7 @@ func (s *service) rtorrent(ctx context.Context, action *domain.Action, release d
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -32,10 +32,6 @@ func (s *service) RunAction(ctx context.Context, action *domain.Action, release 
 		}
 	}()
 
-	if action.ClientID > 0 && action.Client != nil && !action.Client.Enabled {
-		return nil, errors.New("action %s client %s %s not enabled, skipping", action.Name, action.Client.Type, action.Client.Name)
-	}
-
 	// Check preconditions: download torrent file if needed
 	if err := s.CheckActionPreconditions(ctx, action, release); err != nil {
 		return nil, err

--- a/internal/action/sabnzbd.go
+++ b/internal/action/sabnzbd.go
@@ -22,6 +22,7 @@ func (s *service) sabnzbd(ctx context.Context, action *domain.Action, release do
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)

--- a/internal/action/sonarr.go
+++ b/internal/action/sonarr.go
@@ -21,6 +21,7 @@ func (s *service) sonarr(ctx context.Context, action *domain.Action, release dom
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)

--- a/internal/action/transmission.go
+++ b/internal/action/transmission.go
@@ -29,6 +29,7 @@ func (s *service) transmission(ctx context.Context, action *domain.Action, relea
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)

--- a/internal/action/whisparr.go
+++ b/internal/action/whisparr.go
@@ -21,6 +21,7 @@ func (s *service) whisparr(ctx context.Context, action *domain.Action, release d
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
 	}
+	action.Client = client
 
 	if !client.Enabled {
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)


### PR DESCRIPTION
This fixes an issue with a check for non-nil value when running Deluge actions that resulted in panic.

And an additional fix to set client on the action struct so it's properly available to notifications.