### PR TITLE
fix(filters): release download counts

### DIFF
--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -1320,13 +1320,12 @@ func (r *FilterRepo) GetDownloadsByFilterId(ctx context.Context, filterID int) (
 
 func (r *FilterRepo) downloadsByFilterSqlite(ctx context.Context, filterID int) (*domain.FilterDownloads, error) {
 	query := `SELECT
-	COUNT(CASE WHEN CAST(strftime('%s', datetime(release_action_status.timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', strftime('%Y-%m-%dT%H:00:00', datetime('now','localtime'))) AS INTEGER) THEN 1 END) as "hour_count",
-	COUNT(CASE WHEN CAST(strftime('%s', datetime(release_action_status.timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'start of day')) AS INTEGER) THEN 1 END) as "day_count",
-	COUNT(CASE WHEN CAST(strftime('%s', datetime(release_action_status.timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'weekday 0', '-7 days', 'start of day')) AS INTEGER) THEN 1 END) as "week_count",
-	COUNT(CASE WHEN CAST(strftime('%s', datetime(release_action_status.timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'start of month')) AS INTEGER) THEN 1 END) as "month_count",
+	COUNT(CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', strftime('%Y-%m-%dT%H:00:00', datetime('now','localtime'))) AS INTEGER) THEN 1 END) as "hour_count",
+	COUNT(CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'start of day')) AS INTEGER) THEN 1 END) as "day_count",
+	COUNT(CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'weekday 0', '-7 days', 'start of day')) AS INTEGER) THEN 1 END) as "week_count",
+	COUNT(CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'start of month')) AS INTEGER) THEN 1 END) as "month_count",
 	COUNT(*) as "total_count"
-FROM release_action_status
-WHERE (release_action_status.status = 'PUSH_APPROVED' OR release_action_status.status = 'PENDING') AND release_action_status.filter_id = ?;`
+FROM (SELECT MAX(timestamp) AS "timestamp" FROM release_action_status WHERE status IN ('PUSH_APPROVED', 'PUSH_PENDING') AND filter_id = ? GROUP BY release_id);`
 
 	row := r.db.handler.QueryRowContext(ctx, query, filterID)
 	if err := row.Err(); err != nil {
@@ -1350,13 +1349,12 @@ WHERE (release_action_status.status = 'PUSH_APPROVED' OR release_action_status.s
 
 func (r *FilterRepo) downloadsByFilterPostgres(ctx context.Context, filterID int) (*domain.FilterDownloads, error) {
 	query := `SELECT
-    COALESCE(SUM(CASE WHEN release_action_status.timestamp >= date_trunc('hour', CURRENT_TIMESTAMP) THEN 1 ELSE 0 END),0) as "hour_count",
-    COALESCE(SUM(CASE WHEN release_action_status.timestamp >= date_trunc('day', CURRENT_DATE) THEN 1 ELSE 0 END),0) as "day_count",
-    COALESCE(SUM(CASE WHEN release_action_status.timestamp >= date_trunc('week', CURRENT_DATE) THEN 1 ELSE 0 END),0) as "week_count",
-    COALESCE(SUM(CASE WHEN release_action_status.timestamp >= date_trunc('month', CURRENT_DATE) THEN 1 ELSE 0 END),0) as "month_count",
+    COALESCE(SUM(CASE WHEN timestamp >= date_trunc('hour', CURRENT_TIMESTAMP) THEN 1 ELSE 0 END),0) as "hour_count",
+    COALESCE(SUM(CASE WHEN timestamp >= date_trunc('day', CURRENT_DATE) THEN 1 ELSE 0 END),0) as "day_count",
+    COALESCE(SUM(CASE WHEN timestamp >= date_trunc('week', CURRENT_DATE) THEN 1 ELSE 0 END),0) as "week_count",
+    COALESCE(SUM(CASE WHEN timestamp >= date_trunc('month', CURRENT_DATE) THEN 1 ELSE 0 END),0) as "month_count",
     count(*) as "total_count"
-FROM release_action_status
-WHERE (release_action_status.status = 'PUSH_APPROVED' OR release_action_status.status = 'PENDING') AND release_action_status.filter_id = $1;`
+FROM (SELECT MAX(timestamp) AS "timestamp" FROM release_action_status WHERE status IN ('PUSH_APPROVED', 'PUSH_PENDING') AND filter_id = $1 GROUP BY release_id) AS _;`
 
 	row := r.db.handler.QueryRowContext(ctx, query, filterID)
 	if err := row.Err(); err != nil {

--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -926,18 +926,33 @@ func TestFilterRepo_GetDownloadsByFilterId(t *testing.T) {
 
 			action, err := actionRepo.Store(context.Background(), mockAction)
 
-			mockReleaseActionStatus = getMockReleaseActionStatus()
-			mockReleaseActionStatus.FilterID = int64(mockData.ID)
-			mockReleaseActionStatus.Timestamp = mockReleaseActionStatus.Timestamp.AddDate(0, -1, 0)
+			mockAction2 := getMockAction()
+			mockAction2.FilterID = mockData.ID
+			mockAction2.ClientID = mockClient.ID
+
+			action2, err := actionRepo.Store(context.Background(), mockAction2)
+
 			mockRelease.FilterID = mockData.ID
 
 			err = releaseRepo.Store(context.Background(), mockRelease)
 			assert.NoError(t, err)
 
+			mockReleaseActionStatus = getMockReleaseActionStatus()
 			mockReleaseActionStatus.ActionID = int64(action.ID)
+			mockReleaseActionStatus.FilterID = int64(mockData.ID)
 			mockReleaseActionStatus.ReleaseID = mockRelease.ID
+			mockReleaseActionStatus.Timestamp = mockReleaseActionStatus.Timestamp.AddDate(0, -1, 0)
 
 			err = releaseRepo.StoreReleaseActionStatus(context.Background(), mockReleaseActionStatus)
+			assert.NoError(t, err)
+
+			mockReleaseActionStatus2 := getMockReleaseActionStatus()
+			mockReleaseActionStatus2.ActionID = int64(action2.ID)
+			mockReleaseActionStatus2.FilterID = int64(mockData.ID)
+			mockReleaseActionStatus2.ReleaseID = mockRelease.ID
+			mockReleaseActionStatus2.Timestamp = mockReleaseActionStatus2.Timestamp.AddDate(0, -1, 0)
+
+			err = releaseRepo.StoreReleaseActionStatus(context.Background(), mockReleaseActionStatus2)
 			assert.NoError(t, err)
 
 			// Execute


### PR DESCRIPTION
When counting the number of recent downloads to enforce the `Max Downloads` rule on a filter, multiple actions attached to the same filter will be counted as multiple downloads.

This PR changes the logic to count multiple actions as a single download.