### PR TITLE
feat(actions): rename skip reannounce to disable reannounce

### DIFF
--- a/web/src/screens/filters/sections/action_components/ActionQBittorrent.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionQBittorrent.tsx
@@ -179,8 +179,8 @@ export const QBittorrent = ({ idx, action, clients }: ClientActionProps) => (
         <FilterHalfRow>
           <SwitchGroup
             name={`actions.${idx}.reannounce_skip`}
-            label="Skip reannounce"
-            description="If reannounce is not needed, skip it completely"
+            label="Disable reannounce"
+            description="Reannounce is enabled by default. Disable if it's not needed"
             className="pt-2 pb-4"
           />
           <NumberField

--- a/web/src/screens/filters/sections/action_components/ActionTransmission.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionTransmission.tsx
@@ -91,8 +91,8 @@ export const Transmission = ({ idx, action, clients }: ClientActionProps) => (
         <FilterHalfRow>
           <SwitchGroup
             name={`actions.${idx}.reannounce_skip`}
-            label="Skip reannounce"
-            description="If reannounce is not needed, skip it completely"
+            label="Disable reannounce"
+            description="Reannounce is enabled by default. Disable if it's not needed"
             className="pt-2 pb-4"
           />
           <NumberField


### PR DESCRIPTION
Change the confusing label on actions to ignore re-announce. It's on by default so lets call it **Disable Reannounce** instead.

![image](https://github.com/user-attachments/assets/e428991b-8dea-4d79-8d81-e0b906ec5e61)
 