### PR TITLE
chore(build): update workflows and `go.mod` to use latest patch version of Go

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ on:
     - cron: '20 13 * * 6'
 
 env:
-  GO_VERSION: '1.23.0'
+  GO_VERSION: '1.23'
   NODE_VERSION: '20.17.0'
 
 jobs:

--- a/.github/workflows/golang-linter.yml
+++ b/.github/workflows/golang-linter.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: '1.23.0'
+  GO_VERSION: '1.23'
   NODE_VERSION: '20.17.0'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
-  GO_VERSION: '1.23.0'
+  GO_VERSION: '1.23'
   NODE_VERSION: '20.17.0'
 
 permissions:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/autobrr
 
-go 1.23.0
+go 1.23.2
 
 replace github.com/r3labs/sse/v2 => github.com/autobrr/sse/v2 v2.0.0-20230520125637-530e06346d7d
 


### PR DESCRIPTION
Our prebuilt binaries are built with`v1.23.0`, instead of building with the latest patch release. The docker images are "unaffected", since they are built with the latest patch release through alpine.

Can be checked with `go version /path/to/autobrr`

```console
/autobrr_1.47.1_darwin_arm64 ❯ go version autobrr                                                                                                                                            11:49:35 AM
autobrr: go1.23.0
```