### PR TITLE
fix(downloadclient): qBittorrent url parse err handling

### DIFF
--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -158,17 +158,20 @@ func (c DownloadClient) Validate() error {
 	return nil
 }
 
-func (c DownloadClient) BuildLegacyHost() string {
+func (c DownloadClient) BuildLegacyHost() (string, error) {
 	if c.Type == DownloadClientTypeQbittorrent {
 		return c.qbitBuildLegacyHost()
 	}
-	return ""
+	return c.Host, nil
 }
 
 // qbitBuildLegacyHost exists to support older configs
-func (c DownloadClient) qbitBuildLegacyHost() string {
+func (c DownloadClient) qbitBuildLegacyHost() (string, error) {
 	// parse url
-	u, _ := url.Parse(c.Host)
+	u, err := url.Parse(c.Host)
+	if err != nil {
+		return "", err
+	}
 
 	// reset Opaque
 	u.Opaque = ""
@@ -200,5 +203,5 @@ func (c DownloadClient) qbitBuildLegacyHost() string {
 	}
 
 	// make into new string and return
-	return u.String()
+	return u.String(), nil
 }

--- a/internal/domain/client_test.go
+++ b/internal/domain/client_test.go
@@ -153,7 +153,8 @@ func TestDownloadClient_qbitBuildLegacyHost(t *testing.T) {
 				Password:      tt.fields.Password,
 				Settings:      tt.fields.Settings,
 			}
-			assert.Equalf(t, tt.want, c.qbitBuildLegacyHost(), "qbitBuildLegacyHost()")
+			got, _ := c.qbitBuildLegacyHost()
+			assert.Equalf(t, tt.want, got, "qbitBuildLegacyHost()")
 		})
 	}
 }

--- a/internal/download_client/connection.go
+++ b/internal/download_client/connection.go
@@ -71,8 +71,13 @@ func (s *service) testConnection(ctx context.Context, client domain.DownloadClie
 }
 
 func (s *service) testQbittorrentConnection(ctx context.Context, client domain.DownloadClient) error {
+	clientHost, err := client.BuildLegacyHost()
+	if err != nil {
+		return errors.Wrap(err, "error building qBittorrent host url: %s", client.Host)
+	}
+
 	qbtSettings := qbittorrent.Config{
-		Host:          client.BuildLegacyHost(),
+		Host:          clientHost,
 		TLSSkipVerify: client.TLSSkipVerify,
 		Username:      client.Username,
 		Password:      client.Password,

--- a/internal/download_client/service.go
+++ b/internal/download_client/service.go
@@ -181,8 +181,13 @@ func (s *service) GetClient(ctx context.Context, clientId int32) (*domain.Downlo
 
 	switch client.Type {
 	case domain.DownloadClientTypeQbittorrent:
+		clientHost, err := client.BuildLegacyHost()
+		if err != nil {
+			return nil, errors.Wrap(err, "error building qBittorrent host url: %v", client.Host)
+		}
+
 		client.Client = qbittorrent.NewClient(qbittorrent.Config{
-			Host:          client.BuildLegacyHost(),
+			Host:          clientHost,
 			Username:      client.Username,
 			Password:      client.Password,
 			TLSSkipVerify: client.TLSSkipVerify,


### PR DESCRIPTION
Fix lint warning for url parse err handling.