### PR TITLE
feat(indexers): add UploadCX

### DIFF
--- a/internal/indexer/definitions/uploadcx.yaml
+++ b/internal/indexer/definitions/uploadcx.yaml
@@ -1,100 +1,100 @@
----                                                                            
-name: Upload.cx                                                                
-identifier: ULCX                                                               
-description: ULCX is an English private tracker focused on quality movies and tv.                                                                              
-language: en-us                                                                
-urls:                                                                          
-  - https://upload.cx                                                                                                                                                                                                                                                                                                          
-privacy: private                                                               
-protocol: torrent                                                              
-supports:                                                                      
-  - irc                                                                        
-  - rss                                                                        
-# source: UNIT3D                                                               
-settings:                                                                      
-  - name: rsskey                                                               
-    type: secret                                                               
-    required: true                                                             
-    label: RSS key (RID)                                                       
-    help: "Go to your profile > Settings > Security > RSS Key (RID) and paste your RID into this field."                                                       
-                                                                               
-irc:                                                                                                                                                           
+---
+name: Upload.cx
+identifier: ulcx
+description: ULCX is an English private tracker focused on quality movies and tv.
+language: en-us
+urls:
+  - https://upload.cx/
+privacy: private
+protocol: torrent
+supports:
+  - irc
+  - rss
+# source: UNIT3D
+settings:
+  - name: rsskey
+    type: secret
+    required: true
+    label: RSS key (RID)
+    help: "Go to your profile > Settings > Security > RSS Key (RID) and paste your RID into this field."
+
+irc:
   network: P2P-Network
-  server: irc.p2p-network.net                                                                                                                                  
-  port: 6697                                                                                                                                                   
-  tls: true                                                                                                                                                    
-  channels:                                                                                                                                                    
-    - "#ulcx-announce"                                                                                                                                         
-  announcers:                                                                                                                                                  
-    - ULCX                                                                     
-  settings:                                                                                                                                                    
-    - name: nick                                                                                                                                               
-      type: text                                                                                                                                               
-      required: true                                                                                                                                           
-      label: Nick                                                                                                                                              
-      help: Bot nick. Eg. user_bot                                                                                                                             
-                                                                                                                                                               
-    - name: auth.account                                                                                                                                       
-      type: text                                                                                                                                               
-      required: false                                                                                                                                          
-      label: NickServ Account                                                  
-      help: NickServ account. Make sure to group your user and bot.                                                                                                                                                                                                                                                            
-                                                                                                                                                               
-    - name: auth.password                                                      
-      type: secret                                                             
-      required: false                                                                                                                                          
-      label: NickServ Password                                                                                                                                 
-      help: NickServ password                                                                                                                                  
-                                                                                                                                                               
-  parse:                                                                       
-    type: single                                                               
-    lines:                                                                     
-      - tests:                                                                 
-        - line: "[upload.cx] - [An anonymous user] has uploaded [Vinland Saga 2019 S02 1080p BluRay REMUX AVC Dual-Audio AAC 2.0-ZR]. Grab it now! Category: [TV] Type: [Remux] Resolution: [1080p] Size: [105.1 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25678]"                                                
-          expect:                                                              
-            uploader: An anonymous user                                                                                                                        
-            torrentName: Vinland Saga 2019 S02 1080p BluRay REMUX AVC Dual-Audio AAC 2.0-ZR                                                                    
-            category: TV                                                       
-            releaseTags: Remux                                                                                                                                 
-            resolution: 1080p                                                  
-            torrentSize: 105.1 GiB                                                                                                                             
-            freeleechPercent: 25%                                                                                                                              
-            baseUrl: https://upload.cx/                                                                                                                        
-            torrentId: "25678"                                                                                                                                 
-        - line: "[upload.cx] - [Nums] has uploaded [Wrath of Man 2021 Hybrid 2160p UHD BluRay REMUX HDR10+ HEVC TrueHD 7.1 Atmos-WiLDCAT]. Grab it now! Category: [Movies] Type: [Remux] Resolution: [2160p] Size: [70.68 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25682]"                                       
-          expect:                                                                                                                                              
-            uploader: Nums                                                                                                                                     
-            torrentName: Wrath of Man 2021 Hybrid 2160p UHD BluRay REMUX HDR10+ HEVC TrueHD 7.1 Atmos-WiLDCAT                                                  
-            category: Movies                                                                                                                                   
-            releaseTags: Remux                                                 
-            resolution: 2160p                                                  
-            torrentSize: 70.68 GiB                                             
-            freeleechPercent: 25%                                              
-            baseUrl: https://upload.cx/                                        
-            torrentId: "25682"                                                 
-        - line: "[upload.cx] - [ace] has uploaded [Aliens 1986 Theatrical 2160p UHD BluRay REMUX DV HDR HEVC TrueHD 7.1 Atmos-playBD]. Grab it now! Category: [Movies] Type: [Remux] Resolution: [2160p] Size: [55.99 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25685]"                                           
-          expect:                                                              
-            uploader: ace                                                                                                                                      
-            torrentName: Aliens 1986 Theatrical 2160p UHD BluRay REMUX DV HDR HEVC TrueHD 7.1 Atmos-playBD                                                     
-            category: Movies                                                                                                                                   
-            releaseTags: Remux                                                 
-            resolution: 2160p                                                  
-            torrentSize: 55.99 GiB                                             
-            freeleechPercent: 25%                                                                                                                              
-            baseUrl: https://upload.cx/                                        
-            torrentId: "25685"                                                 
-        pattern: '\[upload.cx\] - \[(.*)\] has uploaded \[(.*)\]. Grab it now! Category: \[(.*)\] Type: \[(.*)\] Resolution: \[(.*)\] Size: \[(.*)\] Freeleech: \[(.*)\] Link: \[(https?\:\/\/.*?\/).*\/(\d+)\]'                                                                                                               
-        vars:                                                                  
-          - uploader                                                           
-          - torrentName                                                        
-          - category                                                           
-          - releaseTags                                                        
-          - resolution                                                         
-          - torrentSize                                                        
-          - freeleechPercent                                                   
-          - baseUrl                                                            
-          - torrentId                                                          
-                                                                               
-    match:                                                                                                                                                     
-      infourl: "/torrents/{{ .torrentId }}"                                    
+  server: irc.p2p-network.net
+  port: 6697
+  tls: true
+  channels:
+    - "#ulcx-announce"
+  announcers:
+    - ULCX
+  settings:
+    - name: nick
+      type: text
+      required: true
+      label: Nick
+      help: Bot nick. Eg. user_bot
+
+    - name: auth.account
+      type: text
+      required: false
+      label: NickServ Account
+      help: NickServ account. Make sure to group your user and bot.
+
+    - name: auth.password
+      type: secret
+      required: false
+      label: NickServ Password
+      help: NickServ password
+
+  parse:
+    type: single
+    lines:
+      - tests:
+        - line: "[upload.cx] - [An anonymous user] has uploaded [Vinland Saga 2019 S02 1080p BluRay REMUX AVC Dual-Audio AAC 2.0-ZR]. Grab it now! Category: [TV] Type: [Remux] Resolution: [1080p] Size: [105.1 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25678]"
+          expect:
+            uploader: An anonymous user
+            torrentName: Vinland Saga 2019 S02 1080p BluRay REMUX AVC Dual-Audio AAC 2.0-ZR
+            category: TV
+            releaseTags: Remux
+            resolution: 1080p
+            torrentSize: 105.1 GiB
+            freeleechPercent: 25
+            baseUrl: https://upload.cx/
+            torrentId: "25678"
+        - line: "[upload.cx] - [Nums] has uploaded [Wrath of Man 2021 Hybrid 2160p UHD BluRay REMUX HDR10+ HEVC TrueHD 7.1 Atmos-WiLDCAT]. Grab it now! Category: [Movies] Type: [Remux] Resolution: [2160p] Size: [70.68 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25682]"
+          expect:
+            uploader: Nums
+            torrentName: Wrath of Man 2021 Hybrid 2160p UHD BluRay REMUX HDR10+ HEVC TrueHD 7.1 Atmos-WiLDCAT
+            category: Movies
+            releaseTags: Remux
+            resolution: 2160p
+            torrentSize: 70.68 GiB
+            freeleechPercent: 25
+            baseUrl: https://upload.cx/
+            torrentId: "25682"
+        - line: "[upload.cx] - [ace] has uploaded [Aliens 1986 Theatrical 2160p UHD BluRay REMUX DV HDR HEVC TrueHD 7.1 Atmos-playBD]. Grab it now! Category: [Movies] Type: [Remux] Resolution: [2160p] Size: [55.99 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25685]"
+          expect:
+            uploader: ace
+            torrentName: Aliens 1986 Theatrical 2160p UHD BluRay REMUX DV HDR HEVC TrueHD 7.1 Atmos-playBD
+            category: Movies
+            releaseTags: Remux
+            resolution: 2160p
+            torrentSize: 55.99 GiB
+            freeleechPercent: 25
+            baseUrl: https://upload.cx/
+            torrentId: "25685"
+        pattern: '\[upload.cx\] - \[(.*)\] has uploaded \[(.*)\]. Grab it now! Category: \[(.*)\] Type: \[(.*)\] Resolution: \[(.*)\] Size: \[(.*)\] Freeleech: \[(.*)\] Link: \[(https?\:\/\/.*?\/).*\/(\d+)\]'
+        vars:
+          - uploader
+          - torrentName
+          - category
+          - releaseTags
+          - resolution
+          - torrentSize
+          - freeleechPercent
+          - baseUrl
+          - torrentId
+
+    match:
+      infourl: "/torrents/{{ .torrentId }}"
       torrenturl: "/torrent/download/{{ .torrentId }}.{{ .rsskey }}"

--- a/internal/indexer/definitions/uploadcx.yaml
+++ b/internal/indexer/definitions/uploadcx.yaml
@@ -1,0 +1,100 @@
+---                                                                            
+name: Upload.cx                                                                
+identifier: ULCX                                                               
+description: ULCX is an English private tracker focused on quality movies and tv.                                                                              
+language: en-us                                                                
+urls:                                                                          
+  - https://upload.cx                                                                                                                                                                                                                                                                                                          
+privacy: private                                                               
+protocol: torrent                                                              
+supports:                                                                      
+  - irc                                                                        
+  - rss                                                                        
+# source: UNIT3D                                                               
+settings:                                                                      
+  - name: rsskey                                                               
+    type: secret                                                               
+    required: true                                                             
+    label: RSS key (RID)                                                       
+    help: "Go to your profile > Settings > Security > RSS Key (RID) and paste your RID into this field."                                                       
+                                                                               
+irc:                                                                                                                                                           
+  network: P2P-Network
+  server: irc.p2p-network.net                                                                                                                                  
+  port: 6697                                                                                                                                                   
+  tls: true                                                                                                                                                    
+  channels:                                                                                                                                                    
+    - "#ulcx-announce"                                                                                                                                         
+  announcers:                                                                                                                                                  
+    - ULCX                                                                     
+  settings:                                                                                                                                                    
+    - name: nick                                                                                                                                               
+      type: text                                                                                                                                               
+      required: true                                                                                                                                           
+      label: Nick                                                                                                                                              
+      help: Bot nick. Eg. user_bot                                                                                                                             
+                                                                                                                                                               
+    - name: auth.account                                                                                                                                       
+      type: text                                                                                                                                               
+      required: false                                                                                                                                          
+      label: NickServ Account                                                  
+      help: NickServ account. Make sure to group your user and bot.                                                                                                                                                                                                                                                            
+                                                                                                                                                               
+    - name: auth.password                                                      
+      type: secret                                                             
+      required: false                                                                                                                                          
+      label: NickServ Password                                                                                                                                 
+      help: NickServ password                                                                                                                                  
+                                                                                                                                                               
+  parse:                                                                       
+    type: single                                                               
+    lines:                                                                     
+      - tests:                                                                 
+        - line: "[upload.cx] - [An anonymous user] has uploaded [Vinland Saga 2019 S02 1080p BluRay REMUX AVC Dual-Audio AAC 2.0-ZR]. Grab it now! Category: [TV] Type: [Remux] Resolution: [1080p] Size: [105.1 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25678]"                                                
+          expect:                                                              
+            uploader: An anonymous user                                                                                                                        
+            torrentName: Vinland Saga 2019 S02 1080p BluRay REMUX AVC Dual-Audio AAC 2.0-ZR                                                                    
+            category: TV                                                       
+            releaseTags: Remux                                                                                                                                 
+            resolution: 1080p                                                  
+            torrentSize: 105.1 GiB                                                                                                                             
+            freeleechPercent: 25%                                                                                                                              
+            baseUrl: https://upload.cx/                                                                                                                        
+            torrentId: "25678"                                                                                                                                 
+        - line: "[upload.cx] - [Nums] has uploaded [Wrath of Man 2021 Hybrid 2160p UHD BluRay REMUX HDR10+ HEVC TrueHD 7.1 Atmos-WiLDCAT]. Grab it now! Category: [Movies] Type: [Remux] Resolution: [2160p] Size: [70.68 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25682]"                                       
+          expect:                                                                                                                                              
+            uploader: Nums                                                                                                                                     
+            torrentName: Wrath of Man 2021 Hybrid 2160p UHD BluRay REMUX HDR10+ HEVC TrueHD 7.1 Atmos-WiLDCAT                                                  
+            category: Movies                                                                                                                                   
+            releaseTags: Remux                                                 
+            resolution: 2160p                                                  
+            torrentSize: 70.68 GiB                                             
+            freeleechPercent: 25%                                              
+            baseUrl: https://upload.cx/                                        
+            torrentId: "25682"                                                 
+        - line: "[upload.cx] - [ace] has uploaded [Aliens 1986 Theatrical 2160p UHD BluRay REMUX DV HDR HEVC TrueHD 7.1 Atmos-playBD]. Grab it now! Category: [Movies] Type: [Remux] Resolution: [2160p] Size: [55.99 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25685]"                                           
+          expect:                                                              
+            uploader: ace                                                                                                                                      
+            torrentName: Aliens 1986 Theatrical 2160p UHD BluRay REMUX DV HDR HEVC TrueHD 7.1 Atmos-playBD                                                     
+            category: Movies                                                                                                                                   
+            releaseTags: Remux                                                 
+            resolution: 2160p                                                  
+            torrentSize: 55.99 GiB                                             
+            freeleechPercent: 25%                                                                                                                              
+            baseUrl: https://upload.cx/                                        
+            torrentId: "25685"                                                 
+        pattern: '\[upload.cx\] - \[(.*)\] has uploaded \[(.*)\]. Grab it now! Category: \[(.*)\] Type: \[(.*)\] Resolution: \[(.*)\] Size: \[(.*)\] Freeleech: \[(.*)\] Link: \[(https?\:\/\/.*?\/).*\/(\d+)\]'                                                                                                               
+        vars:                                                                  
+          - uploader                                                           
+          - torrentName                                                        
+          - category                                                           
+          - releaseTags                                                        
+          - resolution                                                         
+          - torrentSize                                                        
+          - freeleechPercent                                                   
+          - baseUrl                                                            
+          - torrentId                                                          
+                                                                               
+    match:                                                                                                                                                     
+      infourl: "/torrents/{{ .torrentId }}"                                    
+      torrenturl: "/torrent/download/{{ .torrentId }}.{{ .rsskey }}"


### PR DESCRIPTION
**We currently only support indexers with IRC announces.**

# Indexer request

-  Do they have irc announce? Yes
-  Link to existing `autodl-irssi .tracker` file: NA

### If no existing `autodl-irssi .tracker` file

- Indexer name: Upload.cx
- Short name: ULCX
- URL: https://upload.cx
- Download link: https://upload.cx/torrents/24921.rsskey

## Announce examples

Please provide 1-5 different announces. And change release titles for good measure. If they have tags like freeleech and internals etc make sure to get examples of those.

- TV: [upload.cx] - [Redacted] has uploaded [The Man in the High Castle S02 2160p AMZN WEB-DL DD+ 5.1 H.265-FLUX]. Grab it now! Category: [TV] Type: [WEB-DL] Resolution: [2160p] Size: [59 GiB] Freeleech: [100] Link: [https://upload.cx/torrents/25694]
- Movie: [upload.cx] - [Redacted] has uploaded [Sahara 2005 Open Matte 1080p BluRay REMUX AVC TrueHD 7.1-WiLDCAT]. Grab it now! Category: [Movies] Type: [Remux] Resolution: [1080p] Size: [36.84 GiB] Freeleech: [25] Link: [https://upload.cx/torrents/25703]

## IRC Network

- Network name: p2p-network
- Network address: irc.p2p-network.net
- Channels: #ULCX-Announce #ULCX-Chat
- Port: 6697 
- SSL/TLS: Yes
- NickServ registration required? Check wiki, guides etc: No
- Is there a required format for the nick? No
- Invite command: NA

## Bonus

Check their categories in the announce an on site

Announce category 
- Movies
- TV

Announce Types
- Full Disc
- Remux
- Encode
- WEB-DL
- WEBRip
- HDTV
