### PR TITLE
feat(releases): show indexer name in indexer filter

### DIFF
--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -134,10 +134,14 @@ export const ReleasesIndexersQueryOptions = () =>
   queryOptions({
     queryKey: ReleaseKeys.indexers(),
     queryFn: async () => {
-      const response = await APIClient.indexers.getAll();
-      return response.map((indexer: IndexerMinimal) => ({
-        name: indexer.name,
-        identifier: indexer.identifier
+      const indexersResponse: IndexerDefinition[] = await APIClient.indexers.getAll();
+      const indexerOptionsResponse: string[] = await APIClient.release.indexerOptions();
+      
+      const indexersMap = new Map(indexersResponse.map((indexer: IndexerDefinition) => [indexer.identifier, indexer.name]));
+      
+      return indexerOptionsResponse.map((identifier: string) => ({
+        name: indexersMap.get(identifier) || "Unknown",
+        identifier: identifier
       }));
     },
     refetchOnWindowFocus: false,

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -140,7 +140,7 @@ export const ReleasesIndexersQueryOptions = () =>
       const indexersMap = new Map(indexersResponse.map((indexer: IndexerDefinition) => [indexer.identifier, indexer.name]));
       
       return indexerOptionsResponse.map((identifier: string) => ({
-        name: indexersMap.get(identifier) || "Unknown",
+        name: indexersMap.get(identifier) || identifier,
         identifier: identifier
       }));
     },

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -135,7 +135,7 @@ export const ReleasesIndexersQueryOptions = () =>
     queryKey: ReleaseKeys.indexers(),
     queryFn: async () => {
       const response = await APIClient.indexers.getAll();
-      return response.map((indexer: any) => ({
+      return response.map((indexer: IndexerMinimal) => ({
         name: indexer.name,
         identifier: indexer.identifier
       }));

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { keepPreviousData, queryOptions } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
 import { APIClient } from "@api/APIClient";
 import {
   ApiKeys,
@@ -133,8 +133,14 @@ export const ReleasesStatsQueryOptions = () =>
 export const ReleasesIndexersQueryOptions = () =>
   queryOptions({
     queryKey: ReleaseKeys.indexers(),
-    queryFn: () => APIClient.release.indexerOptions(),
-    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      const response = await APIClient.indexers.getAll();
+      return response.map((indexer: any) => ({
+        name: indexer.name,
+        identifier: indexer.identifier
+      }));
+    },
+    refetchOnWindowFocus: false,
     staleTime: Infinity
   });
 

--- a/web/src/screens/releases/ReleaseFilters.tsx
+++ b/web/src/screens/releases/ReleaseFilters.tsx
@@ -69,23 +69,23 @@ export const IndexerSelectColumnFilter = ({
 }: FilterProps<object>) => {
   const { data, isSuccess } = useQuery(ReleasesIndexersQueryOptions());
 
+  const options = isSuccess && data.map((indexer, idx) => (
+    <FilterOption key={idx} label={indexer.name} value={indexer.identifier} />
+  ));
+
   // Assign indexer name based on the filterValue (indexer.identifier)
-  const currentIndexerName = isSuccess && data 
-    ? data.find(indexer => indexer.identifier === filterValue)?.name 
-    : "Indexer";
+  const currentIndexerName = data?.find(indexer => indexer.identifier === filterValue)?.name ?? "Indexer";
 
   // Render a multi-select box
   return (
     <ListboxFilter
       id={id}
       key={id}
-      label={currentIndexerName ?? "Indexer"}
+      label={currentIndexerName}
       currentValue={filterValue ?? ""}
       onChange={setFilter}
     >
-      {isSuccess && data && data.map((indexer, idx) => (
-        <FilterOption key={idx} label={indexer.name} value={indexer.identifier} />
-      ))}
+      {options}
     </ListboxFilter>
   );
 };

--- a/web/src/screens/releases/ReleaseFilters.tsx
+++ b/web/src/screens/releases/ReleaseFilters.tsx
@@ -69,10 +69,6 @@ export const IndexerSelectColumnFilter = ({
 }: FilterProps<object>) => {
   const { data, isSuccess } = useQuery(ReleasesIndexersQueryOptions());
 
-  const options = isSuccess && data.map((indexer, idx) => (
-    <FilterOption key={idx} label={indexer.name} value={indexer.identifier} />
-  ));
-
   // Assign indexer name based on the filterValue (indexer.identifier)
   const currentIndexerName = data?.find(indexer => indexer.identifier === filterValue)?.name ?? "Indexer";
 
@@ -85,7 +81,9 @@ export const IndexerSelectColumnFilter = ({
       currentValue={filterValue ?? ""}
       onChange={setFilter}
     >
-      {options}
+      {isSuccess && data && data?.map((indexer, idx) => (
+        <FilterOption key={idx} label={indexer.name} value={indexer.identifier} />
+      ))}
     </ListboxFilter>
   );
 };

--- a/web/src/screens/releases/ReleaseFilters.tsx
+++ b/web/src/screens/releases/ReleaseFilters.tsx
@@ -69,17 +69,22 @@ export const IndexerSelectColumnFilter = ({
 }: FilterProps<object>) => {
   const { data, isSuccess } = useQuery(ReleasesIndexersQueryOptions());
 
+  // Assign indexer name based on the filterValue (indexer.identifier)
+  const currentIndexerName = isSuccess && data 
+    ? data.find(indexer => indexer.identifier === filterValue)?.name 
+    : "Indexer";
+
   // Render a multi-select box
   return (
     <ListboxFilter
       id={id}
       key={id}
-      label={filterValue ?? "Indexer"}
+      label={currentIndexerName ?? "Indexer"}
       currentValue={filterValue ?? ""}
       onChange={setFilter}
     >
-      {isSuccess && data && data?.map((indexer, idx) => (
-        <FilterOption key={idx} label={indexer} value={indexer} />
+      {isSuccess && data && data.map((indexer, idx) => (
+        <FilterOption key={idx} label={indexer.name} value={indexer.identifier} />
       ))}
     </ListboxFilter>
   );


### PR DESCRIPTION
While reviewing #1706 i missed that the indexer filter on the releases page was still showing the identifier
instead of the name now.

This PR adds the required changes to make the options and the current filter value show the name.