### PR TITLE
feat(releases): improve collections/website/streaming service parsing

### DIFF
--- a/internal/domain/release_test.go
+++ b/internal/domain/release_test.go
@@ -1103,6 +1103,41 @@ func TestRelease_Hash(t *testing.T) {
 			},
 			want: "63b5d87abe5fb49131785de426708d31",
 		},
+		{
+			name: "29",
+			fields: fields{
+				TorrentName: "That Other Show 2023 S01E01 2160p WEB-DL DTS-HD 5.1 HEVC-GROUP",
+			},
+			want: "2b4fbd68007c73664cdf9c1abb33fba9",
+		},
+		{
+			name: "30",
+			fields: fields{
+				TorrentName: "That Other Show 2023 S01E01 2160p ATVP WEB-DL DTS-HD 5.1 HEVC-GROUP",
+			},
+			want: "a1ad6c5ef96a50e5c3df434ec118185a",
+		},
+		{
+			name: "31",
+			fields: fields{
+				TorrentName: "That Other Show 2023 S01E01 2160p MA WEB-DL DTS-HD 5.1 HEVC-GROUP",
+			},
+			want: "d2976631b738bcd974e02af2c0b680a1",
+		},
+		{
+			name: "32",
+			fields: fields{
+				TorrentName: "That Other Show 2023 S01E01 2160p DSNP WEB-DL DTS-HD MA 5.1 HEVC-GROUP",
+			},
+			want: "aff58872541a8050146375ca76ea9fe7",
+		},
+		{
+			name: "33",
+			fields: fields{
+				TorrentName: "That Other Show 2023 S01E01 2160p MA WEB-DL DTS-HD MA 5.1 HEVC-GROUP",
+			},
+			want: "6d97a50010e7532478f8f4f9c469b885",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/domain/releasetags.go
+++ b/internal/domain/releasetags.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+
+	"github.com/moistari/rls"
+	"github.com/moistari/rls/taginfo"
 )
 
 var types map[string][]*TagInfo
@@ -264,6 +267,16 @@ func init() {
 			info.re = regexp.MustCompile(`(?i)(?:` + info.RE() + `)`)
 		}
 	}
+
+	var extraTagInfos = map[string][]*taginfo.Taginfo{}
+
+	inf, err := taginfo.New("MA", "Movies Anywhere", "(?-i:MA)", "", "", "")
+	if err != nil {
+		//log.Fatal(err)
+	}
+	extraTagInfos["collection"] = []*taginfo.Taginfo{inf}
+
+	rls.DefaultParser = rls.NewTagParser(taginfo.All(extraTagInfos), rls.DefaultLexers()...)
 }
 
 type TagInfo struct {


### PR DESCRIPTION
This PR adds extra `rls.Taginfo` to be used in release parsing to improve unique hash generation.