### PR TITLE
fix(proxy): add shared transport for proxies

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -160,7 +160,7 @@ func GetProxiedHTTPClient(p *domain.Proxy) (*http.Client, error) {
 		proxyUrl.User = url.UserPassword(p.User, p.Pass)
 	}
 
-	transport := sharedhttp.TransportTLSInsecure
+	transport := sharedhttp.ProxyTransport
 
 	// set user and pass if not empty
 	if p.User != "" && p.Pass != "" {

--- a/pkg/sharedhttp/http.go
+++ b/pkg/sharedhttp/http.go
@@ -52,6 +52,26 @@ var TransportTLSInsecure = &http.Transport{
 	},
 }
 
+var ProxyTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second, // default transport value
+		KeepAlive: 30 * time.Second, // default transport value
+	}).DialContext,
+	ForceAttemptHTTP2:     true,              // default is true; since HTTP/2 multiplexes a single TCP connection.
+	MaxIdleConns:          100,               // default transport value
+	MaxIdleConnsPerHost:   10,                // default is 2, so we want to increase the number to use establish more connections.
+	IdleConnTimeout:       90 * time.Second,  // default transport value
+	ResponseHeaderTimeout: 120 * time.Second, // servers can respond slowly - this should fix some portion of releases getting stuck as pending.
+	TLSHandshakeTimeout:   10 * time.Second,  // default transport value
+	ExpectContinueTimeout: 1 * time.Second,   // default transport value
+	ReadBufferSize:        65536,
+	WriteBufferSize:       65536,
+	TLSClientConfig: &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	},
+}
+
 var Client = &http.Client{
 	Timeout:   60 * time.Second,
 	Transport: Transport,


### PR DESCRIPTION
Add new shared transport used only for Proxies to not interfere with non-proxied requests.

When using the shared transports and once setting a proxy it would persist on the client/transport, even if it was disabled by the application.

This PR adds a new `sharedhttp.ProxyTransport` which proxies will use.

Fixes #1793 