### PR TITLE
build: add web/dist tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,8 +137,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create web-dist artifact
-        working-directory: web/dist
-        run: tar czf ../../dist/web-dist.tar.gz ./*
+        run: tar czf dist/web-dist.tar.gz --directory=web/dist ./
 
       - name: Upload assets
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
PR still under discussion

Checking if goreleaser would add web/dist to the source tarball.

Grabbing an `autobrr_src.tar.gz` file (instead of the git repository tar.gz) would have the web/dist included that can be used to just build the go app later.

Just to help to build on some platforms that present problems within nodejs.
Since web/dist is just web files it is universal anyway we could provide the artifacts.