### PR TITLE
fix(releases): update size after actions run

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -56,6 +56,26 @@ func (repo *ReleaseRepo) Store(ctx context.Context, r *domain.Release) error {
 	return nil
 }
 
+func (repo *ReleaseRepo) Update(ctx context.Context, r *domain.Release) error {
+	queryBuilder := repo.db.squirrel.
+		Update("release").
+		Set("size", r.Size).
+		Where(sq.Eq{"id": r.ID})
+
+	query, args, err := queryBuilder.ToSql()
+	if err != nil {
+		return errors.Wrap(err, "error building query")
+	}
+
+	if _, err = repo.db.handler.ExecContext(ctx, query, args...); err != nil {
+		return errors.Wrap(err, "error executing query")
+	}
+
+	repo.log.Debug().Msgf("release.update: %d %s", r.ID, r.TorrentName)
+
+	return nil
+}
+
 func (repo *ReleaseRepo) StoreReleaseActionStatus(ctx context.Context, status *domain.ReleaseActionStatus) error {
 	if status.ID != 0 {
 		queryBuilder := repo.db.squirrel.

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -31,6 +31,7 @@ import (
 
 type ReleaseRepo interface {
 	Store(ctx context.Context, release *Release) error
+	Update(ctx context.Context, r *Release) error
 	Find(ctx context.Context, params ReleaseQueryParams) (*FindReleasesResponse, error)
 	Get(ctx context.Context, req *GetReleaseRequest) (*Release, error)
 	GetIndexerOptions(ctx context.Context) ([]string, error)

--- a/internal/release/service.go
+++ b/internal/release/service.go
@@ -25,6 +25,7 @@ type Service interface {
 	GetIndexerOptions(ctx context.Context) ([]string, error)
 	Stats(ctx context.Context) (*domain.ReleaseStats, error)
 	Store(ctx context.Context, release *domain.Release) error
+	Update(ctx context.Context, release *domain.Release) error
 	StoreReleaseActionStatus(ctx context.Context, actionStatus *domain.ReleaseActionStatus) error
 	Delete(ctx context.Context, req *domain.DeleteReleaseRequest) error
 	Process(release *domain.Release)
@@ -79,6 +80,10 @@ func (s *service) Stats(ctx context.Context) (*domain.ReleaseStats, error) {
 
 func (s *service) Store(ctx context.Context, release *domain.Release) error {
 	return s.repo.Store(ctx, release)
+}
+
+func (s *service) Update(ctx context.Context, release *domain.Release) error {
+	return s.repo.Update(ctx, release)
 }
 
 func (s *service) StoreReleaseActionStatus(ctx context.Context, status *domain.ReleaseActionStatus) error {
@@ -189,8 +194,6 @@ func (s *service) processFilters(ctx context.Context, filters []*domain.Filter, 
 
 	// loop over and check filters
 	for _, f := range filters {
-		f := f
-
 		l := s.log.With().Str("indexer", release.Indexer.Identifier).Str("filter", f.Name).Str("release", release.TorrentName).Logger()
 
 		// save filter on release
@@ -248,9 +251,7 @@ func (s *service) processFilters(ctx context.Context, filters []*domain.Filter, 
 		var rejections []string
 
 		// run actions (watchFolder, test, exec, qBittorrent, Deluge, arr etc.)
-		for _, a := range actions {
-			act := a
-
+		for _, act := range actions {
 			// only run enabled actions
 			if !act.Enabled {
 				l.Trace().Msgf("release.Process: indexer: %s, filter: %s release: %s action '%s' not enabled, skip", release.Indexer.Name, release.FilterName, release.TorrentName, act.Name)
@@ -289,6 +290,10 @@ func (s *service) processFilters(ctx context.Context, filters []*domain.Filter, 
 
 			// if no rejections consider action approved, run next
 			continue
+		}
+
+		if err = s.Update(ctx, release); err != nil {
+			l.Error().Err(err).Msgf("release.Process: error updating release: %v", release.TorrentName)
 		}
 
 		// if we have rejections from arr, continue to next filter


### PR DESCRIPTION
Update release size after actions run, in case they download and parse .torrent files.

This used to work but was changed/forgotten in one of the many big refactors.

Fixes #1803 