### PR TITLE
fix(web): form slideovers for mobile views

### DIFF
--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -52,9 +52,9 @@ export function FilterAddForm({ isOpen, toggle }: filterAddFormProps) {
 
   return (
     <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" static className="absolute inset-0 overflow-hidden" open={isOpen} onClose={toggle} initialFocus={inputRef}>
+      <Dialog as="div" static className="z-20 fixed inset-0 overflow-hidden" open={isOpen} onClose={toggle} initialFocus={inputRef}>
         <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 pl-10 max-w-full flex sm:pl-16">
+          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
             <TransitionChild
               as={Fragment}
               enter="transform transition ease-in-out duration-500 sm:duration-700"

--- a/web/src/forms/settings/APIKeyAddForm.tsx
+++ b/web/src/forms/settings/APIKeyAddForm.tsx
@@ -46,9 +46,9 @@ export function APIKeyAddForm({ isOpen, toggle }: apiKeyAddFormProps) {
 
   return (
     <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" static className="absolute inset-0 overflow-hidden" open={isOpen} onClose={toggle}>
+      <Dialog as="div" static className="fixed inset-0 overflow-hidden" open={isOpen} onClose={toggle}>
         <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 pl-10 max-w-full flex sm:pl-16">
+          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
             <TransitionChild
               as={Fragment}
               enter="transform transition ease-in-out duration-500 sm:duration-700"

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -772,7 +772,7 @@ export function DownloadClientAddForm({ isOpen, toggle }: formProps) {
         onClose={toggle}
       >
         <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="fixed inset-y-0 right-0 pl-10 max-w-full flex sm:pl-16">
+          <DialogPanel className="fixed inset-y-0 right-0 max-w-full flex">
             <TransitionChild
               as={Fragment}
               enter="transform transition ease-in-out duration-500 sm:duration-700"
@@ -949,7 +949,7 @@ export function DownloadClientUpdateForm({ client, isOpen, toggle }: updateFormP
       <Dialog
         as="div"
         static
-        className="absolute inset-0 overflow-hidden"
+        className="fixed inset-0 overflow-hidden"
         open={isOpen}
         onClose={toggle}
         initialFocus={cancelButtonRef}
@@ -964,7 +964,7 @@ export function DownloadClientUpdateForm({ client, isOpen, toggle }: updateFormP
           text="Are you sure you want to remove this download client? This action cannot be undone."
         />
         <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 pl-10 max-w-full flex sm:pl-16">
+          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
             <TransitionChild
               as={Fragment}
               enter="transform transition ease-in-out duration-500 sm:duration-700"

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -424,9 +424,9 @@ export function IndexerAddForm({ isOpen, toggle }: AddProps) {
 
   return (
     <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" static className="absolute inset-0 overflow-hidden" open={isOpen} onClose={toggle}>
+      <Dialog as="div" static className="fixed inset-0 overflow-hidden" open={isOpen} onClose={toggle}>
         <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 pl-10 sm:pl-0 max-w-full flex">
+          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
             <TransitionChild
               as={Fragment}
               enter="transform transition ease-in-out duration-500 sm:duration-700"

--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -350,12 +350,12 @@ export function NotificationAddForm({ isOpen, toggle }: AddProps) {
       <Dialog
         as="div"
         static
-        className="absolute inset-0 overflow-hidden"
+        className="fixed inset-0 overflow-hidden"
         open={isOpen}
         onClose={toggle}
       >
         <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 pl-10 max-w-full flex sm:pl-16">
+          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
             <TransitionChild
               as={Fragment}
               enter="transform transition ease-in-out duration-500 sm:duration-700"

--- a/web/src/forms/settings/ProxyForms.tsx
+++ b/web/src/forms/settings/ProxyForms.tsx
@@ -63,7 +63,7 @@ export function ProxyAddForm({ isOpen, toggle }: AddProps) {
         onClose={toggle}
       >
         <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 pl-10 max-w-full flex sm:pl-16">
+          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
             <TransitionChild
               as={Fragment}
               enter="transform transition ease-in-out duration-500 sm:duration-700"


### PR DESCRIPTION
During the headlessUI refactors i did, i messed up a couple of mobile sildeover forms.

![image](https://github.com/user-attachments/assets/2d0b7b90-b8ec-4164-9512-fe11980e90b8)

This PR fixes the slideovers to take full widths for the mobile forms while mostly retaining the widths for the desktop view.
Why mostly? I cleaned up the paddings on the slideovers since the do not add any real value and are just clutter imo.

I tested to following forms for correct desktops and mobile views and uniformity:

- [x] FilterAddForm
- [x] IndexerAddForm
- [x] IndexerUpdateForm (uses custom SlideOver component)
- [x] IRCNetworkAddForm (uses custom SlideOver component) 
- [x] IRCNetworkUpdateForm (uses custom SlideOver component) 
- [x] FeedUpdateForm (uses custom SlideOver component) 
- [x] DownloadClientAddForm
- [x] DownloadClientUpdateForm
- [x] NotificationAddForm
- [x] NotificationUpdateForm (uses custom SlideOver component) 
- [x] APIKeyAddForm 
- [x] ProxyAddForm
- [x] ProxyUpdateForm (uses custom SlideOver component) 

![image](https://github.com/user-attachments/assets/46d87882-e1e0-4c5c-b934-b76c21a91bd5)

![image](https://github.com/user-attachments/assets/1dc3665a-5ae3-4a82-8b97-c1b988b68b9e)

![image](https://github.com/user-attachments/assets/7f51b57d-27b8-4d38-848f-9e90f144f192)

![image](https://github.com/user-attachments/assets/01382034-35be-4d28-ad38-5da1d3cc9731)
