### PR TITLE
build: add docs update workflow trigger

### DIFF
--- a/.github/workflows/trigger_docs_update.yml
+++ b/.github/workflows/trigger_docs_update.yml
@@ -1,9 +1,9 @@
-# .github/workflows/trigger_docs_update.yml
 name: Trigger Docs Update
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   trigger_docs_update:


### PR DESCRIPTION
This commit adds the `workflow_dispatch` trigger to the Trigger Docs Update workflow, allowing manual triggering of the workflow in addition to the existing release trigger.