### PR TITLE
feat(macros): add `MetaIMDB`

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -55,6 +55,7 @@ type Macro struct {
 	Leechers                  int
 	LogScore                  int
 	MagnetURI                 string
+	MetaIMDB                  string
 	Origin                    string
 	Other                     []string
 	PreTime                   string
@@ -131,6 +132,7 @@ func NewMacro(release Release) Macro {
 		Leechers:                  release.Leechers,
 		LogScore:                  release.LogScore,
 		MagnetURI:                 release.MagnetURI,
+		MetaIMDB:                  release.MetaIMDB,
 		Origin:                    release.Origin,
 		Other:                     release.Other,
 		PreTime:                   release.PreTime,

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -132,6 +132,7 @@ type Release struct {
 	FilterID                           int                   `json:"-"`
 	Filter                             *Filter               `json:"-"`
 	ActionStatus                       []ReleaseActionStatus `json:"action_status"`
+	MetaIMDB                           string                `json:"-"`
 }
 
 // Hash return md5 hashed normalized release name
@@ -1167,9 +1168,9 @@ func (r *Release) MapVars(def *IndexerDefinition, varMap map[string]string) erro
 		r.Episode = episode
 	}
 
-	//if metaImdb, err := getStringMapValue(varMap, "imdb"); err == nil {
-	//	r.MetaIMDB = metaImdb
-	//}
+	if metaImdb, err := getStringMapValue(varMap, "imdb"); err == nil {
+		r.MetaIMDB = metaImdb
+	}
 
 	return nil
 }


### PR DESCRIPTION
Add new macro `MetaIMDB` which contains IMDB id, only supported by PTP at this time.