### PR TITLE
fix(config): log reload message once

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -387,8 +387,10 @@ func (c *AppConfig) load(configPath string) {
 }
 
 func (c *AppConfig) DynamicReload(log logger.Logger) {
+	viper.WatchConfig()
 	viper.OnConfigChange(func(e fsnotify.Event) {
 		c.m.Lock()
+		defer c.m.Unlock()
 
 		logLevel := viper.GetString("logLevel")
 		c.Config.LogLevel = logLevel
@@ -401,10 +403,7 @@ func (c *AppConfig) DynamicReload(log logger.Logger) {
 		c.Config.CheckForUpdates = checkUpdates
 
 		log.Debug().Msg("config file reloaded!")
-
-		c.m.Unlock()
 	})
-	viper.WatchConfig()
 }
 
 func (c *AppConfig) UpdateConfig() error {


### PR DESCRIPTION
The `config file reloaded!`-message is being logged twice when the configuration is reloaded.

Changes made to address the issue:
- Moved `viper.WatchConfig()` before setting up the `OnConfigChange` callback in `internal/config/config.go`
- Used `defer` for unlocking the mutex to ensure it's always unlocked