### PR TITLE
fix(wildcard): check name length

### DIFF
--- a/pkg/wildcard/match.go
+++ b/pkg/wildcard/match.go
@@ -55,7 +55,7 @@ func match(pattern, name string, simple bool) (matched bool) {
 			}
 
 			offset := base + i
-			if name[base:offset] != pattern[base:offset] {
+			if len(name[base:]) < offset || name[base:offset] != pattern[base:offset] {
 				break
 			}
 

--- a/pkg/wildcard/match.go
+++ b/pkg/wildcard/match.go
@@ -55,7 +55,7 @@ func match(pattern, name string, simple bool) (matched bool) {
 			}
 
 			offset := base + i
-			if len(name[base:]) < offset || name[base:offset] != pattern[base:offset] {
+			if len(name[base:]) <= offset || name[base:offset] != pattern[base:offset] {
 				break
 			}
 

--- a/pkg/wildcard/match.go
+++ b/pkg/wildcard/match.go
@@ -55,7 +55,7 @@ func match(pattern, name string, simple bool) (matched bool) {
 			}
 
 			offset := base + i
-			if len(name[base:]) <= offset || name[base:offset] != pattern[base:offset] {
+			if len(name) < offset || name[base:offset] != pattern[base:offset] {
 				break
 			}
 

--- a/pkg/wildcard/match_test.go
+++ b/pkg/wildcard/match_test.go
@@ -93,9 +93,14 @@ func TestMatch(t *testing.T) {
 			matched: true,
 		},
 		{
-			pattern: "mysteries?of?the?abandoned*",
-			text:    "them",
-			matched: false,
+			pattern: "The God of the Brr*The Power of Brr",
+			text:    "The God of the Brr - The Power of Brr",
+			matched: true,
+		},
+		{
+			pattern: "The God of the Brr*The Power of Brr",
+			text:    "The God of the BrrThe Power of Brr",
+			matched: true,
 		},
 		{
 			pattern: "mysteries?of?the?abandoned*",

--- a/pkg/wildcard/match_test.go
+++ b/pkg/wildcard/match_test.go
@@ -93,14 +93,9 @@ func TestMatch(t *testing.T) {
 			matched: true,
 		},
 		{
-			pattern: "The God of the Brr*The Power of Brr",
-			text:    "The God of the Brr - The Power of Brr",
-			matched: true,
-		},
-		{
-			pattern: "The God of the Brr*The Power of Brr",
-			text:    "The God of the BrrThe Power of Brr",
-			matched: true,
+			pattern: "mysteries?of?the?abandoned*",
+			text:    "them",
+			matched: false,
 		},
 	}
 	// Iterating over the test cases, call the function under test and assert the output.

--- a/pkg/wildcard/match_test.go
+++ b/pkg/wildcard/match_test.go
@@ -97,6 +97,11 @@ func TestMatch(t *testing.T) {
 			text:    "them",
 			matched: false,
 		},
+		{
+			pattern: "mysteries?of?the?abandoned*",
+			text:    "them",
+			matched: false,
+		},
 	}
 	// Iterating over the test cases, call the function under test and assert the output.
 	for i, testCase := range testCases {


### PR DESCRIPTION
In some cases names would be out of bounds and lead to a panic.