### PR TITLE
fix(database): SQLite try reindexing on integrity check error

### DIFF
--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -340,6 +340,10 @@ func (db *DB) sqlitePerformReIndexing(results []string) error {
 		}
 	}
 
+	if len(badIndexes) == 0 {
+		return errors.New("found no indexes to reindex")
+	}
+
 	for _, index := range badIndexes {
 		db.log.Info().Msgf("Database attempt to re-index: %s", index)
 


### PR DESCRIPTION
Try to re-index when encountering errors from integrity check.

Related #1842 