### PR TITLE
fix(web): typos in duplicate release profile settings

### DIFF
--- a/web/src/screens/settings/Releases.tsx
+++ b/web/src/screens/settings/Releases.tsx
@@ -54,8 +54,8 @@ function ReleaseProfileListItem({ profile }: ReleaseProfileProps) {
         <div className="col-span-9 sm:col-span-9 lg:col-span-9 pl-4 sm:pl-4 pr-6 py-3 flex gap-x-0.5 flex-row text-sm font-medium text-gray-900 dark:text-white truncate">
           {profile.release_name && <EnabledPill value={profile.release_name} label="RLS" title="Release name" />}
           {profile.hash && <EnabledPill value={profile.hash} label="Hash" title="Normalized hash of the release name. Use with Release name for exact match" />}
-          {profile.title && <EnabledPill value={profile.title} label="Title" title="Parsed titel" />}
-          {profile.sub_title && <EnabledPill value={profile.sub_title} label="Sub Title" title="Parsed sub titel like Episode name" />}
+          {profile.title && <EnabledPill value={profile.title} label="Title" title="Parsed title" />}
+          {profile.sub_title && <EnabledPill value={profile.sub_title} label="Sub Title" title="Parsed sub title like Episode name" />}
           {profile.group && <EnabledPill value={profile.group} label="Group" title="Release group" />}
           {profile.year && <EnabledPill value={profile.year} label="Year" title="Year" />}
           {profile.month && <EnabledPill value={profile.month} label="Month" title="Month" />}


### PR DESCRIPTION
This PR fixes two typos in the titles for the duplicate release settings.