### PR TITLE
fix(indexers): new baseURL for Fuzer

### DIFF
--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -955,4 +955,8 @@ ALTER TABLE irc_network
     ADD FOREIGN KEY (proxy_id) REFERENCES proxy
         ON DELETE SET NULL;
 `,
+	`UPDATE indexer
+	SET base_url = 'https://fuzer.xyz/'
+	WHERE base_url = 'https://fuzer.me/';
+`,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -1591,4 +1591,8 @@ ALTER TABLE irc_network
             REFERENCES proxy(id)
             ON DELETE SET NULL;
 `,
+	`UPDATE indexer
+	SET base_url = 'https://fuzer.xyz/'
+	WHERE base_url = 'https://fuzer.me/';
+`,
 }

--- a/internal/indexer/definitions/fuzer.yaml
+++ b/internal/indexer/definitions/fuzer.yaml
@@ -4,7 +4,7 @@ identifier: fuzer
 description: Fuzer is a private Israeli tracker
 language: he-il
 urls:
-  - https://fuzer.me/
+  - https://fuzer.xyz/
 privacy: private
 protocol: torrent
 supports:


### PR DESCRIPTION
Old URL just displays a white page while new URL shows login form.

**WARNING:**
This PR contains database migrations. You **cannot** go back to 1.46.x once you run a version with this fix