### PR TITLE
fix(indexers): update Fuzer IRC addr

### DIFF
--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -971,4 +971,8 @@ ALTER TABLE irc_network
 CREATE INDEX filter_priority_index
 	ON filter (priority);
 `,
+	`UPDATE irc_network
+    SET server = 'irc.fuzer.xyz'
+    WHERE server = 'irc.fuzer.me';
+`,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -1613,4 +1613,8 @@ CREATE INDEX filter_enabled_index
 CREATE INDEX filter_priority_index
     ON filter (priority);
 `,
+	`UPDATE irc_network
+    SET server = 'irc.fuzer.xyz'
+    WHERE server = 'irc.fuzer.me';
+`,
 }

--- a/internal/indexer/definitions/fuzer.yaml
+++ b/internal/indexer/definitions/fuzer.yaml
@@ -25,7 +25,7 @@ settings:
 
 irc:
   network: Fuzer
-  server: irc.fuzer.me
+  server: irc.fuzer.xyz
   port: 6697
   tls: true
   channels:


### PR DESCRIPTION
This PR contains database migrations. 
You cannot go back to an older or current stable version once you have used this PR.

maybe push a new patch version for this?

fixes #1763 