### PR TITLE
feat(http): add error logging for API responses

### DIFF
--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -6,9 +6,19 @@ package http
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/autobrr/autobrr/internal/logger"
 )
 
-type encoder struct{}
+type encoder struct {
+	log logger.Logger
+}
+
+func newEncoder(log logger.Logger) encoder {
+	return encoder{
+		log: log,
+	}
+}
 
 type errorResponse struct {
 	Message string `json:"message"`
@@ -26,6 +36,7 @@ func (e encoder) StatusResponse(w http.ResponseWriter, status int, response any)
 		w.WriteHeader(status)
 
 		if err := json.NewEncoder(w).Encode(response); err != nil {
+			e.log.Error().Err(err).Msg("failed to encode response")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -40,6 +51,7 @@ func (e encoder) StatusResponseMessage(w http.ResponseWriter, status int, messag
 		w.WriteHeader(status)
 
 		if err := json.NewEncoder(w).Encode(statusResponse{Message: message}); err != nil {
+			e.log.Error().Err(err).Msg("failed to encode status response")
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -57,6 +69,7 @@ func (e encoder) StatusCreatedData(w http.ResponseWriter, data any) {
 	w.WriteHeader(http.StatusCreated)
 
 	if err := json.NewEncoder(w).Encode(data); err != nil {
+		e.log.Error().Err(err).Msg("failed to encode created data response")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -78,13 +91,15 @@ func (e encoder) NotFoundErr(w http.ResponseWriter, err error) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusNotFound)
 
-	if err := json.NewEncoder(w).Encode(res); err != nil {
+	if encErr := json.NewEncoder(w).Encode(res); encErr != nil {
+		e.log.Error().Err(encErr).Msg("failed to encode not found error response")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 }
 
 func (e encoder) StatusInternalError(w http.ResponseWriter) {
+	e.log.Error().Msg("internal server error")
 	w.WriteHeader(http.StatusInternalServerError)
 }
 
@@ -93,11 +108,13 @@ func (e encoder) Error(w http.ResponseWriter, err error) {
 		Message: err.Error(),
 	}
 
+	e.log.Error().Stack().Err(err).Msg("internal server error")
+
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusInternalServerError)
 
-	if err := json.NewEncoder(w).Encode(res); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+	if encErr := json.NewEncoder(w).Encode(res); encErr != nil {
+		e.log.Error().Err(encErr).Msg("failed to encode error response")
 		return
 	}
 }
@@ -107,10 +124,15 @@ func (e encoder) StatusError(w http.ResponseWriter, status int, err error) {
 		Message: err.Error(),
 	}
 
+	if status >= 500 {
+		e.log.Error().Stack().Err(err).Int("status", status).Msg("server error")
+	}
+
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
 
-	if err := json.NewEncoder(w).Encode(res); err != nil {
+	if encErr := json.NewEncoder(w).Encode(res); encErr != nil {
+		e.log.Error().Err(encErr).Msg("failed to encode status error response")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -7,14 +7,14 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/autobrr/autobrr/internal/logger"
+	"github.com/rs/zerolog"
 )
 
 type encoder struct {
-	log logger.Logger
+	log zerolog.Logger
 }
 
-func newEncoder(log logger.Logger) encoder {
+func newEncoder(log zerolog.Logger) encoder {
 	return encoder{
 		log: log,
 	}
@@ -98,17 +98,12 @@ func (e encoder) NotFoundErr(w http.ResponseWriter, err error) {
 	}
 }
 
-func (e encoder) StatusInternalError(w http.ResponseWriter) {
-	e.log.Error().Msg("internal server error")
-	w.WriteHeader(http.StatusInternalServerError)
-}
-
 func (e encoder) Error(w http.ResponseWriter, err error) {
 	res := errorResponse{
 		Message: err.Error(),
 	}
 
-	e.log.Error().Stack().Err(err).Msg("internal server error")
+	e.log.Error().Err(err).Msg("internal server error")
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusInternalServerError)
@@ -124,9 +119,7 @@ func (e encoder) StatusError(w http.ResponseWriter, status int, err error) {
 		Message: err.Error(),
 	}
 
-	if status >= 500 {
-		e.log.Error().Stack().Err(err).Int("status", status).Msg("server error")
-	}
+	e.log.Error().Err(err).Int("status", status).Msg("server error")
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -9,17 +9,17 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/autobrr/autobrr/internal/config"
-	"github.com/autobrr/autobrr/internal/database"
-	"github.com/autobrr/autobrr/internal/logger"
-	"github.com/autobrr/autobrr/web"
-
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/gorilla/sessions"
 	"github.com/r3labs/sse/v2"
 	"github.com/rs/cors"
 	"github.com/rs/zerolog"
+
+	"github.com/autobrr/autobrr/internal/config"
+	"github.com/autobrr/autobrr/internal/database"
+	"github.com/autobrr/autobrr/internal/logger"
+	"github.com/autobrr/autobrr/web"
 )
 
 type Server struct {
@@ -46,11 +46,14 @@ type Server struct {
 	proxyService          proxyService
 	releaseService        releaseService
 	updateService         updateService
+
+	logger logger.Logger
 }
 
 func NewServer(log logger.Logger, config *config.AppConfig, sse *sse.Server, db *database.DB, version string, commit string, date string, actionService actionService, apiService apikeyService, authService authService, downloadClientSvc downloadClientService, filterSvc filterService, feedSvc feedService, indexerSvc indexerService, ircSvc ircService, notificationSvc notificationService, proxySvc proxyService, releaseSvc releaseService, updateSvc updateService) Server {
 	return Server{
 		log:     log.With().Str("module", "http").Logger(),
+		logger:  log,
 		config:  config,
 		sse:     sse,
 		db:      db,
@@ -125,7 +128,7 @@ func (s Server) Handler() http.Handler {
 
 	r.Use(c.Handler)
 
-	encoder := encoder{}
+	encoder := newEncoder(s.logger)
 
 	r.Route("/api", func(r chi.Router) {
 		r.Route("/auth", newAuthHandler(encoder, s.log, s, s.config.Config, s.cookieStore, s.authService).Routes)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -46,14 +46,11 @@ type Server struct {
 	proxyService          proxyService
 	releaseService        releaseService
 	updateService         updateService
-
-	logger logger.Logger
 }
 
 func NewServer(log logger.Logger, config *config.AppConfig, sse *sse.Server, db *database.DB, version string, commit string, date string, actionService actionService, apiService apikeyService, authService authService, downloadClientSvc downloadClientService, filterSvc filterService, feedSvc feedService, indexerSvc indexerService, ircSvc ircService, notificationSvc notificationService, proxySvc proxyService, releaseSvc releaseService, updateSvc updateService) Server {
 	return Server{
 		log:     log.With().Str("module", "http").Logger(),
-		logger:  log,
 		config:  config,
 		sse:     sse,
 		db:      db,
@@ -128,7 +125,7 @@ func (s Server) Handler() http.Handler {
 
 	r.Use(c.Handler)
 
-	encoder := newEncoder(s.logger)
+	encoder := newEncoder(s.log)
 
 	r.Route("/api", func(r chi.Router) {
 		r.Route("/auth", newAuthHandler(encoder, s.log, s, s.config.Config, s.cookieStore, s.authService).Routes)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -9,17 +9,17 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/autobrr/autobrr/internal/config"
+	"github.com/autobrr/autobrr/internal/database"
+	"github.com/autobrr/autobrr/internal/logger"
+	"github.com/autobrr/autobrr/web"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/gorilla/sessions"
 	"github.com/r3labs/sse/v2"
 	"github.com/rs/cors"
 	"github.com/rs/zerolog"
-
-	"github.com/autobrr/autobrr/internal/config"
-	"github.com/autobrr/autobrr/internal/database"
-	"github.com/autobrr/autobrr/internal/logger"
-	"github.com/autobrr/autobrr/web"
 )
 
 type Server struct {


### PR DESCRIPTION
Adds proper error logging with stack traces for API error responses.

**Before:** API errors (like 500 responses) were not logged
**After:** All API errors are logged with stack traces and context

Testing:
Verified by attempting to create a second user when onboarding is unavailable:

```curl
curl -i -X POST http://localhost:7474/api/auth/onboard -H "Content-Type: application/json" \
  -d '{"username": "testuser2", "password": "test123"}'
```

This produced the expected error log with stack trace:

```shell
2024-11-16T12:38:27+01:00 ERR server error error="onboarding unavailable" stack=[...] status=503
```