### PR TITLE
fix(http): downgrade canOnboard check to warning log level

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -156,6 +156,10 @@ func (h authHandler) onboard(w http.ResponseWriter, r *http.Request) {
 
 func (h authHandler) canOnboard(w http.ResponseWriter, r *http.Request) {
 	if status, err := h.onboardEligible(r.Context()); err != nil {
+		if status == http.StatusServiceUnavailable {
+			h.encoder.StatusWarning(w, status, err.Error())
+			return
+		}
 		h.encoder.StatusError(w, status, err)
 		return
 	}

--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -130,3 +130,16 @@ func (e encoder) StatusError(w http.ResponseWriter, status int, err error) {
 		return
 	}
 }
+
+func (e encoder) StatusWarning(w http.ResponseWriter, status int, message string) {
+	resp := errorResponse{
+		Status:  status,
+		Message: message,
+	}
+
+	e.log.Warn().Str("warning", message).Int("status", status).Msg("server warning")
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(resp)
+}


### PR DESCRIPTION
#### Description

This PR downgrades onboarding availability check responses from error to warning level. 

#### Changes
- Added StatusWarning method to encoder for non-critical responses

#### Notes
This is an improvement to the changes made in https://github.com/autobrr/autobrr/pull/1819