### PR TITLE
build(ci): implement PGO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
         uses: test-summary/action@v2
         with:
           paths: "unit-tests.xml"
-        if: always() && ${{ startsWith(matrix.os, 'windows') == false }}
+        if: always() && startsWith(matrix.os, 'windows') == false
 
   pgo:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           cache: true
 
       - name: Create Profile environment
-        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -cpuprofile="profile/$(echo $pkg | tr -d /).pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh && mkdir profile
+        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -cpuprofile="profile/$(echo $pkg | tr / -).pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh && mkdir profile
 
       - name: Test
         run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,11 @@ jobs:
           cache: true
 
       - name: Create Profile environment
-        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -cpuprofile="profile/$(echo $pkg | tr / -).pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh && mkdir profile
+        run:
+          |
+          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -cpuprofile="profile/$(echo $pkg | tr / -).pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh;
+          chmod +x profile.sh;
+          mkdir profile
 
       - name: Test
         run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,11 @@ jobs:
     name: Automatic PGO ${{ matrix.cgo == 1 && 'CGO ' || ''}}run ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [web]
+    env:
+      GOPATH: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\golang\go' || '' }}
+      GOCACHE: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\golang\cache' || '' }}
+      GOMODCACHE: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\golang\modcache' || '' }}
+      USERPROFILE: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\homedir' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Profile
         shell: bash
-        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...
+        run: ${{ matrix.os == 'windows-latest' && './profile.sh ./...' || 'go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...' }}
 
       - name: Upload pprof
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: true
       matrix:
         cgo: [ 1, 0 ]
-    name: Test ${{ matrix.cgo == 1 && "CGO" || ""}}
+    name: Test ${{ matrix.cgo == 1 && 'CGO'|| ""}}
     runs-on: ubuntu-latest
     services:
       test_postgres:
@@ -116,7 +116,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         cgo: [ 1, 0 ]
-    name: PGO ${{ matrix.cgo == 1 && "CGO " || ""}}run ${{ matrix.os }}
+    name: PGO ${{ matrix.cgo == 1 && 'CGO ' || ''}}run ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [web]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
 
   test:
     name: Test
+    strategy:
+      fail-fast: true
+      matrix:
+        cgo: [ 1, 0 ]
     runs-on: ubuntu-latest
     services:
       test_postgres:
@@ -87,7 +91,7 @@ jobs:
       - name: Create Profile environment
         run:
           |
-          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -cpuprofile="profile/$(echo $pkg | tr / -).pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh;
+          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh;
           chmod +x profile.sh;
           mkdir profile
 
@@ -111,6 +115,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        cgo: [ 1, 0 ]
     name: Automated (PGO) run
     runs-on: ${{ matrix.os }}
     needs: [web]
@@ -134,13 +139,13 @@ jobs:
 
       - name: Generate Profile
         shell: bash
-        run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo cpu-${{ matrix.os }}.pprof
+        run: CGO_ENABLED=${{ matrix.cgo }} go run cmd/autobrr/main.go --pgo cpu-${{ matrix.os }}-${{ matrix.cgo }}.pprof
 
       - name: Upload pprof
         uses: actions/upload-artifact@v4
         with:
-          name: pprof-pgo-${{ matrix.os }}
-          path: cpu-${{ matrix.os }}.pprof
+          name: pprof-pgo-${{ matrix.os }}-${{ matrix.cgo }}
+          path: cpu-${{ matrix.os }}-${{ matrix.cgo }}.pprof
 
   goprofilecombine:
     name: Combine pprof profiles

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
           cache: true
 
       - name: Generate Profile
+        shell: bash
         run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo cpu-${{ matrix.os }}.pprof
 
       - name: Upload pprof

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           cache: true
 
       - name: Generate Profile
-        run: go run cmd/autobrr/main.go --pgo cpu.pprof
+        run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo cpu.pprof
 
       - name: Upload web production build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tgo test -json -cpuprofile="profile/$(echo $pkg | tr -d /).profile" "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh
 
       - name: Test
-        run: go run gotest.tools/gotestsum@latest --raw-command ./profile.sh --junitfile unit-tests.xml --format pkgname -- ./... -tags=integration
+        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./... -tags=integration
 
       - name: visibility
         id: viz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,10 +173,7 @@ jobs:
           cache: false
 
       - name: Merge Profiles
-        run: go run github.com/rakyll/pprof-merge@latest profile/*.pprof
-
-      - name: Rename to pprof
-        run: mv merged.data cpu.pprof
+        run: go tool pprof -proto profile/*.pprof | tee -a cpu.pprof
 
       - name: Upload pprof
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           |
           printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh;
           chmod +x profile.sh;
-          mkdir profile
+          mkdir profile;
 
       - name: Test
         run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
           cache: true
 
       - name: Create Profile environment
+        shell: bash
         run:
           |
           printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ matrix.os == 'ubuntu-latest' && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
@@ -138,7 +139,8 @@ jobs:
           mkdir profile;
 
       - name: Profile
-        run: ./profile.sh ./...
+        shell: bash
+        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...
 
       - name: Upload pprof
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,11 +158,8 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Download pprof-merge
-        run: go get github.com/rakyll/pprof-merge
-
       - name: Merge Profiles
-        run: go run github.com/rakyll/pprof-merge profile/*.pprof
+        run: go run github.com/rakyll/pprof-merge@latest profile/*.pprof
 
       - name: Rename to pprof
         run: mv merged.data cpu.pprof

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,20 +137,14 @@ jobs:
           chmod +x profile.sh;
           mkdir profile;
 
-      - name: Test
-        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...
+      - name: Profile
+        run: ./profile.sh ./...
 
       - name: Upload pprof
         uses: actions/upload-artifact@v4
         with:
           name: pprof-test-${{ matrix.os }}-${{ matrix.cgo }}
           path: profile
-
-      - name: Test Summary
-        uses: test-summary/action@v2
-        with:
-          paths: "unit-tests.xml"
-        if: always()
 
   pgo:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
         uses: test-summary/action@v2
         with:
           paths: "unit-tests.xml"
-        if: ${{ startsWith(matrix.os, 'windows') == false }} && always()
+        if: always() && ${{ startsWith(matrix.os, 'windows') == false }}
 
   pgo:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         cgo: [ 1, 0 ]
-    name: Test ${{ matrix.cgo == 1 && 'CGO'|| ''}}
-    runs-on: ubuntu-latest
+    name: Test${{ matrix.cgo == 1 && ' CGO'|| '' }}
+    runs-on: ${{ matrix.os }}
     services:
       test_postgres:
         image: postgres:12.10
@@ -90,7 +91,7 @@ jobs:
       - name: Create Profile environment
         run:
           |
-          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh;
+          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ matrix.os == 'ubuntu-latest' && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
           chmod +x profile.sh;
           mkdir profile;
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: profile.sh
         id: profile
-        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tgo test -json -cpuprofile="profile/$(echo $pkg | tr -d /).profile" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh
+        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -broken -cpuprofile="profile/$(echo $pkg | tr -d /).profile" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh
 
       - name: Test
         run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # 1.20 is the last version to support Windows < 10, Server < 2016, and MacOS < 1.15.
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -206,7 +205,6 @@ jobs:
         with:
           name: pprof
 
-#     1.20 is the last version to support Windows < 10, Server < 2016, and MacOS < 1.15.
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Upload pprof
         uses: actions/upload-artifact/merge@v4
         with:
-          name: pprof
+          name: pprof-test
           path: profile
 
       - name: Test Summary
@@ -134,7 +134,7 @@ jobs:
       - name: Upload pprof
         uses: actions/upload-artifact/merge@v4
         with:
-          name: pprof
+          name: pprof-pgo
           path: profile
 
   goprofilecombine:
@@ -142,10 +142,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pgo, test]
     steps:
-      - name: Download pprof profile
+      - name: Download pprof-test profile
         uses: actions/download-artifact@v4
         with:
-          name: pprof
+          name: pprof-test
+
+      - name: Download pprof-cpu profile
+        uses: actions/download-artifact@v4
+        with:
+          name: pprof-cpu
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Upload pprof
         uses: actions/upload-artifact@v4
         with:
-          name: pprof-test-${{ matrix.cgo }}
+          name: pprof-test-${{ matrix.os }}-${{ matrix.cgo }}
           path: profile
 
       - name: Test Summary
@@ -143,7 +143,7 @@ jobs:
       - name: Upload pprof
         uses: actions/upload-artifact@v4
         with:
-          name: pprof-test-${{ matrix.cgo }}
+          name: pprof-test-${{ matrix.os }}-${{ matrix.cgo }}
           path: profile
 
       - name: Test Summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         if: always()
 
   pgo:
-    name: Create PGO profile
+    name: Automated run profile (PGO)
     runs-on: ubuntu-latest
     needs: [web]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Upload pprof
         uses: actions/upload-artifact@v4
         with:
-          name: pprof-test
+          name: pprof-test-${{ matrix.cgo }}
           path: profile
 
       - name: Test Summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: profile.sh
+      - name: Create Profile environment
         id: profile
         run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -cpuprofile="profile/$(echo $pkg | tr -d /).pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh && mkdir profile
 
@@ -137,10 +137,10 @@ jobs:
           name: pprof
           path: profile
 
-  profilecombine:
+  goprofilecombine:
     name: Combine pprof profiles
     runs-on: ubuntu-latest
-    needs: [web, test]
+    needs: [pgo, test]
     steps:
       - name: Download pprof profile
         uses: actions/download-artifact@v4
@@ -171,7 +171,7 @@ jobs:
   goreleaserbuild:
     name: Build distribution binaries
     runs-on: ubuntu-latest
-    needs: [web, profilecombine]
+    needs: [web, goprofilecombine]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -258,7 +258,7 @@ jobs:
 #       - linux/riscv64
         - linux/s390x
         - windows/amd64
-    needs: [web, profilecombine]
+    needs: [web, goprofilecombine]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,10 @@ jobs:
 
       - name: profile.sh
         id: profile
-        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tgo test -json -cpuprofile="profile/$(echo $pkg | tr -d /).profile" "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh
+        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tgo test -json -cpuprofile="profile/$(echo $pkg | tr -d /).profile" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh
 
       - name: Test
-        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./... -tags=integration
+        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...
 
       - name: visibility
         id: viz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,11 @@ jobs:
         cgo: [ 1, 0 ]
     name: Test${{ matrix.cgo == 1 && ' CGO'|| '' }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      GOPATH: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\go' || '' }}
+      GOCACHE: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\cache' || '' }}
+      GOMODCACHE: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\modcache' || '' }}
+      USERPROFILE: ${{ startsWith(matrix.os, 'windows') && 'D:\homedir' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,16 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
+      - name: profile.sh
+        id: profile
+        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tgo test -json -cpuprofile="profile/$(echo $pkg | tr -d /).profile" "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh
+
       - name: Test
-        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname -- ./... -tags=integration
+        run: go run gotest.tools/gotestsum@latest --raw-command ./profile.sh --junitfile unit-tests.xml --format pkgname -- ./... -tags=integration
+
+      - name: visibility
+        id: viz
+        run: ls -la profile/
 
       - name: Test Summary
         uses: test-summary/action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
+          cache: ${{ matrix.os != 'windows-latest'}}
 
       - name: Generate Profile
         shell: bash
@@ -166,7 +166,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
+          cache: false
 
       - name: Merge Profiles
         run: go run github.com/rakyll/pprof-merge@latest profile/*.pprof

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...
 
       - name: Upload pprof
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact@v4
         with:
           name: pprof-test
           path: profile
@@ -132,7 +132,7 @@ jobs:
         run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo profile/cpu.pprof
 
       - name: Upload pprof
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact@v4
         with:
           name: pprof-pgo
           path: profile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         cgo: [ 1, 0 ]
-    name: Test${{ matrix.cgo == 1 && ' CGO'|| '' }}
+    name: Test${{ matrix.cgo == 1 && ' CGO'|| '' }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     services:
-      if: ${{ matrix.os == 'ubuntu-latest' }}
       test_postgres:
         image: postgres:12.10
         ports:
@@ -77,6 +76,48 @@ jobs:
           POSTGRES_PASSWORD: testdb
           POSTGRES_DB: autobrr
         options: --health-cmd pg_isready --health-interval 1s --health-timeout 5s --health-retries 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Create Profile environment
+        run:
+          |
+          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ matrix.os == 'ubuntu-latest' && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
+          chmod +x profile.sh;
+          mkdir profile;
+
+      - name: Test
+        run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...
+
+      - name: Upload pprof
+        uses: actions/upload-artifact@v4
+        with:
+          name: pprof-test-${{ matrix.cgo }}
+          path: profile
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "unit-tests.xml"
+        if: always()
+
+  testother:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [macos-latest, windows-latest]
+        cgo: [ 1, 0 ]
+    name: Test${{ matrix.cgo == 1 && ' CGO'|| '' }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -156,7 +197,7 @@ jobs:
   goprofilecombine:
     name: Combine pprof profiles
     runs-on: ubuntu-latest
-    needs: [pgo, test]
+    needs: [pgo, test, testother]
     steps:
       - name: Download pprof profiles
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,8 @@ jobs:
           POSTGRES_PASSWORD: testdb
           POSTGRES_DB: autobrr
         options: --health-cmd pg_isready --health-interval 1s --health-timeout 5s --health-retries 60
+    env:
+      CGO_ENABLED: ${{ matrix.cgo }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,7 +93,7 @@ jobs:
       - name: Create Profile environment
         run:
           |
-          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ startsWith(matrix.os, 'ubuntu') && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
+          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tgo test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ startsWith(matrix.os, 'ubuntu') && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
           chmod +x profile.sh;
           mkdir profile;
 
@@ -123,6 +125,7 @@ jobs:
       GOCACHE: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\cache' || '' }}
       GOMODCACHE: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\modcache' || '' }}
       USERPROFILE: ${{ startsWith(matrix.os, 'windows') && 'D:\homedir' || '' }}
+      CGO_ENABLED: ${{ matrix.cgo }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -139,7 +142,7 @@ jobs:
         shell: bash
         run:
           |
-          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ startsWith(matrix.os, 'ubuntu') && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
+          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tgo test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ startsWith(matrix.os, 'ubuntu') && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
           chmod +x profile.sh;
           mkdir profile;
 
@@ -173,6 +176,7 @@ jobs:
       GOCACHE: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\cache' || '' }}
       GOMODCACHE: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\modcache' || '' }}
       USERPROFILE: ${{ startsWith(matrix.os, 'windows') && 'D:\homedir' || '' }}
+      CGO_ENABLED: ${{ matrix.cgo }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -192,8 +196,7 @@ jobs:
           cache: true
 
       - name: Generate Profile
-        shell: bash
-        run: CGO_ENABLED=${{ matrix.cgo }} go run cmd/autobrr/main.go --pgo cpu-${{ matrix.os }}-${{ matrix.cgo }}.pprof
+        run: go run cmd/autobrr/main.go --pgo cpu-${{ matrix.os }}-${{ matrix.cgo }}.pprof
 
       - name: Upload pprof
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,11 @@ jobs:
         if: always()
 
   pgo:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
     name: Automated run profile (PGO)
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: [web]
     steps:
       - name: Checkout
@@ -125,13 +128,13 @@ jobs:
           cache: true
 
       - name: Generate Profile
-        run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo cpu.pprof
+        run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo cpu-${{ matrix.os }}.pprof
 
       - name: Upload pprof
         uses: actions/upload-artifact@v4
         with:
-          name: pprof-pgo
-          path: cpu.pprof
+          name: pprof-pgo-${{ matrix.os }}
+          path: cpu-${{ matrix.os }}.pprof
 
   goprofilecombine:
     name: Combine pprof profiles

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,11 +146,16 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: pprof-test
+          path: profile
 
       - name: Download pprof-pgo profile
         uses: actions/download-artifact@v4
         with:
           name: pprof-pgo
+          path: profile
+
+      - name: List contents
+        run: ls -la profile
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,10 +147,10 @@ jobs:
         with:
           name: pprof-test
 
-      - name: Download pprof-cpu profile
+      - name: Download pprof-pgo profile
         uses: actions/download-artifact@v4
         with:
-          name: pprof-cpu
+          name: pprof-pgo
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,9 +91,11 @@ jobs:
       - name: Test
         run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...
 
-      - name: visibility
-        id: viz
-        run: ls -la profile/
+      - name: Upload pprof
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: pprof
+          path: profile
 
       - name: Test Summary
         uses: test-summary/action@v2
@@ -123,14 +125,17 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Generate Profile
-        run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo cpu.pprof
+      - name: Setup Profile
+        run: mkdir profile
 
-      - name: Upload web production build
-        uses: actions/upload-artifact@v4
+      - name: Generate Profile
+        run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo profile/cpu.pprof
+
+      - name: Upload pprof
+        uses: actions/upload-artifact/merge@v4
         with:
           name: pprof
-          path: cpu.pprof
+          path: profile
 
   goreleaserbuild:
     name: Build distribution binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,10 +137,41 @@ jobs:
           name: pprof
           path: profile
 
+  profilecombine:
+    name: Combine pprof profiles
+    runs-on: ubuntu-latest
+    needs: [web, test]
+    steps:
+      - name: Download pprof profile
+        uses: actions/download-artifact@v4
+        with:
+          name: pprof
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Download pprof-merge
+        run: go get github.com/rakyll/pprof-merge
+
+      - name: Merge Profiles
+        run: go run github.com/rakyll/pprof-merge profile/*.pprof
+
+      - name: Rename to pprof
+        run: mv merged.data cpu.pprof
+
+      - name: Upload pprof
+        uses: actions/upload-artifact@v4
+        with:
+          name: pprof
+          path: cpu.pprof
+
   goreleaserbuild:
     name: Build distribution binaries
     runs-on: ubuntu-latest
-    needs: [web, test, pgo]
+    needs: [web, profilecombine]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -227,7 +258,7 @@ jobs:
 #       - linux/riscv64
         - linux/s390x
         - windows/amd64
-    needs: [web, test, pgo]
+    needs: [web, profilecombine]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         cgo: [ 1, 0 ]
-    name: Automatic PGO ${{ matrix.cgo == 1 && 'CGO ' || ''}} run ${{ matrix.os }}
+    name: Automatic PGO ${{ matrix.cgo == 1 && 'CGO ' || ''}}run ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [web]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [web]
     env:
-      GOPATH: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\golang\go' || '' }}
-      GOCACHE: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\golang\cache' || '' }}
-      GOMODCACHE: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\golang\modcache' || '' }}
-      USERPROFILE: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\homedir' || '' }}
+      GOPATH: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\go' || '' }}
+      GOCACHE: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\cache' || '' }}
+      GOMODCACHE: ${{ startsWith(matrix.os, 'windows') && 'D:\golang\modcache' || '' }}
+      USERPROFILE: ${{ startsWith(matrix.os, 'windows') && 'D:\homedir' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,7 +347,7 @@ jobs:
     name: Publish Docker multi-arch manifest
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: [docker, test]
+    needs: [docker]
     steps:
       - name: Download image digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: true
       matrix:
         cgo: [ 1, 0 ]
-    name: Test ${{ matrix.cgo == 1 && 'CGO'|| ""}}
+    name: Test ${{ matrix.cgo == 1 && 'CGO'|| ''}}
     runs-on: ubuntu-latest
     services:
       test_postgres:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,10 @@ jobs:
 
   pgo:
     strategy:
+      fail-fast: true
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-    name: Automated run profile (PGO)
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: Automated (PGO) run
     runs-on: ${{ matrix.os }}
     needs: [web]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         cgo: [ 1, 0 ]
-    name: PGO ${{ matrix.cgo == 1 && 'CGO ' || ''}}run ${{ matrix.os }}
+    name: Automatic PGO ${{ matrix.cgo == 1 && 'CGO ' || ''}} run ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [web]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,6 @@ jobs:
           cache: true
 
       - name: Create Profile environment
-        id: profile
         run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -cpuprofile="profile/$(echo $pkg | tr -d /).pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh && mkdir profile
 
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: profile.sh
         id: profile
-        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -broken -cpuprofile="profile/$(echo $pkg | tr -d /).profile" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh
+        run: printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=0 go test -json -cpuprofile="profile/$(echo $pkg | tr -d /).pprof" -tags=integration "$pkg"\ndone' | tee -a profile.sh && chmod +x profile.sh && mkdir profile
 
       - name: Test
         run: go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Create Profile environment
         run:
           |
-          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ matrix.os == 'ubuntu-latest' && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
+          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ startsWith(matrix.os, 'ubuntu') && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
           chmod +x profile.sh;
           mkdir profile;
 
@@ -139,13 +139,13 @@ jobs:
         shell: bash
         run:
           |
-          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ matrix.os == 'ubuntu-latest' && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
+          printf '#!/usr/bin/env bash\nset -eu\nfor pkg in $(go list "$@"); do\n\tCGO_ENABLED=${{ matrix.cgo }} go test -json -cpuprofile="profile/$(echo $pkg | tr / -)-${{ matrix.cgo }}.pprof" ${{ startsWith(matrix.os, 'ubuntu') && '-tags=integration ' || '' }}"$pkg"\ndone' | tee -a profile.sh;
           chmod +x profile.sh;
           mkdir profile;
 
       - name: Profile
         shell: bash
-        run: ${{ matrix.os == 'windows-latest' && './profile.sh ./...' || 'go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...' }}
+        run: ${{ startsWith(matrix.os, 'windows') && './profile.sh ./...' || 'go run gotest.tools/gotestsum@latest --junitfile unit-tests.xml --format pkgname --raw-command ./profile.sh -- ./...' }}
 
       - name: Upload pprof
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: ${{ matrix.os != 'windows-latest'}}
+          cache: true
 
       - name: Generate Profile
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,11 @@ jobs:
           path: web/dist
 
   test:
-    name: Test
     strategy:
       fail-fast: true
       matrix:
         cgo: [ 1, 0 ]
+    name: Test ${{ matrix.cgo == 1 && "CGO" || ""}}
     runs-on: ubuntu-latest
     services:
       test_postgres:
@@ -116,7 +116,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         cgo: [ 1, 0 ]
-    name: Automated (PGO) run
+    name: PGO ${{ matrix.cgo == 1 && "CGO " || ""}}run ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [web]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,12 @@ jobs:
           name: pprof-test-${{ matrix.os }}-${{ matrix.cgo }}
           path: profile
 
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "unit-tests.xml"
+        if: ${{ startsWith(matrix.os, 'windows') == false }} && always()
+
   pgo:
     strategy:
       fail-fast: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,33 +124,25 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Setup Profile
-        run: mkdir profile
-
       - name: Generate Profile
-        run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo profile/cpu.pprof
+        run: CGO_ENABLED=0 go run cmd/autobrr/main.go --pgo cpu.pprof
 
       - name: Upload pprof
         uses: actions/upload-artifact@v4
         with:
           name: pprof-pgo
-          path: profile
+          path: cpu.pprof
 
   goprofilecombine:
     name: Combine pprof profiles
     runs-on: ubuntu-latest
     needs: [pgo, test]
     steps:
-      - name: Download pprof-test profile
+      - name: Download pprof profiles
         uses: actions/download-artifact@v4
         with:
-          name: pprof-test
-          path: profile
-
-      - name: Download pprof-pgo profile
-        uses: actions/download-artifact@v4
-        with:
-          name: pprof-pgo
+          pattern: pprof-*
+          merge-multiple: true
           path: profile
 
       - name: List contents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
 #       - linux/riscv64
         - linux/s390x
         - windows/amd64
-    needs: [web, test]
+    needs: [web, test, pgo]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -226,6 +226,11 @@ jobs:
         with:
           name: web-dist
           path: web/dist
+
+      - name: Download pprof profile
+        uses: actions/download-artifact@v4
+        with:
+          name: pprof
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
     name: Test${{ matrix.cgo == 1 && ' CGO'|| '' }}
     runs-on: ${{ matrix.os }}
     services:
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       test_postgres:
         image: postgres:12.10
         ports:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,10 @@ jobs:
           paths: "unit-tests.xml"
         if: always()
 
-  goreleaserbuild:
-    name: Build distribution binaries
+  pgo:
+    name: Create PGO profile
     runs-on: ubuntu-latest
-    needs: [web, test]
+    needs: [web]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -108,6 +108,42 @@ jobs:
         with:
           name: web-dist
           path: web/dist
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Generate Profile
+        run: go run cmd/autobrr/main.go --pgo cpu.pprof
+
+      - name: Upload web production build
+        uses: actions/upload-artifact@v4
+        with:
+          name: pprof
+          path: cpu.pprof
+
+  goreleaserbuild:
+    name: Build distribution binaries
+    runs-on: ubuntu-latest
+    needs: [web, test, pgo]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download web production build
+        uses: actions/download-artifact@v4
+        with:
+          name: web-dist
+          path: web/dist
+
+      - name: Download pprof profile
+        uses: actions/download-artifact@v4
+        with:
+          name: pprof
 
 #     1.20 is the last version to support Windows < 10, Server < 2016, and MacOS < 1.15.
       - name: Set up Go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
   - id: autobrr
     env:
       - CGO_ENABLED=0
+    flags:
+      - -pgo=cpu.pprof
     goos:
       - linux
       - windows

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -26,7 +26,7 @@ export GOARCH=$TARGETARCH; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v6" ]] && export GOARM=6; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v7" ]] && export GOARM=7; \
 echo $GOARCH $GOOS $GOARM$GOAMD64; \
-go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrr cmd/autobrr/main.go && \
+go build -pgo=cpu.pprof -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrr cmd/autobrr/main.go && \
 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrrctl cmd/autobrrctl/main.go
 
 # build runner

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -26,7 +26,7 @@ export GOARCH=$TARGETARCH; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v6" ]] && export GOARM=6; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v7" ]] && export GOARM=7; \
 echo $GOARCH $GOOS $GOARM$GOAMD64; \
-go build -pgo=cpu.pprof -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrr cmd/autobrr/main.go && \
+go build -pgo=profile/*.pprof -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrr cmd/autobrr/main.go && \
 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrrctl cmd/autobrrctl/main.go
 
 # build runner

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -26,7 +26,7 @@ export GOARCH=$TARGETARCH; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v6" ]] && export GOARM=6; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v7" ]] && export GOARM=7; \
 echo $GOARCH $GOOS $GOARM$GOAMD64; \
-go build -pgo=profile/*.pprof -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrr cmd/autobrr/main.go && \
+go build -pgo=cpu.pprof -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrr cmd/autobrr/main.go && \
 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrrctl cmd/autobrrctl/main.go
 
 # build runner

--- a/ciwindows.Dockerfile
+++ b/ciwindows.Dockerfile
@@ -26,7 +26,7 @@ export GOARCH=$TARGETARCH; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v6" ]] && export GOARM=6; \
 [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v7" ]] && export GOARM=7; \
 echo $GOARCH $GOOS $GOARM$GOAMD64; \
-go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrr.exe cmd/autobrr/main.go && \
+go build -pgo=cpu.pprof -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrr.exe cmd/autobrr/main.go && \
 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrrctl.exe cmd/autobrrctl/main.go
 
 # build runner

--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -198,7 +198,7 @@ func pgoRun(file string) func() {
 		return nil
 	}
 
-	f, err := os.Create(profilePath)
+	f, err := os.Create(file)
 	if err != nil {
 		log.Fatalf("could not create CPU profile: %v", err)
 	}

--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"os/signal"
 	"runtime/pprof"
@@ -59,11 +60,11 @@ func main() {
 	if len(profilePath) != 0 {
 		f, err := os.Create(profilePath)
 		if err != nil {
-			log.Fatal().Err(err).Msg("could not create CPU profile")
+			log.Fatalf("could not create CPU profile: %v", err)
 		}
 
 		if err := pprof.StartCPUProfile(f); err != nil {
-			log.Fatal().Err(err).Msg("could not start CPU profile")
+			log.Fatalf("could not create CPU profile: %v", err)
 		}
 
 		shutdownFunc = func() {
@@ -142,7 +143,8 @@ func main() {
 		downloadService       = releasedownload.NewDownloadService(log, releaseRepo, indexerRepo, proxyService)
 		downloadClientService = download_client.NewService(log, downloadClientRepo)
 		actionService         = action.NewService(log, actionRepo, downloadClientService, downloadService, bus)
-		indexerService        = indexer.NewService(log, cfg.Config, bus, indexerRepo, releaseRepo, indexerAPIService, schedulingService)		filterService         = filter.NewService(log, filterRepo, actionService, releaseRepo, indexerAPIService, indexerService, downloadService)
+		indexerService        = indexer.NewService(log, cfg.Config, bus, indexerRepo, releaseRepo, indexerAPIService, schedulingService)
+		filterService         = filter.NewService(log, filterRepo, actionService, releaseRepo, indexerAPIService, indexerService, downloadService)
 		releaseService        = release.NewService(log, releaseRepo, actionService, filterService, indexerService)
 		ircService            = irc.NewService(log, serverEvents, ircRepo, releaseService, indexerService, notificationService, proxyService)
 		feedService           = feed.NewService(log, feedRepo, feedCacheRepo, releaseService, proxyService, schedulingService)


### PR DESCRIPTION
default.pgo needs to be along side the unit being compiled at the time of this writing, which isn't great for general profiles being created. The file is intentionally named cpu.pprof, to denote that it needs to be statically added on the command as defualt.pgo isn't read from the current (present working) directory.

Committing binary profiling data to a git repository is just crazy (which is the present recommendation from the go team), hence the run-time generation as part of the pipeline. Tests are used as a kludge now to try and get more inlining, but this is the wrong approach in the future once more e2e comes into the tree.