### PR TITLE
feat(indexers): FearNoPeer update IRC server

### DIFF
--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -975,4 +975,16 @@ CREATE INDEX filter_priority_index
     SET server = 'irc.fuzer.xyz'
     WHERE server = 'irc.fuzer.me';
 `,
+	`UPDATE irc_network
+    SET server = 'irc.scenehd.org'
+    WHERE server = 'irc.scenehd.eu';
+	
+UPDATE irc_network
+    SET server = 'irc.p2p-network.net', name = 'P2P-Network', nick = nick || '_0'
+    WHERE server = 'irc.librairc.net';
+	
+UPDATE irc_network
+    SET server = 'irc.atw-inter.net', name = 'ATW-Inter'
+    WHERE server = 'irc.ircnet.com';
+`,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -1617,4 +1617,16 @@ CREATE INDEX filter_priority_index
     SET server = 'irc.fuzer.xyz'
     WHERE server = 'irc.fuzer.me';
 `,
+	`UPDATE irc_network
+	SET server = 'irc.scenehd.org'
+	WHERE server = 'irc.scenehd.eu';
+	
+UPDATE irc_network
+	SET server = 'irc.p2p-network.net', name = 'P2P-Network', nick = nick || '_0'
+	WHERE server = 'irc.librairc.net';
+	
+UPDATE irc_network
+	SET server = 'irc.atw-inter.net', name = 'ATW-Inter'
+	WHERE server = 'irc.ircnet.com';
+`,
 }

--- a/internal/indexer/definitions/fearnopeer.yaml
+++ b/internal/indexer/definitions/fearnopeer.yaml
@@ -19,8 +19,8 @@ settings:
     help: "Go to your profile > Settings > Security > RSS Key (RID) and paste your RID into this field."
 
 irc:
-  network: LibraIRC
-  server: irc.librairc.net
+  network: P2P-Network
+  server: irc.p2p-network.net
   port: 6697
   tls: true
   channels:


### PR DESCRIPTION
Update FNP irc server and add migrations for SceneHD and BitHUmen changes all in one.

The update for FNP from LibraIRC to P2P-Network will set the nick to nick_0 to not cause any UNIQUE constraint issues. Users will have to update or merge with existing P2P-Network config.