### PR TITLE
feat(notifications): optional Telegram sender

### DIFF
--- a/internal/notification/telegram.go
+++ b/internal/notification/telegram.go
@@ -64,7 +64,7 @@ func NewTelegramSender(log zerolog.Logger, settings domain.Notification) domain.
 
 func (s *telegramSender) Send(event domain.NotificationEvent, payload domain.NotificationPayload) error {
 
-	payload.Sender = "autobrr"
+	payload.Sender = s.Settings.Username
 
 	message := s.builder.BuildBody(payload)
 	m := TelegramMessage{

--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -146,6 +146,12 @@ function FormFieldsTelegram() {
         help="Reverse proxy domain for api.telegram.org, only needs to be specified if the network you are using has blocked the Telegram API."
         placeholder="http(s)://ip:port"
       />
+      <TextFieldWide
+        name="username"
+        label="Sender"
+        help="Custom sender name to show at the top of a notification"
+        placeholder="autobrr"
+      />
     </div>
   );
 }
@@ -373,7 +379,8 @@ export function NotificationAddForm({ isOpen, toggle }: AddProps) {
                     type: "",
                     name: "",
                     webhook: "",
-                    events: []
+                    events: [],
+                    username: ""
                   }}
                   onSubmit={onSubmit}
                   validate={validate}
@@ -577,6 +584,7 @@ interface InitialValues {
   topic?: string;
   host?: string;
   events: NotificationEvent[];
+  username?: string
 }
 
 export function NotificationUpdateForm({ isOpen, toggle, notification }: UpdateProps) {
@@ -626,7 +634,8 @@ export function NotificationUpdateForm({ isOpen, toggle, notification }: UpdateP
     channel: notification.channel,
     topic: notification.topic,
     host: notification.host,
-    events: notification.events || []
+    events: notification.events || [],
+    username: notification.username
   };
 
   return (

--- a/web/src/types/Notification.d.ts
+++ b/web/src/types/Notification.d.ts
@@ -25,4 +25,5 @@ interface ServiceNotification {
   priority?: number;
   topic?: string;
   host?: string;
+  username?: string;
 }


### PR DESCRIPTION
**WARNING:**
This PR contains database migrations. You cannot go back to 1.46.x or earlier once you run a version with these changes.

Since there were complaints about the hardcoded autobrr sender in the Telegram notifications
it's now an optional field in the Telegram form fields.

If that field is left empty, there will not be an additional line with a sender.
If you enter something in this field, there will be an additional line with the string you entered.

ref https://github.com/autobrr/autobrr/pull/1723