### PR TITLE
feat(macros): add Description

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -32,6 +32,7 @@ type Macro struct {
 	CurrentMonth              int
 	CurrentSecond             int
 	CurrentYear               int
+	Description               string		  
 	DownloadUrl               string
 	Episode                   int
 	FilterID                  int
@@ -103,6 +104,7 @@ func NewMacro(release Release) Macro {
 		CurrentMonth:              int(currentTime.Month()),
 		CurrentSecond:             currentTime.Second(),
 		CurrentYear:               currentTime.Year(),
+		Description:               release.Description,
 		DownloadUrl:               release.DownloadURL,
 		Episode:                   release.Episode,
 		FilterID:                  release.FilterID,


### PR DESCRIPTION
Some trackers add information about the release in the description. This change would allow the description to be available for Exec action and take decisions based on that.