### PR TITLE
fix(build): do not create flat tarball for web-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Create web-dist artifact
         if: startsWith(github.ref, 'refs/tags/')
-        run: mkdir -p dist && tar czf dist/web-dist.tar.gz --directory=web/dist ./
+        run: mkdir -p dist && tar czf dist/web-dist.tar.gz web/dist
 
       - name: Upload web-dist to release assets
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Turns out that the flat tarball isnt working as I expected it would 🙈 sorry

It will actually be better to have it inside folder because the apkbuilder doest put them inside any folder when extracting and it end being a messy src folder