### PR TITLE
feat(notifications): Telegram set sender

### DIFF
--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -64,6 +64,7 @@ type NotificationPayload struct {
 	Protocol       ReleaseProtocol       // torrent, usenet
 	Implementation ReleaseImplementation // irc, rss, api
 	Timestamp      time.Time
+	Sender         string
 }
 
 type NotificationType string

--- a/internal/notification/message_builder.go
+++ b/internal/notification/message_builder.go
@@ -26,6 +26,7 @@ type MessageBuilderPlainText struct{}
 // BuildBody constructs the body of the notification message.
 func (b *MessageBuilderPlainText) BuildBody(payload domain.NotificationPayload) string {
 	messageParts := []ConditionMessagePart{
+		{payload.Sender != "", "%v\n", []interface{}{payload.Sender}},
 		{payload.Subject != "" && payload.Message != "", "%v\n%v", []interface{}{payload.Subject, payload.Message}},
 		{payload.ReleaseName != "", "New release: %v\n", []interface{}{payload.ReleaseName}},
 		{payload.Size > 0, "Size: %v\n", []interface{}{humanize.Bytes(payload.Size)}},
@@ -45,6 +46,7 @@ type MessageBuilderHTML struct{}
 
 func (b *MessageBuilderHTML) BuildBody(payload domain.NotificationPayload) string {
 	messageParts := []ConditionMessagePart{
+		{payload.Sender != "", "<b>%v</b>\n", []interface{}{html.EscapeString(payload.Sender)}},
 		{payload.Subject != "" && payload.Message != "", "<b>%v</b> %v\n", []interface{}{html.EscapeString(payload.Subject), html.EscapeString(payload.Message)}},
 		{payload.ReleaseName != "", "<b>New release:</b> %v\n", []interface{}{html.EscapeString(payload.ReleaseName)}},
 		{payload.Size > 0, "<b>Size:</b> %v\n", []interface{}{humanize.Bytes(payload.Size)}},

--- a/internal/notification/telegram.go
+++ b/internal/notification/telegram.go
@@ -63,6 +63,9 @@ func NewTelegramSender(log zerolog.Logger, settings domain.Notification) domain.
 }
 
 func (s *telegramSender) Send(event domain.NotificationEvent, payload domain.NotificationPayload) error {
+
+	payload.Sender = "autobrr"
+
 	message := s.builder.BuildBody(payload)
 	m := TelegramMessage{
 		ChatID:          s.Settings.Channel,


### PR DESCRIPTION
This PR adds a conditional sender payload for telegram for the message to say which app the notification is coming from.

Fixes #1722 