### PR TITLE
build: upload web-dist to release assets on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: mkdir -p dist && tar czf dist/web-dist.tar.gz --directory=web/dist ./
 
+      - name: Upload web-dist to release assets
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            dist/web-dist.tar.gz
+
       - name: Upload assets
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Upload `web-dist.tar.gz` to release assets after goreleaser build and push.

This uses the action [softprops/action-gh-release](https://github.com/softprops/action-gh-release?tab=readme-ov-file#%EF%B8%8F-uploading-release-assets) which has this function:

> If a tag already has a GitHub release, the existing release will be updated with the release assets.

Running this on tag events after GoReleaser _should_ work.