### PR TITLE
fix(web): remove unnecessary link to Logs

### DIFF
--- a/web/src/screens/settings/Logs.tsx
+++ b/web/src/screens/settings/Logs.tsx
@@ -4,7 +4,6 @@
  */
 
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import { toast } from "react-hot-toast";
 import Select from "react-select";
 
@@ -80,14 +79,7 @@ function LogSettings() {
       title="Logs"
       description={
         <>
-          Configure log level, log size rotation, etc. You can download your old log files
-          {" "}
-          <Link
-            to="/settings/logs"
-            className="text-gray-700 dark:text-gray-200 underline font-semibold underline-offset-2 decoration-blue-500 decoration hover:text-black hover:dark:text-gray-100"
-          >
-            on the Logs page
-          </Link>.
+          Configure log level, log size rotation, etc. You can download your old log files below.
         </>
       }
     >

--- a/web/src/screens/settings/Logs.tsx
+++ b/web/src/screens/settings/Logs.tsx
@@ -77,11 +77,7 @@ function LogSettings() {
   return (
     <Section
       title="Logs"
-      description={
-        <>
-          Configure log level, log size rotation, etc. You can download your old log files below.
-        </>
-      }
+      description="Configure log level, log size rotation, etc. You can download your old log files below."
     >
       <div className="-mx-4 lg:col-span-9">
         <div className="divide-y divide-gray-200 dark:divide-gray-750">


### PR DESCRIPTION
The link linked to the page you're already viewing, which seemed unnecessary.

Old:
![image](https://github.com/user-attachments/assets/fdcbc0e7-e910-443a-bed3-2c8f3e4cfa38)

New:
![image](https://github.com/user-attachments/assets/5048a147-428b-4932-9592-fa74a85a8cc8)
