### PR TITLE
feat(ci): add workflow to trigger docs update on release

### DIFF
--- a/.github/workflows/trigger_docs_update.yml
+++ b/.github/workflows/trigger_docs_update.yml
@@ -1,0 +1,18 @@
+# .github/workflows/trigger_docs_update.yml
+name: Trigger Docs Update
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger_docs_update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs workflow
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.DOCS_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/autobrr/autobrr.com/dispatches \
+            -d '{"event_type": "update-release-notes"}'


### PR DESCRIPTION
Adds workflow to trigger docs update in autobrr.com when a new release is published.

We need to:
- Create PAT in autobrr/autobrr.com with `workflow` scope
- Add PAT as `DOCS_TOKEN` secret in this repo