### PR TITLE
fix(indexers): OPS API test function

### DIFF
--- a/pkg/ops/ops.go
+++ b/pkg/ops/ops.go
@@ -165,7 +165,7 @@ type Userstats struct {
 	Uploaded           int64   `json:"uploaded"`
 	Downloaded         int64   `json:"downloaded"`
 	Ratio              float64 `json:"ratio"`
-	Requiredratio      int64   `json:"requiredratio"`
+	Requiredratio      float64 `json:"requiredratio"`
 	BonusPoints        int64   `json:"bonusPoints"`
 	BonusPointsPerHour float64 `json:"bonusPointsPerHour"`
 	Class              string  `json:"class"`


### PR DESCRIPTION
Fix for OPS API returning required ratio as float if not 0.