### PR TITLE
fix(indexers): BTFiles size parsing

### DIFF
--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -690,6 +690,9 @@ func (r *Release) MapVars(def *IndexerDefinition, varMap map[string]string) erro
 	}
 
 	if torrentSize, err := getStringMapValue(varMap, "torrentSize"); err == nil {
+		// Some indexers like BTFiles announces size with comma. Humanize does not handle that well and strips it.
+		torrentSize = strings.Replace(torrentSize, ",", ".", 1)
+
 		// handling for indexer who doesn't explicitly set which size unit is used like (AR)
 		if def.IRC != nil && def.IRC.Parse != nil && def.IRC.Parse.ForceSizeUnit != "" {
 			torrentSize = fmt.Sprintf("%s %s", torrentSize, def.IRC.Parse.ForceSizeUnit)

--- a/internal/indexer/definitions/btfiles.yaml
+++ b/internal/indexer/definitions/btfiles.yaml
@@ -62,7 +62,7 @@ irc:
             category: XXX » HD
             tags: ""
             torrentName: Some.Porno.22.08.16.Famous.Actress.XXX.1080p.MP4-GROUP
-            torrentSize: 3,00 GB
+            torrentSize: 3.00 GB
             baseUrl: https://bittorrentfiles.me/
             torrentId: "0000000"
         - line: '[Music » Single] [Dance Hall] Artist-Album-WEB-2021-GROUP  [ 63,09 MB | Pred 2022-08-16 08:58:06 (GMT) | URL: https://bittorrentfiles.me/details.php?id=0000000 ]'
@@ -70,7 +70,7 @@ irc:
             category: Music » Single
             tags: Dance Hall
             torrentName: Artist-Album-WEB-2021-GROUP
-            torrentSize: 63,09 MB
+            torrentSize: 63.09 MB
             baseUrl: https://bittorrentfiles.me/
             torrentId: "0000000"
         - line: '[Sports » HD] Sports.League.2022.08.15.Team1.vs.Team2.720p.WEB.h264-GROUP  [ 6,26 GB | Pred 2022-08-16 08:46:25 (GMT) | URL: https://bittorrentfiles.me/details.php?id=0000000 ]'
@@ -78,7 +78,7 @@ irc:
             category: Sports » HD
             tags: ""
             torrentName: Sports.League.2022.08.15.Team1.vs.Team2.720p.WEB.h264-GROUP
-            torrentSize: 6,26 GB
+            torrentSize: 6.26 GB
             baseUrl: https://bittorrentfiles.me/
             torrentId: "0000000"
         pattern: '\[(.*?)\] (?:\[(.*)\] )?(.*)  \[ ([\d\.,]+ \w+) \| Pred .+ \| URL\: (https?\:\/\/[^\/]+\/).*[&\?]id=(\d+) \]'

--- a/internal/indexer/definitions/btfiles.yaml
+++ b/internal/indexer/definitions/btfiles.yaml
@@ -62,7 +62,7 @@ irc:
             category: XXX » HD
             tags: ""
             torrentName: Some.Porno.22.08.16.Famous.Actress.XXX.1080p.MP4-GROUP
-            torrentSize: 3.00 GB
+            torrentSize: 3,00 GB
             baseUrl: https://bittorrentfiles.me/
             torrentId: "0000000"
         - line: '[Music » Single] [Dance Hall] Artist-Album-WEB-2021-GROUP  [ 63,09 MB | Pred 2022-08-16 08:58:06 (GMT) | URL: https://bittorrentfiles.me/details.php?id=0000000 ]'
@@ -70,7 +70,7 @@ irc:
             category: Music » Single
             tags: Dance Hall
             torrentName: Artist-Album-WEB-2021-GROUP
-            torrentSize: 63.09 MB
+            torrentSize: 63,09 MB
             baseUrl: https://bittorrentfiles.me/
             torrentId: "0000000"
         - line: '[Sports » HD] Sports.League.2022.08.15.Team1.vs.Team2.720p.WEB.h264-GROUP  [ 6,26 GB | Pred 2022-08-16 08:46:25 (GMT) | URL: https://bittorrentfiles.me/details.php?id=0000000 ]'
@@ -78,7 +78,7 @@ irc:
             category: Sports » HD
             tags: ""
             torrentName: Sports.League.2022.08.15.Team1.vs.Team2.720p.WEB.h264-GROUP
-            torrentSize: 6.26 GB
+            torrentSize: 6,26 GB
             baseUrl: https://bittorrentfiles.me/
             torrentId: "0000000"
         pattern: '\[(.*?)\] (?:\[(.*)\] )?(.*)  \[ ([\d\.,]+ \w+) \| Pred .+ \| URL\: (https?\:\/\/[^\/]+\/).*[&\?]id=(\d+) \]'


### PR DESCRIPTION
BTFiles announces size with comma delimiter. The humanize package strips the comma so `3,76GB` becomes `376GB` which is not ideal.

This fix adds a replace comma to dot.

Fixes #1804 