### PR TITLE
fix(build): run web-dist tarball step for tags only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create web-dist artifact
+        if: startsWith(github.ref, 'refs/tags/')
         run: tar czf dist/web-dist.tar.gz --directory=web/dist ./
 
       - name: Upload assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Create web-dist artifact
         if: startsWith(github.ref, 'refs/tags/')
-        run: tar czf dist/web-dist.tar.gz --directory=web/dist ./
+        run: mkdir -p dist && tar czf dist/web-dist.tar.gz --directory=web/dist ./
 
       - name: Upload assets
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
After merge the #1721 we notice it that some steps doesnt run on merge event and pipeline failed because was missing "dist" folder (created by those skipped steps).

This is to fix it but also ensure to run on tags creation only.