### PR TITLE
fix(downloadclients): arrs change size type to uint64

### DIFF
--- a/internal/action/lidarr.go
+++ b/internal/action/lidarr.go
@@ -34,7 +34,7 @@ func (s *service) lidarr(ctx context.Context, action *domain.Action, release dom
 		InfoUrl:          release.InfoURL,
 		DownloadUrl:      release.DownloadURL,
 		MagnetUrl:        release.MagnetURI,
-		Size:             int64(release.Size),
+		Size:             release.Size,
 		Indexer:          release.Indexer.GetExternalIdentifier(),
 		DownloadClientId: client.Settings.ExternalDownloadClientId,
 		DownloadClient:   client.Settings.ExternalDownloadClient,

--- a/internal/action/radarr.go
+++ b/internal/action/radarr.go
@@ -34,7 +34,7 @@ func (s *service) radarr(ctx context.Context, action *domain.Action, release dom
 		InfoUrl:          release.InfoURL,
 		DownloadUrl:      release.DownloadURL,
 		MagnetUrl:        release.MagnetURI,
-		Size:             int64(release.Size),
+		Size:             release.Size,
 		Indexer:          release.Indexer.GetExternalIdentifier(),
 		DownloadClientId: client.Settings.ExternalDownloadClientId,
 		DownloadClient:   client.Settings.ExternalDownloadClient,

--- a/internal/action/readarr.go
+++ b/internal/action/readarr.go
@@ -34,7 +34,7 @@ func (s *service) readarr(ctx context.Context, action *domain.Action, release do
 		InfoUrl:          release.InfoURL,
 		DownloadUrl:      release.DownloadURL,
 		MagnetUrl:        release.MagnetURI,
-		Size:             int64(release.Size),
+		Size:             release.Size,
 		Indexer:          release.Indexer.GetExternalIdentifier(),
 		DownloadClientId: client.Settings.ExternalDownloadClientId,
 		DownloadClient:   client.Settings.ExternalDownloadClient,

--- a/internal/action/sonarr.go
+++ b/internal/action/sonarr.go
@@ -34,7 +34,7 @@ func (s *service) sonarr(ctx context.Context, action *domain.Action, release dom
 		InfoUrl:          release.InfoURL,
 		DownloadUrl:      release.DownloadURL,
 		MagnetUrl:        release.MagnetURI,
-		Size:             int64(release.Size),
+		Size:             release.Size,
 		Indexer:          release.Indexer.GetExternalIdentifier(),
 		DownloadClientId: client.Settings.ExternalDownloadClientId,
 		DownloadClient:   client.Settings.ExternalDownloadClient,

--- a/internal/action/whisparr.go
+++ b/internal/action/whisparr.go
@@ -34,7 +34,7 @@ func (s *service) whisparr(ctx context.Context, action *domain.Action, release d
 		InfoUrl:          release.InfoURL,
 		DownloadUrl:      release.DownloadURL,
 		MagnetUrl:        release.MagnetURI,
-		Size:             int64(release.Size),
+		Size:             release.Size,
 		Indexer:          release.Indexer.GetExternalIdentifier(),
 		DownloadClientId: client.Settings.ExternalDownloadClientId,
 		DownloadClient:   client.Settings.ExternalDownloadClient,

--- a/pkg/lidarr/client.go
+++ b/pkg/lidarr/client.go
@@ -42,6 +42,10 @@ func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) 
 
 	defer resp.Body.Close()
 
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
+
 	var buf bytes.Buffer
 	if _, err = io.Copy(&buf, resp.Body); err != nil {
 		return resp.StatusCode, nil, errors.Wrap(err, "lidarr.io.Copy error")
@@ -124,6 +128,10 @@ func (c *client) postBody(ctx context.Context, endpoint string, data interface{}
 	}
 
 	defer resp.Body.Close()
+
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
 
 	var buf bytes.Buffer
 	if _, err = io.Copy(&buf, resp.Body); err != nil {

--- a/pkg/lidarr/client.go
+++ b/pkg/lidarr/client.go
@@ -17,6 +17,10 @@ import (
 
 func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v1/", endpoint)
 	reqUrl := u.String()
 
@@ -48,6 +52,10 @@ func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) 
 
 func (c *client) post(ctx context.Context, endpoint string, data interface{}) (*http.Response, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v1/", endpoint)
 	reqUrl := u.String()
 
@@ -87,6 +95,10 @@ func (c *client) post(ctx context.Context, endpoint string, data interface{}) (*
 
 func (c *client) postBody(ctx context.Context, endpoint string, data interface{}) (int, []byte, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v1/", endpoint)
 	reqUrl := u.String()
 

--- a/pkg/lidarr/lidarr.go
+++ b/pkg/lidarr/lidarr.go
@@ -66,7 +66,7 @@ type Release struct {
 	InfoUrl          string `json:"infoUrl,omitempty"`
 	DownloadUrl      string `json:"downloadUrl,omitempty"`
 	MagnetUrl        string `json:"magnetUrl,omitempty"`
-	Size             int64  `json:"size"`
+	Size             uint64 `json:"size"`
 	Indexer          string `json:"indexer"`
 	DownloadProtocol string `json:"downloadProtocol"`
 	Protocol         string `json:"protocol"`

--- a/pkg/radarr/client.go
+++ b/pkg/radarr/client.go
@@ -42,6 +42,10 @@ func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) 
 
 	defer resp.Body.Close()
 
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
+
 	var buf bytes.Buffer
 	if _, err = io.Copy(&buf, resp.Body); err != nil {
 		return resp.StatusCode, nil, errors.Wrap(err, "radarr.io.Copy")
@@ -126,6 +130,10 @@ func (c *client) postBody(ctx context.Context, endpoint string, data interface{}
 	}
 
 	defer resp.Body.Close()
+
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
 
 	var buf bytes.Buffer
 	if _, err = io.Copy(&buf, resp.Body); err != nil {

--- a/pkg/radarr/client.go
+++ b/pkg/radarr/client.go
@@ -17,6 +17,10 @@ import (
 
 func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v3/", endpoint)
 	reqUrl := u.String()
 
@@ -48,6 +52,10 @@ func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) 
 
 func (c *client) post(ctx context.Context, endpoint string, data interface{}) (*http.Response, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v3/", endpoint)
 	reqUrl := u.String()
 
@@ -89,6 +97,10 @@ func (c *client) post(ctx context.Context, endpoint string, data interface{}) (*
 
 func (c *client) postBody(ctx context.Context, endpoint string, data interface{}) (int, []byte, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v3/", endpoint)
 	reqUrl := u.String()
 

--- a/pkg/radarr/radarr.go
+++ b/pkg/radarr/radarr.go
@@ -65,7 +65,7 @@ type Release struct {
 	InfoUrl          string `json:"infoUrl,omitempty"`
 	DownloadUrl      string `json:"downloadUrl,omitempty"`
 	MagnetUrl        string `json:"magnetUrl,omitempty"`
-	Size             int64  `json:"size"`
+	Size             uint64 `json:"size"`
 	Indexer          string `json:"indexer"`
 	DownloadProtocol string `json:"downloadProtocol"`
 	Protocol         string `json:"protocol"`

--- a/pkg/readarr/client.go
+++ b/pkg/readarr/client.go
@@ -42,6 +42,10 @@ func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) 
 
 	defer resp.Body.Close()
 
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
+
 	var buf bytes.Buffer
 	if _, err = io.Copy(&buf, resp.Body); err != nil {
 		return resp.StatusCode, nil, errors.Wrap(err, "readarr.io.Copy")
@@ -126,6 +130,10 @@ func (c *client) postBody(ctx context.Context, endpoint string, data interface{}
 	}
 
 	defer resp.Body.Close()
+
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
 
 	var buf bytes.Buffer
 	if _, err = io.Copy(&buf, resp.Body); err != nil {

--- a/pkg/readarr/client.go
+++ b/pkg/readarr/client.go
@@ -17,6 +17,10 @@ import (
 
 func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v1/", endpoint)
 	reqUrl := u.String()
 
@@ -48,6 +52,10 @@ func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) 
 
 func (c *client) post(ctx context.Context, endpoint string, data interface{}) (*http.Response, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v1/", endpoint)
 	reqUrl := u.String()
 
@@ -87,6 +95,10 @@ func (c *client) post(ctx context.Context, endpoint string, data interface{}) (*
 
 func (c *client) postBody(ctx context.Context, endpoint string, data interface{}) (int, []byte, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v1/", endpoint)
 	reqUrl := u.String()
 

--- a/pkg/readarr/readarr.go
+++ b/pkg/readarr/readarr.go
@@ -67,7 +67,7 @@ type Release struct {
 	InfoUrl          string `json:"infoUrl,omitempty"`
 	DownloadUrl      string `json:"downloadUrl,omitempty"`
 	MagnetUrl        string `json:"magnetUrl,omitempty"`
-	Size             int64  `json:"size"`
+	Size             uint64 `json:"size"`
 	Indexer          string `json:"indexer"`
 	DownloadProtocol string `json:"downloadProtocol"`
 	Protocol         string `json:"protocol"`

--- a/pkg/sonarr/client.go
+++ b/pkg/sonarr/client.go
@@ -42,6 +42,10 @@ func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) 
 
 	defer resp.Body.Close()
 
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
+
 	var buf bytes.Buffer
 	if _, err = io.Copy(&buf, resp.Body); err != nil {
 		return resp.StatusCode, nil, errors.Wrap(err, "sonarr.io.Copy")
@@ -124,6 +128,10 @@ func (c *client) postBody(ctx context.Context, endpoint string, data interface{}
 	}
 
 	defer resp.Body.Close()
+
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
 
 	var buf bytes.Buffer
 	if _, err = io.Copy(&buf, resp.Body); err != nil {

--- a/pkg/sonarr/client.go
+++ b/pkg/sonarr/client.go
@@ -17,6 +17,10 @@ import (
 
 func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v3/", endpoint)
 	reqUrl := u.String()
 
@@ -48,6 +52,10 @@ func (c *client) get(ctx context.Context, endpoint string) (int, []byte, error) 
 
 func (c *client) post(ctx context.Context, endpoint string, data interface{}) (*http.Response, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v3/", endpoint)
 	reqUrl := u.String()
 
@@ -87,6 +95,10 @@ func (c *client) post(ctx context.Context, endpoint string, data interface{}) (*
 
 func (c *client) postBody(ctx context.Context, endpoint string, data interface{}) (int, []byte, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v3/", endpoint)
 	reqUrl := u.String()
 

--- a/pkg/sonarr/sonarr.go
+++ b/pkg/sonarr/sonarr.go
@@ -67,7 +67,7 @@ type Release struct {
 	InfoUrl          string `json:"infoUrl,omitempty"`
 	DownloadUrl      string `json:"downloadUrl,omitempty"`
 	MagnetUrl        string `json:"magnetUrl,omitempty"`
-	Size             int64  `json:"size"`
+	Size             uint64 `json:"size"`
 	Indexer          string `json:"indexer"`
 	DownloadProtocol string `json:"downloadProtocol"`
 	Protocol         string `json:"protocol"`

--- a/pkg/whisparr/client.go
+++ b/pkg/whisparr/client.go
@@ -16,6 +16,10 @@ import (
 
 func (c *client) get(ctx context.Context, endpoint string) (*http.Response, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v3/", endpoint)
 	reqUrl := u.String()
 
@@ -45,6 +49,10 @@ func (c *client) get(ctx context.Context, endpoint string) (*http.Response, erro
 
 func (c *client) post(ctx context.Context, endpoint string, data interface{}) (*http.Response, error) {
 	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
 	u.Path = path.Join(u.Path, "/api/v3/", endpoint)
 	reqUrl := u.String()
 

--- a/pkg/whisparr/whisparr.go
+++ b/pkg/whisparr/whisparr.go
@@ -65,7 +65,7 @@ type Release struct {
 	InfoUrl          string `json:"infoUrl,omitempty"`
 	DownloadUrl      string `json:"downloadUrl,omitempty"`
 	MagnetUrl        string `json:"magnetUrl,omitempty"`
-	Size             int64  `json:"size"`
+	Size             uint64 `json:"size"`
 	Indexer          string `json:"indexer"`
 	DownloadProtocol string `json:"downloadProtocol"`
 	Protocol         string `json:"protocol"`


### PR DESCRIPTION
Change size types to uint64 for arr clients, and also add error handling to url.Parse methods.

This should fix CodeQL reports and lint errors.