### PR TITLE
chore(license): update copyright year in headers

### DIFF
--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/cmd/autobrrctl/main.go
+++ b/cmd/autobrrctl/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/cmd/autobrrctl/main.go
+++ b/cmd/autobrrctl/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/internal/action/deluge.go
+++ b/internal/action/deluge.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/deluge.go
+++ b/internal/action/deluge.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/exec.go
+++ b/internal/action/exec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/exec.go
+++ b/internal/action/exec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/exec_test.go
+++ b/internal/action/exec_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/exec_test.go
+++ b/internal/action/exec_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/lidarr.go
+++ b/internal/action/lidarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/lidarr.go
+++ b/internal/action/lidarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/porla.go
+++ b/internal/action/porla.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/porla.go
+++ b/internal/action/porla.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/qbittorrent.go
+++ b/internal/action/qbittorrent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/qbittorrent.go
+++ b/internal/action/qbittorrent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/radarr.go
+++ b/internal/action/radarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/radarr.go
+++ b/internal/action/radarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/readarr.go
+++ b/internal/action/readarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/readarr.go
+++ b/internal/action/readarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/rtorrent.go
+++ b/internal/action/rtorrent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/rtorrent.go
+++ b/internal/action/rtorrent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/sabnzbd.go
+++ b/internal/action/sabnzbd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/sabnzbd.go
+++ b/internal/action/sabnzbd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/service.go
+++ b/internal/action/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/service.go
+++ b/internal/action/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/sonarr.go
+++ b/internal/action/sonarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/sonarr.go
+++ b/internal/action/sonarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/transmission.go
+++ b/internal/action/transmission.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/transmission.go
+++ b/internal/action/transmission.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/whisparr.go
+++ b/internal/action/whisparr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/action/whisparr.go
+++ b/internal/action/whisparr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package action

--- a/internal/announce/announce.go
+++ b/internal/announce/announce.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package announce

--- a/internal/announce/announce.go
+++ b/internal/announce/announce.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package announce

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package api

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package api

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package auth

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package auth

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package config

--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/action_test.go
+++ b/internal/database/action_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/action_test.go
+++ b/internal/database/action_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/api.go
+++ b/internal/database/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/api.go
+++ b/internal/database/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/api_test.go
+++ b/internal/database/api_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/api_test.go
+++ b/internal/database/api_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/download_client.go
+++ b/internal/database/download_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/download_client.go
+++ b/internal/database/download_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/download_client_test.go
+++ b/internal/database/download_client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/download_client_test.go
+++ b/internal/database/download_client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/feed.go
+++ b/internal/database/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/feed.go
+++ b/internal/database/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/feed_cache.go
+++ b/internal/database/feed_cache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/feed_cache.go
+++ b/internal/database/feed_cache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/feed_cache_test.go
+++ b/internal/database/feed_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/feed_cache_test.go
+++ b/internal/database/feed_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/feed_test.go
+++ b/internal/database/feed_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/feed_test.go
+++ b/internal/database/feed_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/indexer.go
+++ b/internal/database/indexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/indexer.go
+++ b/internal/database/indexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/indexer_test.go
+++ b/internal/database/indexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/indexer_test.go
+++ b/internal/database/indexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/irc.go
+++ b/internal/database/irc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/irc.go
+++ b/internal/database/irc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/irc_test.go
+++ b/internal/database/irc_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/irc_test.go
+++ b/internal/database/irc_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/list.go
+++ b/internal/database/list.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package database
 
 import (

--- a/internal/database/notification.go
+++ b/internal/database/notification.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/notification.go
+++ b/internal/database/notification.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/notification_test.go
+++ b/internal/database/notification_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/notification_test.go
+++ b/internal/database/notification_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/proxy.go
+++ b/internal/database/proxy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/proxy.go
+++ b/internal/database/proxy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/proxy_test.go
+++ b/internal/database/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/proxy_test.go
+++ b/internal/database/proxy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/release_test.go
+++ b/internal/database/release_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/release_test.go
+++ b/internal/database/release_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/user.go
+++ b/internal/database/user.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/user_test.go
+++ b/internal/database/user_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/user_test.go
+++ b/internal/database/user_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/database/utils.go
+++ b/internal/database/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/utils.go
+++ b/internal/database/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/utils_test.go
+++ b/internal/database/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/database/utils_test.go
+++ b/internal/database/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package database

--- a/internal/diagnostics/profiling.go
+++ b/internal/diagnostics/profiling.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package diagnostics

--- a/internal/diagnostics/profiling.go
+++ b/internal/diagnostics/profiling.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package diagnostics

--- a/internal/domain/action.go
+++ b/internal/domain/action.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/action.go
+++ b/internal/domain/action.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/api.go
+++ b/internal/domain/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/api.go
+++ b/internal/domain/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/client_test.go
+++ b/internal/domain/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/client_test.go
+++ b/internal/domain/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/error.go
+++ b/internal/domain/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/error.go
+++ b/internal/domain/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/feed.go
+++ b/internal/domain/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/feed.go
+++ b/internal/domain/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/filter_test.go
+++ b/internal/domain/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/filter_test.go
+++ b/internal/domain/filter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/indexer_test.go
+++ b/internal/domain/indexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/indexer_test.go
+++ b/internal/domain/indexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/list.go
+++ b/internal/domain/list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/list.go
+++ b/internal/domain/list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/macros_test.go
+++ b/internal/domain/macros_test.go
@@ -1,14 +1,13 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain
 
 import (
 	"fmt"
+	"github.com/moistari/rls"
 	"testing"
 	"time"
-
-	"github.com/moistari/rls"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/domain/macros_test.go
+++ b/internal/domain/macros_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/moistari/rls"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/domain/macros_test.go
+++ b/internal/domain/macros_test.go
@@ -1,13 +1,14 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain
 
 import (
 	"fmt"
-	"github.com/moistari/rls"
 	"testing"
 	"time"
+
+	"github.com/moistari/rls"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/proxy.go
+++ b/internal/domain/proxy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/proxy.go
+++ b/internal/domain/proxy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain
@@ -10,8 +10,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"golang.org/x/text/transform"
-	"golang.org/x/text/unicode/norm"
 	"html"
 	"io"
 	"math"
@@ -23,6 +21,9 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/autobrr/autobrr/pkg/sharedhttp"

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain
@@ -10,6 +10,8 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 	"html"
 	"io"
 	"math"
@@ -21,9 +23,6 @@ import (
 	"strings"
 	"time"
 	"unicode"
-
-	"golang.org/x/text/transform"
-	"golang.org/x/text/unicode/norm"
 
 	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/autobrr/autobrr/pkg/sharedhttp"

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -22,9 +22,6 @@ import (
 	"time"
 	"unicode"
 
-	"golang.org/x/text/transform"
-	"golang.org/x/text/unicode/norm"
-
 	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/autobrr/autobrr/pkg/sharedhttp"
 
@@ -34,6 +31,8 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/moistari/rls"
 	"golang.org/x/net/publicsuffix"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
 )
 
 type ReleaseRepo interface {

--- a/internal/domain/release_download_test.go
+++ b/internal/domain/release_download_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/domain/release_download_test.go
+++ b/internal/domain/release_download_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/domain/release_test.go
+++ b/internal/domain/release_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/release_test.go
+++ b/internal/domain/release_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/releasetags.go
+++ b/internal/domain/releasetags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/releasetags.go
+++ b/internal/domain/releasetags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/releasetags_test.go
+++ b/internal/domain/releasetags_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/releasetags_test.go
+++ b/internal/domain/releasetags_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/download_client/cache.go
+++ b/internal/download_client/cache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package download_client

--- a/internal/download_client/cache.go
+++ b/internal/download_client/cache.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package download_client

--- a/internal/download_client/connection.go
+++ b/internal/download_client/connection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package download_client

--- a/internal/download_client/connection.go
+++ b/internal/download_client/connection.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package download_client

--- a/internal/download_client/service.go
+++ b/internal/download_client/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package download_client

--- a/internal/download_client/service.go
+++ b/internal/download_client/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package download_client

--- a/internal/events/subscribers.go
+++ b/internal/events/subscribers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package events

--- a/internal/events/subscribers.go
+++ b/internal/events/subscribers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package events

--- a/internal/feed/cleanup.go
+++ b/internal/feed/cleanup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/cleanup.go
+++ b/internal/feed/cleanup.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/client.go
+++ b/internal/feed/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/client.go
+++ b/internal/feed/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/newznab.go
+++ b/internal/feed/newznab.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/newznab.go
+++ b/internal/feed/newznab.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/rss_test.go
+++ b/internal/feed/rss_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/rss_test.go
+++ b/internal/feed/rss_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed

--- a/internal/feed/torznab.go
+++ b/internal/feed/torznab.go
@@ -1,16 +1,15 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed
 
 import (
 	"context"
+	"github.com/autobrr/autobrr/internal/proxy"
 	"math"
 	"sort"
 	"strconv"
 	"time"
-
-	"github.com/autobrr/autobrr/internal/proxy"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/release"

--- a/internal/feed/torznab.go
+++ b/internal/feed/torznab.go
@@ -1,15 +1,16 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package feed
 
 import (
 	"context"
-	"github.com/autobrr/autobrr/internal/proxy"
 	"math"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/autobrr/autobrr/internal/proxy"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/release"

--- a/internal/feed/torznab.go
+++ b/internal/feed/torznab.go
@@ -10,9 +10,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/autobrr/autobrr/internal/proxy"
-
 	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/autobrr/autobrr/internal/proxy"
 	"github.com/autobrr/autobrr/internal/release"
 	"github.com/autobrr/autobrr/internal/scheduler"
 	"github.com/autobrr/autobrr/pkg/errors"

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package filter

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package filter

--- a/internal/http/action.go
+++ b/internal/http/action.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/action.go
+++ b/internal/http/action.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/apikey.go
+++ b/internal/http/apikey.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/apikey.go
+++ b/internal/http/apikey.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/auth_test.go
+++ b/internal/http/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/http/auth_test.go
+++ b/internal/http/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/internal/http/config.go
+++ b/internal/http/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/config.go
+++ b/internal/http/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/download_client.go
+++ b/internal/http/download_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/download_client.go
+++ b/internal/http/download_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/feed.go
+++ b/internal/http/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/feed.go
+++ b/internal/http/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/health.go
+++ b/internal/http/health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/health.go
+++ b/internal/http/health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/indexer.go
+++ b/internal/http/indexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/indexer.go
+++ b/internal/http/indexer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/irc.go
+++ b/internal/http/irc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/irc.go
+++ b/internal/http/irc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/list.go
+++ b/internal/http/list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/list.go
+++ b/internal/http/list.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/logs.go
+++ b/internal/http/logs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/notification.go
+++ b/internal/http/notification.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/notification.go
+++ b/internal/http/notification.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/release.go
+++ b/internal/http/release.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/release.go
+++ b/internal/http/release.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/update.go
+++ b/internal/http/update.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/update.go
+++ b/internal/http/update.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/web.go
+++ b/internal/http/web.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/web.go
+++ b/internal/http/web.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/web_legacy.go
+++ b/internal/http/web_legacy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/web_legacy.go
+++ b/internal/http/web_legacy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/webhook.go
+++ b/internal/http/webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/webhook.go
+++ b/internal/http/webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/indexer/api.go
+++ b/internal/indexer/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package indexer

--- a/internal/indexer/api.go
+++ b/internal/indexer/api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package indexer

--- a/internal/indexer/definitions.go
+++ b/internal/indexer/definitions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package indexer

--- a/internal/indexer/definitions.go
+++ b/internal/indexer/definitions.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package indexer

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package indexer

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package indexer

--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package indexer

--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package indexer

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/internal/irc/service.go
+++ b/internal/irc/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/internal/irc/service.go
+++ b/internal/irc/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/internal/list/process_arr_lidarr.go
+++ b/internal/list/process_arr_lidarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_arr_lidarr.go
+++ b/internal/list/process_arr_lidarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_arr_radarr.go
+++ b/internal/list/process_arr_radarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_arr_radarr.go
+++ b/internal/list/process_arr_radarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_arr_readarr.go
+++ b/internal/list/process_arr_readarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_arr_readarr.go
+++ b/internal/list/process_arr_readarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_arr_sonarr.go
+++ b/internal/list/process_arr_sonarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_arr_sonarr.go
+++ b/internal/list/process_arr_sonarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_mdblist.go
+++ b/internal/list/process_list_mdblist.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_mdblist.go
+++ b/internal/list/process_list_mdblist.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_metacritic.go
+++ b/internal/list/process_list_metacritic.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_metacritic.go
+++ b/internal/list/process_list_metacritic.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_plaintext.go
+++ b/internal/list/process_list_plaintext.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_plaintext.go
+++ b/internal/list/process_list_plaintext.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_steam.go
+++ b/internal/list/process_list_steam.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_steam.go
+++ b/internal/list/process_list_steam.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_trakt.go
+++ b/internal/list/process_list_trakt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/process_list_trakt.go
+++ b/internal/list/process_list_trakt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/scheduled_jobs.go
+++ b/internal/list/scheduled_jobs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/scheduled_jobs.go
+++ b/internal/list/scheduled_jobs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/service.go
+++ b/internal/list/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/service.go
+++ b/internal/list/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/tags.go
+++ b/internal/list/tags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/tags.go
+++ b/internal/list/tags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/tags_test.go
+++ b/internal/list/tags_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/tags_test.go
+++ b/internal/list/tags_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/title.go
+++ b/internal/list/title.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/title.go
+++ b/internal/list/title.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list

--- a/internal/list/title_test.go
+++ b/internal/list/title_test.go
@@ -1,11 +1,12 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_processTitle(t *testing.T) {

--- a/internal/list/title_test.go
+++ b/internal/list/title_test.go
@@ -1,12 +1,11 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package list
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func Test_processTitle(t *testing.T) {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package logger

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package logger

--- a/internal/logger/mock.go
+++ b/internal/logger/mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package logger

--- a/internal/logger/mock.go
+++ b/internal/logger/mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package logger

--- a/internal/logger/sanitize_test.go
+++ b/internal/logger/sanitize_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package logger

--- a/internal/logger/sanitize_test.go
+++ b/internal/logger/sanitize_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package logger

--- a/internal/logger/sse_writer.go
+++ b/internal/logger/sse_writer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package logger

--- a/internal/logger/sse_writer.go
+++ b/internal/logger/sse_writer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package logger

--- a/internal/mock/indexer_api.go
+++ b/internal/mock/indexer_api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package mock

--- a/internal/mock/indexer_api.go
+++ b/internal/mock/indexer_api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package mock

--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/gotify.go
+++ b/internal/notification/gotify.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/gotify.go
+++ b/internal/notification/gotify.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/notifiarr.go
+++ b/internal/notification/notifiarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/notifiarr.go
+++ b/internal/notification/notifiarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/ntfy.go
+++ b/internal/notification/ntfy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/ntfy.go
+++ b/internal/notification/ntfy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/pushover.go
+++ b/internal/notification/pushover.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/pushover.go
+++ b/internal/notification/pushover.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/telegram.go
+++ b/internal/notification/telegram.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/notification/telegram.go
+++ b/internal/notification/telegram.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package notification

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package proxy

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package proxy

--- a/internal/release/service.go
+++ b/internal/release/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package release

--- a/internal/release/service.go
+++ b/internal/release/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package release

--- a/internal/scheduler/jobs.go
+++ b/internal/scheduler/jobs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package scheduler

--- a/internal/scheduler/jobs.go
+++ b/internal/scheduler/jobs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package scheduler

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package scheduler

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package scheduler

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package server

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package server

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package update

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package update

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package user

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package user

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package utils

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package utils

--- a/pkg/argon2id/argon2id.go
+++ b/pkg/argon2id/argon2id.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package argon2id

--- a/pkg/argon2id/argon2id.go
+++ b/pkg/argon2id/argon2id.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package argon2id

--- a/pkg/argon2id/argon2id_test.go
+++ b/pkg/argon2id/argon2id_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package argon2id

--- a/pkg/argon2id/argon2id_test.go
+++ b/pkg/argon2id/argon2id_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package argon2id

--- a/pkg/arr/lidarr/client.go
+++ b/pkg/arr/lidarr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package lidarr

--- a/pkg/arr/lidarr/client.go
+++ b/pkg/arr/lidarr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package lidarr

--- a/pkg/arr/lidarr/lidarr.go
+++ b/pkg/arr/lidarr/lidarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package lidarr

--- a/pkg/arr/lidarr/lidarr.go
+++ b/pkg/arr/lidarr/lidarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package lidarr

--- a/pkg/arr/lidarr/lidarr_test.go
+++ b/pkg/arr/lidarr/lidarr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/arr/lidarr/lidarr_test.go
+++ b/pkg/arr/lidarr/lidarr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/arr/radarr/client.go
+++ b/pkg/arr/radarr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package radarr

--- a/pkg/arr/radarr/client.go
+++ b/pkg/arr/radarr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package radarr

--- a/pkg/arr/radarr/radarr.go
+++ b/pkg/arr/radarr/radarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package radarr

--- a/pkg/arr/radarr/radarr.go
+++ b/pkg/arr/radarr/radarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package radarr

--- a/pkg/arr/radarr/radarr_test.go
+++ b/pkg/arr/radarr/radarr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/arr/radarr/radarr_test.go
+++ b/pkg/arr/radarr/radarr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/arr/readarr/client.go
+++ b/pkg/arr/readarr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package readarr

--- a/pkg/arr/readarr/client.go
+++ b/pkg/arr/readarr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package readarr

--- a/pkg/arr/readarr/readarr.go
+++ b/pkg/arr/readarr/readarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package readarr

--- a/pkg/arr/readarr/readarr.go
+++ b/pkg/arr/readarr/readarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package readarr

--- a/pkg/arr/readarr/readarr_test.go
+++ b/pkg/arr/readarr/readarr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/arr/readarr/readarr_test.go
+++ b/pkg/arr/readarr/readarr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/arr/sonarr/client.go
+++ b/pkg/arr/sonarr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package sonarr

--- a/pkg/arr/sonarr/client.go
+++ b/pkg/arr/sonarr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package sonarr

--- a/pkg/arr/sonarr/sonarr.go
+++ b/pkg/arr/sonarr/sonarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package sonarr

--- a/pkg/arr/sonarr/sonarr.go
+++ b/pkg/arr/sonarr/sonarr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package sonarr

--- a/pkg/arr/sonarr/sonarr_test.go
+++ b/pkg/arr/sonarr/sonarr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/arr/sonarr/sonarr_test.go
+++ b/pkg/arr/sonarr/sonarr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/btn/btn.go
+++ b/pkg/btn/btn.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package btn

--- a/pkg/btn/btn.go
+++ b/pkg/btn/btn.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package btn

--- a/pkg/btn/btn_test.go
+++ b/pkg/btn/btn_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/btn/btn_test.go
+++ b/pkg/btn/btn_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/btn/client.go
+++ b/pkg/btn/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package btn

--- a/pkg/btn/client.go
+++ b/pkg/btn/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package btn

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package errors

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package errors

--- a/pkg/ggn/ggn.go
+++ b/pkg/ggn/ggn.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package ggn

--- a/pkg/ggn/ggn.go
+++ b/pkg/ggn/ggn.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package ggn

--- a/pkg/ggn/ggn_test.go
+++ b/pkg/ggn/ggn_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/ggn/ggn_test.go
+++ b/pkg/ggn/ggn_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/jsonrpc/jsonrpc.go
+++ b/pkg/jsonrpc/jsonrpc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package jsonrpc

--- a/pkg/jsonrpc/jsonrpc.go
+++ b/pkg/jsonrpc/jsonrpc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package jsonrpc

--- a/pkg/newznab/caps.go
+++ b/pkg/newznab/caps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package newznab

--- a/pkg/newznab/caps.go
+++ b/pkg/newznab/caps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package newznab

--- a/pkg/newznab/category.go
+++ b/pkg/newznab/category.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package newznab

--- a/pkg/newznab/category.go
+++ b/pkg/newznab/category.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package newznab

--- a/pkg/newznab/feed.go
+++ b/pkg/newznab/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package newznab

--- a/pkg/newznab/feed.go
+++ b/pkg/newznab/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package newznab

--- a/pkg/newznab/newznab.go
+++ b/pkg/newznab/newznab.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package newznab

--- a/pkg/newznab/newznab.go
+++ b/pkg/newznab/newznab.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package newznab

--- a/pkg/ops/ops.go
+++ b/pkg/ops/ops.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package ops

--- a/pkg/ops/ops.go
+++ b/pkg/ops/ops.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package ops

--- a/pkg/ops/ops_test.go
+++ b/pkg/ops/ops_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/ops/ops_test.go
+++ b/pkg/ops/ops_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/porla/client.go
+++ b/pkg/porla/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package porla

--- a/pkg/porla/client.go
+++ b/pkg/porla/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package porla

--- a/pkg/porla/domain.go
+++ b/pkg/porla/domain.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package porla

--- a/pkg/porla/domain.go
+++ b/pkg/porla/domain.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package porla

--- a/pkg/porla/methods.go
+++ b/pkg/porla/methods.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package porla

--- a/pkg/porla/methods.go
+++ b/pkg/porla/methods.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package porla

--- a/pkg/ptp/ptp.go
+++ b/pkg/ptp/ptp.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package ptp

--- a/pkg/ptp/ptp.go
+++ b/pkg/ptp/ptp.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package ptp

--- a/pkg/ptp/ptp_test.go
+++ b/pkg/ptp/ptp_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/ptp/ptp_test.go
+++ b/pkg/ptp/ptp_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/red/red.go
+++ b/pkg/red/red.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package red

--- a/pkg/red/red.go
+++ b/pkg/red/red.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package red

--- a/pkg/red/red_test.go
+++ b/pkg/red/red_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/red/red_test.go
+++ b/pkg/red/red_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/regexcache/regex.go
+++ b/pkg/regexcache/regex.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package regexcache

--- a/pkg/regexcache/regex.go
+++ b/pkg/regexcache/regex.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package regexcache

--- a/pkg/sabnzbd/sabnzbd.go
+++ b/pkg/sabnzbd/sabnzbd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package sabnzbd

--- a/pkg/sabnzbd/sabnzbd.go
+++ b/pkg/sabnzbd/sabnzbd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package sabnzbd

--- a/pkg/sharedhttp/http.go
+++ b/pkg/sharedhttp/http.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package sharedhttp

--- a/pkg/sharedhttp/http.go
+++ b/pkg/sharedhttp/http.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package sharedhttp

--- a/pkg/torznab/caps.go
+++ b/pkg/torznab/caps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torznab

--- a/pkg/torznab/caps.go
+++ b/pkg/torznab/caps.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torznab

--- a/pkg/torznab/category.go
+++ b/pkg/torznab/category.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torznab

--- a/pkg/torznab/category.go
+++ b/pkg/torznab/category.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torznab

--- a/pkg/torznab/feed.go
+++ b/pkg/torznab/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torznab

--- a/pkg/torznab/feed.go
+++ b/pkg/torznab/feed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torznab

--- a/pkg/torznab/torznab.go
+++ b/pkg/torznab/torznab.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torznab

--- a/pkg/torznab/torznab.go
+++ b/pkg/torznab/torznab.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torznab

--- a/pkg/torznab/torznab_test.go
+++ b/pkg/torznab/torznab_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/torznab/torznab_test.go
+++ b/pkg/torznab/torznab_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package version

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package version

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package version

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package version

--- a/pkg/whisparr/client.go
+++ b/pkg/whisparr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package whisparr

--- a/pkg/whisparr/client.go
+++ b/pkg/whisparr/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package whisparr

--- a/pkg/whisparr/whisparr.go
+++ b/pkg/whisparr/whisparr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package whisparr

--- a/pkg/whisparr/whisparr.go
+++ b/pkg/whisparr/whisparr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package whisparr

--- a/pkg/wildcard/match.go
+++ b/pkg/wildcard/match.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package wildcard

--- a/pkg/wildcard/match.go
+++ b/pkg/wildcard/match.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package wildcard

--- a/pkg/wildcard/match_test.go
+++ b/pkg/wildcard/match_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package wildcard

--- a/pkg/wildcard/match_test.go
+++ b/pkg/wildcard/match_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package wildcard

--- a/test/docs/docs_test.go
+++ b/test/docs/docs_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/test/docs/docs_test.go
+++ b/test/docs/docs_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 //go:build integration

--- a/test/mockindexer/irc/client.go
+++ b/test/mockindexer/irc/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/test/mockindexer/irc/client.go
+++ b/test/mockindexer/irc/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/test/mockindexer/irc/handlers.go
+++ b/test/mockindexer/irc/handlers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/test/mockindexer/irc/handlers.go
+++ b/test/mockindexer/irc/handlers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/test/mockindexer/irc/server.go
+++ b/test/mockindexer/irc/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/test/mockindexer/irc/server.go
+++ b/test/mockindexer/irc/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package irc

--- a/test/mockindexer/main.go
+++ b/test/mockindexer/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/test/mockindexer/main.go
+++ b/test/mockindexer/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/web/build.go
+++ b/web/build.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 // Package web web/build.go

--- a/web/build.go
+++ b/web/build.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 // Package web web/build.go

--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+  ~ Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
   ~ SPDX-License-Identifier: GPL-2.0-or-later
   -->
 

--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+  ~ Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
   ~ SPDX-License-Identifier: GPL-2.0-or-later
   -->
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -20,7 +20,7 @@ declare module '@tanstack/react-router' {
 }
 
 export function App() {
-  const [, setSettings] = SettingsContext.use();
+  const [ , setSettings] = SettingsContext.use();
 
   useEffect(() => {
     const themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -20,7 +20,7 @@ declare module '@tanstack/react-router' {
 }
 
 export function App() {
-  const [ , setSettings] = SettingsContext.use();
+  const [, setSettings] = SettingsContext.use();
 
   useEffect(() => {
     const themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/QueryClient.tsx
+++ b/web/src/api/QueryClient.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -30,7 +30,7 @@ export const queryClient = new QueryClient({
         });
         return;
       } else {
-        toast.custom((t) => <Toast type="error" body={ error?.message } t={ t }/>);
+        toast.custom((t) => <Toast type="error" body={error?.message} t={t} />);
       }
     }
   }),
@@ -79,7 +79,7 @@ export const queryClient = new QueryClient({
             (error as Error).message :
             `${error}`
         );
-        toast.custom((t) => <Toast type="error" body={message} t={t}/>);
+        toast.custom((t) => <Toast type="error" body={message} t={t} />);
       }
     }
   }

--- a/web/src/api/QueryClient.tsx
+++ b/web/src/api/QueryClient.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -30,7 +30,7 @@ export const queryClient = new QueryClient({
         });
         return;
       } else {
-        toast.custom((t) => <Toast type="error" body={error?.message} t={t} />);
+        toast.custom((t) => <Toast type="error" body={ error?.message } t={ t }/>);
       }
     }
   }),
@@ -79,7 +79,7 @@ export const queryClient = new QueryClient({
             (error as Error).message :
             `${error}`
         );
-        toast.custom((t) => <Toast type="error" body={message} t={t} />);
+        toast.custom((t) => <Toast type="error" body={message} t={t}/>);
       }
     }
   }

--- a/web/src/api/QueryClient.tsx
+++ b/web/src/api/QueryClient.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/query_keys.ts
+++ b/web/src/api/query_keys.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/api/query_keys.ts
+++ b/web/src/api/query_keys.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/Checkbox.tsx
+++ b/web/src/components/Checkbox.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/Checkbox.tsx
+++ b/web/src/components/Checkbox.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ExternalLink.tsx
+++ b/web/src/components/ExternalLink.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/ExternalLink.tsx
+++ b/web/src/components/ExternalLink.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/Icons.tsx
+++ b/web/src/components/Icons.tsx
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 
 interface IconProps {
-  className?: string;
+    className?: string;
 }
 
 export const SortIcon = ({ className }: IconProps) => (
@@ -21,5 +21,5 @@ export const SortDownIcon = ({ className }: IconProps) => (
 );
 
 export const RingResizeSpinner = ({ className }: IconProps) => (
-  <svg className={className} stroke="currentColor" fill="currentColor" strokeWidth="3" strokeLinecap="round" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><g><circle cx="12" cy="12" r="9.5" fill="none"><animate attributeName="stroke-dasharray" dur="1.5s" calcMode="spline" values="0 150;42 150;42 150;42 150" keyTimes="0;0.475;0.95;1" keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" repeatCount="indefinite" /><animate attributeName="stroke-dashoffset" dur="1.5s" calcMode="spline" values="0;-16;-59;-59" keyTimes="0;0.475;0.95;1" keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" repeatCount="indefinite" /></circle><animateTransform attributeName="transform" type="rotate" dur="2s" values="0 12 12;360 12 12" repeatCount="indefinite" /></g></svg>
+  <svg className={className} stroke="currentColor" fill="currentColor" strokeWidth="3" strokeLinecap="round" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><g><circle cx="12" cy="12" r="9.5" fill="none"><animate attributeName="stroke-dasharray" dur="1.5s" calcMode="spline" values="0 150;42 150;42 150;42 150" keyTimes="0;0.475;0.95;1" keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" repeatCount="indefinite"/><animate attributeName="stroke-dashoffset" dur="1.5s" calcMode="spline" values="0;-16;-59;-59" keyTimes="0;0.475;0.95;1" keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" repeatCount="indefinite"/></circle><animateTransform attributeName="transform" type="rotate" dur="2s" values="0 12 12;360 12 12" repeatCount="indefinite"/></g></svg>
 );

--- a/web/src/components/Icons.tsx
+++ b/web/src/components/Icons.tsx
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 
 interface IconProps {
-    className?: string;
+  className?: string;
 }
 
 export const SortIcon = ({ className }: IconProps) => (
@@ -21,5 +21,5 @@ export const SortDownIcon = ({ className }: IconProps) => (
 );
 
 export const RingResizeSpinner = ({ className }: IconProps) => (
-  <svg className={className} stroke="currentColor" fill="currentColor" strokeWidth="3" strokeLinecap="round" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><g><circle cx="12" cy="12" r="9.5" fill="none"><animate attributeName="stroke-dasharray" dur="1.5s" calcMode="spline" values="0 150;42 150;42 150;42 150" keyTimes="0;0.475;0.95;1" keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" repeatCount="indefinite"/><animate attributeName="stroke-dashoffset" dur="1.5s" calcMode="spline" values="0;-16;-59;-59" keyTimes="0;0.475;0.95;1" keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" repeatCount="indefinite"/></circle><animateTransform attributeName="transform" type="rotate" dur="2s" values="0 12 12;360 12 12" repeatCount="indefinite"/></g></svg>
+  <svg className={className} stroke="currentColor" fill="currentColor" strokeWidth="3" strokeLinecap="round" viewBox="0 0 24 24" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><g><circle cx="12" cy="12" r="9.5" fill="none"><animate attributeName="stroke-dasharray" dur="1.5s" calcMode="spline" values="0 150;42 150;42 150;42 150" keyTimes="0;0.475;0.95;1" keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" repeatCount="indefinite" /><animate attributeName="stroke-dashoffset" dur="1.5s" calcMode="spline" values="0;-16;-59;-59" keyTimes="0;0.475;0.95;1" keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" repeatCount="indefinite" /></circle><animateTransform attributeName="transform" type="rotate" dur="2s" values="0 12 12;360 12 12" repeatCount="indefinite" /></g></svg>
 );

--- a/web/src/components/Icons.tsx
+++ b/web/src/components/Icons.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/alerts/ErrorPage.tsx
+++ b/web/src/components/alerts/ErrorPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -14,7 +14,7 @@ type ErrorPageProps = {
 
 export const ErrorPage = ({ error, reset }: ErrorPageProps) => {
   let pageTitle = "We caught an unrecoverable error!";
-  let errorLine: string, summary ="";
+  let errorLine: string, summary = "";
 
   if (error instanceof Error) {
     const stack = new StackTracey(error);
@@ -67,7 +67,7 @@ export const ErrorPage = ({ error, reset }: ErrorPageProps) => {
         >
           <div className="flex items-center">
             <svg className="mr-2 w-5 h-5 text-red-700 dark:text-red-800" fill="currentColor" viewBox="0 0 20 20"
-                 xmlns="http://www.w3.org/2000/svg">
+              xmlns="http://www.w3.org/2000/svg">
               <path
                 fillRule="evenodd"
                 d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
@@ -93,7 +93,7 @@ export const ErrorPage = ({ error, reset }: ErrorPageProps) => {
               reset();
             }}
           >
-            <ArrowPathIcon className="-ml-0.5 mr-2 h-5 w-5"/>
+            <ArrowPathIcon className="-ml-0.5 mr-2 h-5 w-5" />
             Reset page state
           </button>
         </div>

--- a/web/src/components/alerts/ErrorPage.tsx
+++ b/web/src/components/alerts/ErrorPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/alerts/ErrorPage.tsx
+++ b/web/src/components/alerts/ErrorPage.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -14,7 +14,7 @@ type ErrorPageProps = {
 
 export const ErrorPage = ({ error, reset }: ErrorPageProps) => {
   let pageTitle = "We caught an unrecoverable error!";
-  let errorLine: string, summary = "";
+  let errorLine: string, summary ="";
 
   if (error instanceof Error) {
     const stack = new StackTracey(error);
@@ -67,7 +67,7 @@ export const ErrorPage = ({ error, reset }: ErrorPageProps) => {
         >
           <div className="flex items-center">
             <svg className="mr-2 w-5 h-5 text-red-700 dark:text-red-800" fill="currentColor" viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg">
+                 xmlns="http://www.w3.org/2000/svg">
               <path
                 fillRule="evenodd"
                 d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
@@ -93,7 +93,7 @@ export const ErrorPage = ({ error, reset }: ErrorPageProps) => {
               reset();
             }}
           >
-            <ArrowPathIcon className="-ml-0.5 mr-2 h-5 w-5" />
+            <ArrowPathIcon className="-ml-0.5 mr-2 h-5 w-5"/>
             Reset page state
           </button>
         </div>

--- a/web/src/components/alerts/NotFound.tsx
+++ b/web/src/components/alerts/NotFound.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -12,7 +12,7 @@ export const NotFound = () => {
   return (
     <div className="min-h-screen flex flex-col justify-center ">
       <div className="flex justify-center">
-        <Logo className="h-24 sm:h-48"/>
+        <Logo className="h-24 sm:h-48" />
       </div>
       <h2 className="text-2xl text-center font-bold text-gray-900 dark:text-gray-200 my-8 px-2">
         404 Page not found

--- a/web/src/components/alerts/NotFound.tsx
+++ b/web/src/components/alerts/NotFound.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -12,7 +12,7 @@ export const NotFound = () => {
   return (
     <div className="min-h-screen flex flex-col justify-center ">
       <div className="flex justify-center">
-        <Logo className="h-24 sm:h-48" />
+        <Logo className="h-24 sm:h-48"/>
       </div>
       <h2 className="text-2xl text-center font-bold text-gray-900 dark:text-gray-200 my-8 px-2">
         404 Page not found

--- a/web/src/components/alerts/NotFound.tsx
+++ b/web/src/components/alerts/NotFound.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/alerts/Warning.tsx
+++ b/web/src/components/alerts/Warning.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/alerts/Warning.tsx
+++ b/web/src/components/alerts/Warning.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/alerts/index.tsx
+++ b/web/src/components/alerts/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/alerts/index.tsx
+++ b/web/src/components/alerts/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/data-table/Buttons.tsx
+++ b/web/src/components/data-table/Buttons.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -7,10 +7,10 @@ import React from "react";
 import { classNames } from "@utils";
 
 interface ButtonProps {
-    className?: string;
-    children: React.ReactNode;
-    disabled?: boolean;
-    onClick?: () => void;
+  className?: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+  onClick?: () => void;
 }
 
 export const TableButton = ({ children, className, disabled, onClick }: ButtonProps) => (

--- a/web/src/components/data-table/Buttons.tsx
+++ b/web/src/components/data-table/Buttons.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -7,10 +7,10 @@ import React from "react";
 import { classNames } from "@utils";
 
 interface ButtonProps {
-  className?: string;
-  children: React.ReactNode;
-  disabled?: boolean;
-  onClick?: () => void;
+    className?: string;
+    children: React.ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
 }
 
 export const TableButton = ({ children, className, disabled, onClick }: ButtonProps) => (

--- a/web/src/components/data-table/Buttons.tsx
+++ b/web/src/components/data-table/Buttons.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/data-table/Cells.tsx
+++ b/web/src/components/data-table/Cells.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -55,7 +55,7 @@ export const LinksCell = (props: CellContext<Release, unknown>) => {
           requiresClick
           label={<DocumentTextIcon
             className="h-5 w-5 cursor-pointer text-blue-400 hover:text-blue-500 dark:text-blue-500 dark:hover:text-blue-600"
-            aria-hidden={true} />}
+            aria-hidden={true}/>}
           title="Details"
         >
           <div className="mb-1">
@@ -70,9 +70,9 @@ export const LinksCell = (props: CellContext<Release, unknown>) => {
             <CellLine title="Title">{props.row.original.title}</CellLine>
             {props.row.original.year > 0 && <CellLine title="Year">{props.row.original.year.toString()}</CellLine>}
             {props.row.original.season > 0 &&
-              <CellLine title="Season">{props.row.original.season.toString()}</CellLine>}
+                <CellLine title="Season">{props.row.original.season.toString()}</CellLine>}
             {props.row.original.episode > 0 &&
-              <CellLine title="Episode">{props.row.original.episode.toString()}</CellLine>}
+                <CellLine title="Episode">{props.row.original.episode.toString()}</CellLine>}
             <CellLine title="Resolution">{props.row.original.resolution}</CellLine>
             <CellLine title="Source">{props.row.original.source}</CellLine>
             <CellLine title="Codec">{props.row.original.codec}</CellLine>
@@ -105,32 +105,32 @@ export const LinksCell = (props: CellContext<Release, unknown>) => {
   );
 };
 
-export const AgeCell = ({ cell }: CellContext<Release, unknown>) => (
+export const AgeCell = ({cell}: CellContext<Release, unknown>) => (
   <div className="text-sm text-gray-500" title={simplifyDate(cell.getValue() as string)}>
-    {formatDistanceToNowStrict(new Date(cell.getValue() as string), { addSuffix: false })}
+    {formatDistanceToNowStrict(new Date(cell.getValue() as string), {addSuffix: false})}
   </div>
 );
 
 export const IndexerCell = (props: CellContext<Release, unknown>) => (
-  <div
-    className={classNames(
-      "py-3 text-sm font-medium box-content text-gray-900 dark:text-gray-300",
-      "max-w-[96px] sm:max-w-[216px] md:max-w-[360px] lg:max-w-[640px] xl:max-w-[840px]"
-    )}
-  >
-    <Tooltip
-      requiresClick
-      label={props.row.original.indexer.name ? props.row.original.indexer.name : props.row.original.indexer.identifier}
-      maxWidth="max-w-[90vw]"
+    <div
+      className={classNames(
+        "py-3 text-sm font-medium box-content text-gray-900 dark:text-gray-300",
+        "max-w-[96px] sm:max-w-[216px] md:max-w-[360px] lg:max-w-[640px] xl:max-w-[840px]"
+      )}
     >
+      <Tooltip
+        requiresClick
+        label={props.row.original.indexer.name ? props.row.original.indexer.name : props.row.original.indexer.identifier}
+        maxWidth="max-w-[90vw]"
+      >
       <span className="whitespace-pre-wrap break-words">
         {props.row.original.indexer.name ? props.row.original.indexer.name : props.row.original.indexer.identifier}
       </span>
-    </Tooltip>
-  </div>
+      </Tooltip>
+    </div>
 );
 
-export const TitleCell = ({ cell }: CellContext<Release, string>) => (
+export const TitleCell = ({cell}: CellContext<Release, string>) => (
   <div
     className={classNames(
       "py-3 text-sm font-medium box-content text-gray-900 dark:text-gray-300",
@@ -175,7 +175,7 @@ const RetryActionButton = ({ status }: RetryActionButtonProps) => {
 
   const replayAction = () => {
     console.log("replay action");
-    mutation.mutate({ releaseId: status.release_id, actionId: status.id });
+    mutation.mutate({ releaseId: status.release_id,actionId: status.id });
   };
 
   return (
@@ -190,9 +190,9 @@ const RetryActionButton = ({ status }: RetryActionButtonProps) => {
 };
 
 interface StatusCellMapEntry {
-  colors: string;
-  icon: React.ReactElement;
-  textFormatter: (status: ReleaseActionStatus) => React.ReactElement;
+    colors: string;
+    icon: React.ReactElement;
+    textFormatter: (status: ReleaseActionStatus) => React.ReactElement;
 }
 
 const StatusCellMap: Record<string, StatusCellMapEntry> = {
@@ -202,10 +202,10 @@ const StatusCellMap: Record<string, StatusCellMapEntry> = {
     textFormatter: (status: ReleaseActionStatus) => (
       <>
         <span>
-          Action
+        Action
           {" "}
           <span className="font-bold underline underline-offset-2 decoration-2 decoration-red-500">
-            error
+          error
           </span>
           {": "}
           {status.action}
@@ -222,12 +222,12 @@ const StatusCellMap: Record<string, StatusCellMapEntry> = {
     textFormatter: (status: ReleaseActionStatus) => (
       <>
         <span>
-          Action
+        Action
           {" "}
           <span
             className="font-bold underline underline-offset-2 decoration-2 decoration-sky-500"
           >
-            rejected
+          rejected
           </span>
           {": "}
           {status.action}
@@ -247,7 +247,7 @@ const StatusCellMap: Record<string, StatusCellMapEntry> = {
           Action
           {" "}
           <span className="font-bold underline underline-offset-2 decoration-2 decoration-green-500">
-            approved
+          approved
           </span>
           {": "}
           {status.action}
@@ -267,7 +267,7 @@ const StatusCellMap: Record<string, StatusCellMapEntry> = {
           Action
           {" "}
           <span className="font-bold underline underline-offset-2 decoration-2 decoration-yellow-500">
-            pending
+          pending
           </span>
           {": "}
           {status.action}

--- a/web/src/components/data-table/Cells.tsx
+++ b/web/src/components/data-table/Cells.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -55,7 +55,7 @@ export const LinksCell = (props: CellContext<Release, unknown>) => {
           requiresClick
           label={<DocumentTextIcon
             className="h-5 w-5 cursor-pointer text-blue-400 hover:text-blue-500 dark:text-blue-500 dark:hover:text-blue-600"
-            aria-hidden={true}/>}
+            aria-hidden={true} />}
           title="Details"
         >
           <div className="mb-1">
@@ -70,9 +70,9 @@ export const LinksCell = (props: CellContext<Release, unknown>) => {
             <CellLine title="Title">{props.row.original.title}</CellLine>
             {props.row.original.year > 0 && <CellLine title="Year">{props.row.original.year.toString()}</CellLine>}
             {props.row.original.season > 0 &&
-                <CellLine title="Season">{props.row.original.season.toString()}</CellLine>}
+              <CellLine title="Season">{props.row.original.season.toString()}</CellLine>}
             {props.row.original.episode > 0 &&
-                <CellLine title="Episode">{props.row.original.episode.toString()}</CellLine>}
+              <CellLine title="Episode">{props.row.original.episode.toString()}</CellLine>}
             <CellLine title="Resolution">{props.row.original.resolution}</CellLine>
             <CellLine title="Source">{props.row.original.source}</CellLine>
             <CellLine title="Codec">{props.row.original.codec}</CellLine>
@@ -105,32 +105,32 @@ export const LinksCell = (props: CellContext<Release, unknown>) => {
   );
 };
 
-export const AgeCell = ({cell}: CellContext<Release, unknown>) => (
+export const AgeCell = ({ cell }: CellContext<Release, unknown>) => (
   <div className="text-sm text-gray-500" title={simplifyDate(cell.getValue() as string)}>
-    {formatDistanceToNowStrict(new Date(cell.getValue() as string), {addSuffix: false})}
+    {formatDistanceToNowStrict(new Date(cell.getValue() as string), { addSuffix: false })}
   </div>
 );
 
 export const IndexerCell = (props: CellContext<Release, unknown>) => (
-    <div
-      className={classNames(
-        "py-3 text-sm font-medium box-content text-gray-900 dark:text-gray-300",
-        "max-w-[96px] sm:max-w-[216px] md:max-w-[360px] lg:max-w-[640px] xl:max-w-[840px]"
-      )}
+  <div
+    className={classNames(
+      "py-3 text-sm font-medium box-content text-gray-900 dark:text-gray-300",
+      "max-w-[96px] sm:max-w-[216px] md:max-w-[360px] lg:max-w-[640px] xl:max-w-[840px]"
+    )}
+  >
+    <Tooltip
+      requiresClick
+      label={props.row.original.indexer.name ? props.row.original.indexer.name : props.row.original.indexer.identifier}
+      maxWidth="max-w-[90vw]"
     >
-      <Tooltip
-        requiresClick
-        label={props.row.original.indexer.name ? props.row.original.indexer.name : props.row.original.indexer.identifier}
-        maxWidth="max-w-[90vw]"
-      >
       <span className="whitespace-pre-wrap break-words">
         {props.row.original.indexer.name ? props.row.original.indexer.name : props.row.original.indexer.identifier}
       </span>
-      </Tooltip>
-    </div>
+    </Tooltip>
+  </div>
 );
 
-export const TitleCell = ({cell}: CellContext<Release, string>) => (
+export const TitleCell = ({ cell }: CellContext<Release, string>) => (
   <div
     className={classNames(
       "py-3 text-sm font-medium box-content text-gray-900 dark:text-gray-300",
@@ -175,7 +175,7 @@ const RetryActionButton = ({ status }: RetryActionButtonProps) => {
 
   const replayAction = () => {
     console.log("replay action");
-    mutation.mutate({ releaseId: status.release_id,actionId: status.id });
+    mutation.mutate({ releaseId: status.release_id, actionId: status.id });
   };
 
   return (
@@ -190,9 +190,9 @@ const RetryActionButton = ({ status }: RetryActionButtonProps) => {
 };
 
 interface StatusCellMapEntry {
-    colors: string;
-    icon: React.ReactElement;
-    textFormatter: (status: ReleaseActionStatus) => React.ReactElement;
+  colors: string;
+  icon: React.ReactElement;
+  textFormatter: (status: ReleaseActionStatus) => React.ReactElement;
 }
 
 const StatusCellMap: Record<string, StatusCellMapEntry> = {
@@ -202,10 +202,10 @@ const StatusCellMap: Record<string, StatusCellMapEntry> = {
     textFormatter: (status: ReleaseActionStatus) => (
       <>
         <span>
-        Action
+          Action
           {" "}
           <span className="font-bold underline underline-offset-2 decoration-2 decoration-red-500">
-          error
+            error
           </span>
           {": "}
           {status.action}
@@ -222,12 +222,12 @@ const StatusCellMap: Record<string, StatusCellMapEntry> = {
     textFormatter: (status: ReleaseActionStatus) => (
       <>
         <span>
-        Action
+          Action
           {" "}
           <span
             className="font-bold underline underline-offset-2 decoration-2 decoration-sky-500"
           >
-          rejected
+            rejected
           </span>
           {": "}
           {status.action}
@@ -247,7 +247,7 @@ const StatusCellMap: Record<string, StatusCellMapEntry> = {
           Action
           {" "}
           <span className="font-bold underline underline-offset-2 decoration-2 decoration-green-500">
-          approved
+            approved
           </span>
           {": "}
           {status.action}
@@ -267,7 +267,7 @@ const StatusCellMap: Record<string, StatusCellMapEntry> = {
           Action
           {" "}
           <span className="font-bold underline underline-offset-2 decoration-2 decoration-yellow-500">
-          pending
+            pending
           </span>
           {": "}
           {status.action}

--- a/web/src/components/data-table/Cells.tsx
+++ b/web/src/components/data-table/Cells.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/data-table/index.tsx
+++ b/web/src/components/data-table/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/data-table/index.tsx
+++ b/web/src/components/data-table/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/debug.tsx
+++ b/web/src/components/debug.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -7,7 +7,7 @@ import { FC } from "react";
 import { SettingsContext } from "@utils/Context";
 
 interface DebugProps {
-  values: unknown;
+    values: unknown;
 }
 
 export const DEBUG: FC<DebugProps> = ({ values }) => {

--- a/web/src/components/debug.tsx
+++ b/web/src/components/debug.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/debug.tsx
+++ b/web/src/components/debug.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -7,7 +7,7 @@ import { FC } from "react";
 import { SettingsContext } from "@utils/Context";
 
 interface DebugProps {
-    values: unknown;
+  values: unknown;
 }
 
 export const DEBUG: FC<DebugProps> = ({ values }) => {

--- a/web/src/components/emptystates/index.tsx
+++ b/web/src/components/emptystates/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/emptystates/index.tsx
+++ b/web/src/components/emptystates/index.tsx
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 import { PlusIcon } from "@heroicons/react/24/solid";
 
 interface EmptySimpleProps {
-  title: string;
-  subtitle?: string;
-  buttonText?: string;
-  buttonAction?: () => void;
+    title: string;
+    subtitle?: string;
+    buttonText?: string;
+    buttonAction?: () => void;
 }
 
 export const EmptySimple = ({
@@ -39,9 +39,9 @@ export const EmptySimple = ({
 );
 
 interface EmptyListStateProps {
-  text: string;
-  buttonText?: string;
-  buttonOnClick?: () => void;
+    text: string;
+    buttonText?: string;
+    buttonOnClick?: () => void;
 }
 
 export function EmptyListState({ text, buttonText, buttonOnClick }: EmptyListStateProps) {

--- a/web/src/components/emptystates/index.tsx
+++ b/web/src/components/emptystates/index.tsx
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 import { PlusIcon } from "@heroicons/react/24/solid";
 
 interface EmptySimpleProps {
-    title: string;
-    subtitle?: string;
-    buttonText?: string;
-    buttonAction?: () => void;
+  title: string;
+  subtitle?: string;
+  buttonText?: string;
+  buttonAction?: () => void;
 }
 
 export const EmptySimple = ({
@@ -39,9 +39,9 @@ export const EmptySimple = ({
 );
 
 interface EmptyListStateProps {
-    text: string;
-    buttonText?: string;
-    buttonOnClick?: () => void;
+  text: string;
+  buttonText?: string;
+  buttonOnClick?: () => void;
 }
 
 export function EmptyListState({ text, buttonText, buttonOnClick }: EmptyListStateProps) {

--- a/web/src/components/fields/text.tsx
+++ b/web/src/components/fields/text.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/fields/text.tsx
+++ b/web/src/components/fields/text.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/Header.tsx
+++ b/web/src/components/header/Header.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -22,7 +22,7 @@ import { AuthContext } from "@utils/Context";
 export const Header = () => {
   const loginRoute = getRouteApi("/login");
 
-  const { isError:isConfigError, error: configError, data: config } = useQuery(ConfigQueryOptions(true));
+  const { isError: isConfigError, error: configError, data: config } = useQuery(ConfigQueryOptions(true));
   if (isConfigError) {
     console.log(configError);
   }

--- a/web/src/components/header/Header.tsx
+++ b/web/src/components/header/Header.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -22,7 +22,7 @@ import { AuthContext } from "@utils/Context";
 export const Header = () => {
   const loginRoute = getRouteApi("/login");
 
-  const { isError: isConfigError, error: configError, data: config } = useQuery(ConfigQueryOptions(true));
+  const { isError:isConfigError, error: configError, data: config } = useQuery(ConfigQueryOptions(true));
   if (isConfigError) {
     console.log(configError);
   }

--- a/web/src/components/header/Header.tsx
+++ b/web/src/components/header/Header.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/LeftNav.tsx
+++ b/web/src/components/header/LeftNav.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/LeftNav.tsx
+++ b/web/src/components/header/LeftNav.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/MobileNav.tsx
+++ b/web/src/components/header/MobileNav.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -27,14 +27,14 @@ export const MobileNav = (props: RightNavProps) => (
               <span className={
                 classNames(
                   "shadow-sm border bg-gray-100 border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-white block px-3 py-2 rounded-md text-base",
-                  isActive
-                    ? "underline underline-offset-2 decoration-2 decoration-sky-500 font-bold text-black"
-                    : "font-medium"
+                isActive
+                ? "underline underline-offset-2 decoration-2 decoration-sky-500 font-bold text-black"
+                : "font-medium"
                 )
               }>
-                {item.name}
+              {item.name}
               </span>
-            )
+          )
           }}
         </Link>
       ))}

--- a/web/src/components/header/MobileNav.tsx
+++ b/web/src/components/header/MobileNav.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/MobileNav.tsx
+++ b/web/src/components/header/MobileNav.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -27,14 +27,14 @@ export const MobileNav = (props: RightNavProps) => (
               <span className={
                 classNames(
                   "shadow-sm border bg-gray-100 border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-white block px-3 py-2 rounded-md text-base",
-                isActive
-                ? "underline underline-offset-2 decoration-2 decoration-sky-500 font-bold text-black"
-                : "font-medium"
+                  isActive
+                    ? "underline underline-offset-2 decoration-2 decoration-sky-500 font-bold text-black"
+                    : "font-medium"
                 )
               }>
-              {item.name}
+                {item.name}
               </span>
-          )
+            )
           }}
         </Link>
       ))}

--- a/web/src/components/header/RightNav.tsx
+++ b/web/src/components/header/RightNav.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/RightNav.tsx
+++ b/web/src/components/header/RightNav.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/_shared.ts
+++ b/web/src/components/header/_shared.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/_shared.ts
+++ b/web/src/components/header/_shared.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/index.tsx
+++ b/web/src/components/header/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/header/index.tsx
+++ b/web/src/components/header/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/headings/index.tsx
+++ b/web/src/components/headings/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/headings/index.tsx
+++ b/web/src/components/headings/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/hot-toast/components/checkmark.tsx
+++ b/web/src/components/hot-toast/components/checkmark.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { styled, keyframes } from 'goober';
 
 const circleAnimation = keyframes`

--- a/web/src/components/hot-toast/components/error.tsx
+++ b/web/src/components/hot-toast/components/error.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { styled, keyframes } from 'goober';
 
 const circleAnimation = keyframes`

--- a/web/src/components/hot-toast/components/loader.tsx
+++ b/web/src/components/hot-toast/components/loader.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { styled, keyframes } from 'goober';
 
 const rotate = keyframes`

--- a/web/src/components/hot-toast/components/toast-bar.tsx
+++ b/web/src/components/hot-toast/components/toast-bar.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import * as React from 'react';
 import { styled, keyframes } from 'goober';
 

--- a/web/src/components/hot-toast/components/toast-icon.tsx
+++ b/web/src/components/hot-toast/components/toast-icon.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import * as React from 'react';
 import { styled, keyframes } from 'goober';
 

--- a/web/src/components/hot-toast/components/toaster.tsx
+++ b/web/src/components/hot-toast/components/toaster.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { css, setup } from 'goober';
 import * as React from 'react';
 import {

--- a/web/src/components/hot-toast/core/store.ts
+++ b/web/src/components/hot-toast/core/store.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useEffect, useState } from 'react';
 import { DefaultToastOptions, Toast, ToastType } from './types';
 

--- a/web/src/components/hot-toast/core/toast.ts
+++ b/web/src/components/hot-toast/core/toast.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import {
   Renderable,
   Toast,

--- a/web/src/components/hot-toast/core/types.ts
+++ b/web/src/components/hot-toast/core/types.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import React, { CSSProperties } from 'react';
 
 export type ToastType = 'success' | 'error' | 'loading' | 'blank' | 'custom';

--- a/web/src/components/hot-toast/core/use-toaster.ts
+++ b/web/src/components/hot-toast/core/use-toaster.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { useEffect, useCallback } from 'react';
 import { dispatch, ActionType, useStore } from './store';
 import { toast } from './toast';

--- a/web/src/components/hot-toast/core/utils.ts
+++ b/web/src/components/hot-toast/core/utils.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 export const genId = (() => {
   let count = 0;
   return () => {

--- a/web/src/components/hot-toast/headless/index.ts
+++ b/web/src/components/hot-toast/headless/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { toast } from '../core/toast';
 
 export type {

--- a/web/src/components/hot-toast/index.ts
+++ b/web/src/components/hot-toast/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
 import { toast } from './core/toast';
 
 export * from './headless';

--- a/web/src/components/inputs/common.tsx
+++ b/web/src/components/inputs/common.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/common.tsx
+++ b/web/src/components/inputs/common.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/index.ts
+++ b/web/src/components/inputs/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/index.ts
+++ b/web/src/components/inputs/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/input.tsx
+++ b/web/src/components/inputs/input.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/input.tsx
+++ b/web/src/components/inputs/input.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/input_wide.tsx
+++ b/web/src/components/inputs/input_wide.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/input_wide.tsx
+++ b/web/src/components/inputs/input_wide.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/radio.tsx
+++ b/web/src/components/inputs/radio.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -8,20 +8,20 @@ import { RadioGroup, Description, Label, Radio } from "@headlessui/react";
 import { classNames } from "@utils";
 
 export interface radioFieldsetOption {
-    label: string;
-    description: string;
-    value: string;
-    type?: string;
+  label: string;
+  description: string;
+  value: string;
+  type?: string;
 }
 
 interface props {
-    name: string;
-    legend: string;
-    options: radioFieldsetOption[];
+  name: string;
+  legend: string;
+  options: radioFieldsetOption[];
 }
 
 interface anyObj {
-    [key: string]: string
+  [key: string]: string
 }
 
 function RadioFieldsetWide({ name, legend, options }: props) {

--- a/web/src/components/inputs/radio.tsx
+++ b/web/src/components/inputs/radio.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/radio.tsx
+++ b/web/src/components/inputs/radio.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -8,20 +8,20 @@ import { RadioGroup, Description, Label, Radio } from "@headlessui/react";
 import { classNames } from "@utils";
 
 export interface radioFieldsetOption {
-  label: string;
-  description: string;
-  value: string;
-  type?: string;
+    label: string;
+    description: string;
+    value: string;
+    type?: string;
 }
 
 interface props {
-  name: string;
-  legend: string;
-  options: radioFieldsetOption[];
+    name: string;
+    legend: string;
+    options: radioFieldsetOption[];
 }
 
 interface anyObj {
-  [key: string]: string
+    [key: string]: string
 }
 
 function RadioFieldsetWide({ name, legend, options }: props) {

--- a/web/src/components/inputs/select.tsx
+++ b/web/src/components/inputs/select.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/select.tsx
+++ b/web/src/components/inputs/select.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/select_wide.tsx
+++ b/web/src/components/inputs/select_wide.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -76,7 +76,7 @@ export function SelectFieldCreatable<T>({ name, label, help, placeholder, toolti
                 }
               })}
               // value={field?.value ? field.value : options.find(o => o.value == field?.value)}
-              value={field?.value ? { value: field.value, label: field.value } : field.value}
+              value={field?.value ? { value: field.value, label: field.value  } : field.value}
               onChange={(newValue: unknown) => {
                 if (newValue) {
                   setFieldValue(field.name, (newValue as { value: string }).value);
@@ -85,7 +85,7 @@ export function SelectFieldCreatable<T>({ name, label, help, placeholder, toolti
                   setFieldValue(field.name, "")
                 }
               }}
-              options={[...[...options, { value: field.value, label: field.value }].reduce((map, obj) => map.set(obj.value, obj), new Map()).values()]}
+              options={[...[...options, { value: field.value, label: field.value  }].reduce((map, obj) => map.set(obj.value, obj), new Map()).values()]}
             />
           )}
         </Field>
@@ -141,7 +141,7 @@ export function SelectField<T>({ name, label, help, placeholder, options }: Sele
                 }
               })}
               // value={field?.value ? field.value : options.find(o => o.value == field?.value)}
-              value={field?.value ? { value: field.value, label: field.value } : field.value}
+              value={field?.value ? { value: field.value, label: field.value  } : field.value}
               onChange={(newValue: unknown) => {
                 if (newValue) {
                   setFieldValue(field.name, (newValue as { value: string }).value);
@@ -150,7 +150,7 @@ export function SelectField<T>({ name, label, help, placeholder, options }: Sele
                   setFieldValue(field.name, "")
                 }
               }}
-              options={[...[...options, { value: field.value, label: field.value }].reduce((map, obj) => map.set(obj.value, obj), new Map()).values()]}
+              options={[...[...options, { value: field.value, label: field.value  }].reduce((map, obj) => map.set(obj.value, obj), new Map()).values()]}
             />
           )}
         </Field>
@@ -265,26 +265,26 @@ export function ListFilterMultiSelectField({ name, label, help, tooltip, options
       <div className="sm:col-span-2">
         <Field name={name} type="select">
           {({
-            field,
-            form: { setFieldValue }
-          }: FieldProps) => (
-            <>
-              <RMSC
-                {...field}
-                options={options}
-                // disabled={disabled}
-                labelledBy={name}
-                // isCreatable={creatable}
-                // onCreateOption={handleNewField}
-                value={field.value && field.value.map((item: ListFilterMultiSelectOption) => ({
-                  value: item.id,
-                  label: item.name
-                }))}
-                onChange={(values: MultiSelectOption[]) => {
-                  const item = values && values.map((i) => ({ id: i.value, name: i.label }));
-                  setFieldValue(field.name, item);
-                }}
-              />
+              field,
+              form: { setFieldValue }
+            }: FieldProps) => (
+              <>
+                <RMSC
+                  {...field}
+                  options={options}
+                  // disabled={disabled}
+                  labelledBy={name}
+                  // isCreatable={creatable}
+                  // onCreateOption={handleNewField}
+                  value={field.value && field.value.map((item: ListFilterMultiSelectOption) => ({
+                    value: item.id,
+                    label: item.name
+                  }))}
+                  onChange={(values: MultiSelectOption[]) => {
+                    const item = values && values.map((i) => ({ id: i.value, name: i.label }));
+                    setFieldValue(field.name, item);
+                  }}
+                />
             </>
           )}
         </Field>

--- a/web/src/components/inputs/select_wide.tsx
+++ b/web/src/components/inputs/select_wide.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -76,7 +76,7 @@ export function SelectFieldCreatable<T>({ name, label, help, placeholder, toolti
                 }
               })}
               // value={field?.value ? field.value : options.find(o => o.value == field?.value)}
-              value={field?.value ? { value: field.value, label: field.value  } : field.value}
+              value={field?.value ? { value: field.value, label: field.value } : field.value}
               onChange={(newValue: unknown) => {
                 if (newValue) {
                   setFieldValue(field.name, (newValue as { value: string }).value);
@@ -85,7 +85,7 @@ export function SelectFieldCreatable<T>({ name, label, help, placeholder, toolti
                   setFieldValue(field.name, "")
                 }
               }}
-              options={[...[...options, { value: field.value, label: field.value  }].reduce((map, obj) => map.set(obj.value, obj), new Map()).values()]}
+              options={[...[...options, { value: field.value, label: field.value }].reduce((map, obj) => map.set(obj.value, obj), new Map()).values()]}
             />
           )}
         </Field>
@@ -141,7 +141,7 @@ export function SelectField<T>({ name, label, help, placeholder, options }: Sele
                 }
               })}
               // value={field?.value ? field.value : options.find(o => o.value == field?.value)}
-              value={field?.value ? { value: field.value, label: field.value  } : field.value}
+              value={field?.value ? { value: field.value, label: field.value } : field.value}
               onChange={(newValue: unknown) => {
                 if (newValue) {
                   setFieldValue(field.name, (newValue as { value: string }).value);
@@ -150,7 +150,7 @@ export function SelectField<T>({ name, label, help, placeholder, options }: Sele
                   setFieldValue(field.name, "")
                 }
               }}
-              options={[...[...options, { value: field.value, label: field.value  }].reduce((map, obj) => map.set(obj.value, obj), new Map()).values()]}
+              options={[...[...options, { value: field.value, label: field.value }].reduce((map, obj) => map.set(obj.value, obj), new Map()).values()]}
             />
           )}
         </Field>
@@ -265,26 +265,26 @@ export function ListFilterMultiSelectField({ name, label, help, tooltip, options
       <div className="sm:col-span-2">
         <Field name={name} type="select">
           {({
-              field,
-              form: { setFieldValue }
-            }: FieldProps) => (
-              <>
-                <RMSC
-                  {...field}
-                  options={options}
-                  // disabled={disabled}
-                  labelledBy={name}
-                  // isCreatable={creatable}
-                  // onCreateOption={handleNewField}
-                  value={field.value && field.value.map((item: ListFilterMultiSelectOption) => ({
-                    value: item.id,
-                    label: item.name
-                  }))}
-                  onChange={(values: MultiSelectOption[]) => {
-                    const item = values && values.map((i) => ({ id: i.value, name: i.label }));
-                    setFieldValue(field.name, item);
-                  }}
-                />
+            field,
+            form: { setFieldValue }
+          }: FieldProps) => (
+            <>
+              <RMSC
+                {...field}
+                options={options}
+                // disabled={disabled}
+                labelledBy={name}
+                // isCreatable={creatable}
+                // onCreateOption={handleNewField}
+                value={field.value && field.value.map((item: ListFilterMultiSelectOption) => ({
+                  value: item.id,
+                  label: item.name
+                }))}
+                onChange={(values: MultiSelectOption[]) => {
+                  const item = values && values.map((i) => ({ id: i.value, name: i.label }));
+                  setFieldValue(field.name, item);
+                }}
+              />
             </>
           )}
         </Field>

--- a/web/src/components/inputs/select_wide.tsx
+++ b/web/src/components/inputs/select_wide.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/switch.tsx
+++ b/web/src/components/inputs/switch.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -86,26 +86,26 @@ interface SwitchButtonProps {
 }
 
 const SwitchButton = ({ name, defaultValue }: SwitchButtonProps) => (
-  <Field as="div" className="flex items-center justify-between">
-    <FormikField
-      name={name}
-      defaultValue={defaultValue as boolean}
-      type="checkbox"
-    >
-      {({
-        field,
-        form: { setFieldValue }
-      }: FieldProps) => (
-        <Checkbox
-          {...field}
-          value={!!field.checked}
-          setValue={(value) => {
-            setFieldValue(field?.name ?? "", value);
-          }}
-        />
-      )}
-    </FormikField>
-  </Field>
+    <Field as="div" className="flex items-center justify-between">
+      <FormikField
+        name={name}
+        defaultValue={defaultValue as boolean}
+        type="checkbox"
+      >
+        {({
+            field,
+            form: { setFieldValue }
+          }: FieldProps) => (
+          <Checkbox
+            {...field}
+            value={!!field.checked}
+            setValue={(value) => {
+              setFieldValue(field?.name ?? "", value);
+            }}
+          />
+        )}
+      </FormikField>
+    </Field>
 );
 
 export { SwitchGroup, SwitchButton };

--- a/web/src/components/inputs/switch.tsx
+++ b/web/src/components/inputs/switch.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -86,26 +86,26 @@ interface SwitchButtonProps {
 }
 
 const SwitchButton = ({ name, defaultValue }: SwitchButtonProps) => (
-    <Field as="div" className="flex items-center justify-between">
-      <FormikField
-        name={name}
-        defaultValue={defaultValue as boolean}
-        type="checkbox"
-      >
-        {({
-            field,
-            form: { setFieldValue }
-          }: FieldProps) => (
-          <Checkbox
-            {...field}
-            value={!!field.checked}
-            setValue={(value) => {
-              setFieldValue(field?.name ?? "", value);
-            }}
-          />
-        )}
-      </FormikField>
-    </Field>
+  <Field as="div" className="flex items-center justify-between">
+    <FormikField
+      name={name}
+      defaultValue={defaultValue as boolean}
+      type="checkbox"
+    >
+      {({
+        field,
+        form: { setFieldValue }
+      }: FieldProps) => (
+        <Checkbox
+          {...field}
+          value={!!field.checked}
+          setValue={(value) => {
+            setFieldValue(field?.name ?? "", value);
+          }}
+        />
+      )}
+    </FormikField>
+  </Field>
 );
 
 export { SwitchGroup, SwitchButton };

--- a/web/src/components/inputs/switch.tsx
+++ b/web/src/components/inputs/switch.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/text.tsx
+++ b/web/src/components/inputs/text.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -60,7 +60,7 @@ export const Input: FC<InputProps> = forwardRef<HTMLInputElement, InputProps>(
       id,
       name,
       label,
-      type,
+      type ,
       className = "",
       placeholder,
       autoComplete,

--- a/web/src/components/inputs/text.tsx
+++ b/web/src/components/inputs/text.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/inputs/text.tsx
+++ b/web/src/components/inputs/text.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -60,7 +60,7 @@ export const Input: FC<InputProps> = forwardRef<HTMLInputElement, InputProps>(
       id,
       name,
       label,
-      type ,
+      type,
       className = "",
       placeholder,
       autoComplete,

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -150,7 +150,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
       }, 400);
     }
   };
-  
+
   // When the 'Cancel' button is clicked
   const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -178,7 +178,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
           >
             <DialogPanel className="inline-block align-bottom border border-transparent dark:border-gray-700 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
               <ModalUpper title={props.title} text={props.text} />
-              
+
               <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 flex justify-center">
                 <input
                   type="text"
@@ -203,9 +203,8 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
                     <button
                       type="button"
                       disabled={!isInputCorrect}
-                      className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 ${
-                        isInputCorrect ? "bg-red-600 text-white hover:bg-red-700" : "bg-gray-300"
-                      } text-base font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm`}
+                      className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 ${isInputCorrect ? "bg-red-600 text-white hover:bg-red-700" : "bg-gray-300"
+                        } text-base font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm`}
                       onClick={handleForceRun}
                     >
                       Force Run

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -150,7 +150,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
       }, 400);
     }
   };
-
+  
   // When the 'Cancel' button is clicked
   const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -178,7 +178,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
           >
             <DialogPanel className="inline-block align-bottom border border-transparent dark:border-gray-700 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
               <ModalUpper title={props.title} text={props.text} />
-
+              
               <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 flex justify-center">
                 <input
                   type="text"
@@ -203,8 +203,9 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
                     <button
                       type="button"
                       disabled={!isInputCorrect}
-                      className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 ${isInputCorrect ? "bg-red-600 text-white hover:bg-red-700" : "bg-gray-300"
-                        } text-base font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm`}
+                      className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 ${
+                        isInputCorrect ? "bg-red-600 text-white hover:bg-red-700" : "bg-gray-300"
+                      } text-base font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm`}
                       onClick={handleForceRun}
                     >
                       Force Run

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/notifications/Toast.tsx
+++ b/web/src/components/notifications/Toast.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/notifications/Toast.tsx
+++ b/web/src/components/notifications/Toast.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/panels/index.tsx
+++ b/web/src/components/panels/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/panels/index.tsx
+++ b/web/src/components/panels/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -10,7 +10,7 @@ interface PortalProps {
   children?: ReactNode;
 }
 
-export const Portal = ({ children }: PortalProps) => {
+export const Portal = ({children }: PortalProps) => {
   const mount = document.getElementById("portal-root");
   const el = document.createElement("div");
 

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -10,7 +10,7 @@ interface PortalProps {
   children?: ReactNode;
 }
 
-export const Portal = ({children }: PortalProps) => {
+export const Portal = ({ children }: PortalProps) => {
   const mount = document.getElementById("portal-root");
   const el = document.createElement("div");
 

--- a/web/src/components/portal/Portal.tsx
+++ b/web/src/components/portal/Portal.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/portal/index.ts
+++ b/web/src/components/portal/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/portal/index.ts
+++ b/web/src/components/portal/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/tooltips/DocsTooltip.tsx
+++ b/web/src/components/tooltips/DocsTooltip.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/tooltips/DocsTooltip.tsx
+++ b/web/src/components/tooltips/DocsTooltip.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/tooltips/Tooltip.tsx
+++ b/web/src/components/tooltips/Tooltip.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/components/tooltips/Tooltip.tsx
+++ b/web/src/components/tooltips/Tooltip.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/domain/constants.ts
+++ b/web/src/domain/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/domain/constants.ts
+++ b/web/src/domain/constants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/domain/react-table-config.d.ts
+++ b/web/src/domain/react-table-config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/domain/react-table-config.d.ts
+++ b/web/src/domain/react-table-config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/_shared.ts
+++ b/web/src/forms/_shared.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/_shared.ts
+++ b/web/src/forms/_shared.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -30,7 +30,7 @@ export function FilterAddForm({ isOpen, toggle }: AddFormProps) {
       toast.custom((t) => <Toast type="success" body={`Filter ${filter.name} was added`} t={t} />);
 
       if (filter.id) {
-        navigate({ to: "/filters/$filterId", params: { filterId: filter.id }})
+        navigate({ to: "/filters/$filterId", params: { filterId: filter.id } })
       }
     }
   });
@@ -115,7 +115,7 @@ export function FilterAddForm({ isOpen, toggle }: AddFormProps) {
                               {({
                                 field,
                                 meta
-                              }: FieldProps ) => (
+                              }: FieldProps) => (
                                 <div className="sm:col-span-2">
                                   <input
                                     {...field}

--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -30,7 +30,7 @@ export function FilterAddForm({ isOpen, toggle }: AddFormProps) {
       toast.custom((t) => <Toast type="success" body={`Filter ${filter.name} was added`} t={t} />);
 
       if (filter.id) {
-        navigate({ to: "/filters/$filterId", params: { filterId: filter.id } })
+        navigate({ to: "/filters/$filterId", params: { filterId: filter.id }})
       }
     }
   });
@@ -115,7 +115,7 @@ export function FilterAddForm({ isOpen, toggle }: AddFormProps) {
                               {({
                                 field,
                                 meta
-                              }: FieldProps) => (
+                              }: FieldProps ) => (
                                 <div className="sm:col-span-2">
                                   <input
                                     {...field}

--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/index.ts
+++ b/web/src/forms/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/index.ts
+++ b/web/src/forms/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/settings/APIKeyAddForm.tsx
+++ b/web/src/forms/settings/APIKeyAddForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -25,7 +25,7 @@ export function APIKeyAddForm({ isOpen, toggle }: AddFormProps) {
     onSuccess: (_, key) => {
       queryClient.invalidateQueries({ queryKey: ApiKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`API key ${key.name} was added`} t={t} />);
+      toast.custom((t) => <Toast type="success" body={`API key ${key.name} was added`} t={t}/>);
 
       toggle();
     }
@@ -81,7 +81,7 @@ export function APIKeyAddForm({ isOpen, toggle }: AddFormProps) {
                                 onClick={toggle}
                               >
                                 <span className="sr-only">Close panel</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                                <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
                               </button>
                             </div>
                           </div>
@@ -139,7 +139,7 @@ export function APIKeyAddForm({ isOpen, toggle }: AddFormProps) {
                           </button>
                         </div>
                       </div>
-                      <DEBUG values={values} />
+                      <DEBUG values={values}/>
                     </Form>
                   )}
                 </Formik>

--- a/web/src/forms/settings/APIKeyAddForm.tsx
+++ b/web/src/forms/settings/APIKeyAddForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -25,7 +25,7 @@ export function APIKeyAddForm({ isOpen, toggle }: AddFormProps) {
     onSuccess: (_, key) => {
       queryClient.invalidateQueries({ queryKey: ApiKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`API key ${key.name} was added`} t={t}/>);
+      toast.custom((t) => <Toast type="success" body={`API key ${key.name} was added`} t={t} />);
 
       toggle();
     }
@@ -81,7 +81,7 @@ export function APIKeyAddForm({ isOpen, toggle }: AddFormProps) {
                                 onClick={toggle}
                               >
                                 <span className="sr-only">Close panel</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
+                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                               </button>
                             </div>
                           </div>
@@ -139,7 +139,7 @@ export function APIKeyAddForm({ isOpen, toggle }: AddFormProps) {
                           </button>
                         </div>
                       </div>
-                      <DEBUG values={values}/>
+                      <DEBUG values={values} />
                     </Form>
                   )}
                 </Formik>

--- a/web/src/forms/settings/APIKeyAddForm.tsx
+++ b/web/src/forms/settings/APIKeyAddForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -852,7 +852,7 @@ export function DownloadClientAddForm({ isOpen, toggle }: AddFormProps) {
   );
 }
 
-export function DownloadClientUpdateForm({ isOpen, toggle, data: client}: UpdateFormProps<DownloadClient>) {
+export function DownloadClientUpdateForm({ isOpen, toggle, data: client }: UpdateFormProps<DownloadClient>) {
   const [isTesting, setIsTesting] = useState(false);
   const [isSuccessfulTest, setIsSuccessfulTest] = useState(false);
   const [isErrorTest, setIsErrorTest] = useState(false);

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -852,7 +852,7 @@ export function DownloadClientAddForm({ isOpen, toggle }: AddFormProps) {
   );
 }
 
-export function DownloadClientUpdateForm({ isOpen, toggle, data: client }: UpdateFormProps<DownloadClient>) {
+export function DownloadClientUpdateForm({ isOpen, toggle, data: client}: UpdateFormProps<DownloadClient>) {
   const [isTesting, setIsTesting] = useState(false);
   const [isSuccessfulTest, setIsSuccessfulTest] = useState(false);
   const [isErrorTest, setIsErrorTest] = useState(false);

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/settings/FeedForms.tsx
+++ b/web/src/forms/settings/FeedForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -35,7 +35,7 @@ interface InitialValues {
   settings: FeedSettings;
 }
 
-export function FeedUpdateForm({ isOpen, toggle, data }: UpdateFormProps<Feed>) {
+export function FeedUpdateForm({ isOpen, toggle, data}: UpdateFormProps<Feed>) {
   const feed = data;
   const [isTesting, setIsTesting] = useState(false);
   const [isTestSuccessful, setIsSuccessfulTest] = useState(false);
@@ -47,7 +47,7 @@ export function FeedUpdateForm({ isOpen, toggle, data }: UpdateFormProps<Feed>) 
     mutationFn: (feed: Feed) => APIClient.feeds.update(feed),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: FeedKeys.lists() });
-
+      
       toast.custom((t) => <Toast type="success" body={`${feed.name} was updated successfully`} t={t} />);
       toggle();
     }
@@ -191,10 +191,10 @@ function FormFieldsTorznab() {
       <PasswordFieldWide name="api_key" label="API key" />
 
       {interval < 15 && <WarningLabel />}
-      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban." />
+      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban."/>
 
-      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh." />
-      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed." />
+      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh."/>
+      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed."/>
     </div>
   );
 }
@@ -215,10 +215,10 @@ function FormFieldsNewznab() {
       <PasswordFieldWide name="api_key" label="API key" />
 
       {interval < 15 && <WarningLabel />}
-      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban." />
+      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban."/>
 
-      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh." />
-      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed." />
+      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh."/>
+      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed."/>
     </div>
   );
 }
@@ -239,9 +239,9 @@ function FormFieldsRSS() {
       <SelectFieldBasic name="settings.download_type" label="Download type" options={FeedDownloadTypeOptions} />
 
       {interval < 15 && <WarningLabel />}
-      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban." />
-      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh." />
-      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed." />
+      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban."/>
+      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh."/>
+      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed."/>
 
       <PasswordFieldWide name="cookie" label="Cookie" help="Not commonly used" />
     </div>

--- a/web/src/forms/settings/FeedForms.tsx
+++ b/web/src/forms/settings/FeedForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -35,7 +35,7 @@ interface InitialValues {
   settings: FeedSettings;
 }
 
-export function FeedUpdateForm({ isOpen, toggle, data}: UpdateFormProps<Feed>) {
+export function FeedUpdateForm({ isOpen, toggle, data }: UpdateFormProps<Feed>) {
   const feed = data;
   const [isTesting, setIsTesting] = useState(false);
   const [isTestSuccessful, setIsSuccessfulTest] = useState(false);
@@ -47,7 +47,7 @@ export function FeedUpdateForm({ isOpen, toggle, data}: UpdateFormProps<Feed>) {
     mutationFn: (feed: Feed) => APIClient.feeds.update(feed),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: FeedKeys.lists() });
-      
+
       toast.custom((t) => <Toast type="success" body={`${feed.name} was updated successfully`} t={t} />);
       toggle();
     }
@@ -191,10 +191,10 @@ function FormFieldsTorznab() {
       <PasswordFieldWide name="api_key" label="API key" />
 
       {interval < 15 && <WarningLabel />}
-      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban."/>
+      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban." />
 
-      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh."/>
-      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed."/>
+      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh." />
+      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed." />
     </div>
   );
 }
@@ -215,10 +215,10 @@ function FormFieldsNewznab() {
       <PasswordFieldWide name="api_key" label="API key" />
 
       {interval < 15 && <WarningLabel />}
-      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban."/>
+      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban." />
 
-      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh."/>
-      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed."/>
+      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh." />
+      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed." />
     </div>
   );
 }
@@ -239,9 +239,9 @@ function FormFieldsRSS() {
       <SelectFieldBasic name="settings.download_type" label="Download type" options={FeedDownloadTypeOptions} />
 
       {interval < 15 && <WarningLabel />}
-      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban."/>
-      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh."/>
-      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed."/>
+      <NumberFieldWide name="interval" label="Refresh interval" help="Minutes. Recommended 15-30. Too low and risk ban." />
+      <NumberFieldWide name="timeout" label="Refresh timeout" help="Seconds to wait before cancelling refresh." />
+      <NumberFieldWide name="max_age" label="Max age" help="Enter the maximum age of feed content in seconds. It is recommended to set this to '0' to disable the age filter, ensuring all items in the feed are processed." />
 
       <PasswordFieldWide name="cookie" label="Cookie" help="Not commonly used" />
     </div>

--- a/web/src/forms/settings/FeedForms.tsx
+++ b/web/src/forms/settings/FeedForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -60,32 +60,32 @@ const IrcSettingFields = (ind: IndexerDefinition, indexer: string) => {
 
           {ind.irc.settings.map((f: IndexerSetting, idx: number) => {
             switch (f.type) {
-              case "text": {
-                return (
-                  <TextFieldWide
-                    key={idx}
-                    name={`irc.${f.name}`}
-                    label={f.label}
-                    required={f.required}
-                    help={f.help}
-                    autoComplete="off"
-                    validate={validateField(f)}
-                    tooltip={
-                      <div>
-                        <p>Please read our IRC guide if you are unfamiliar with IRC.</p>
-                        <DocsLink href="https://autobrr.com/configuration/irc" />
-                      </div>
-                    }
-                  />
-                );
-              }
-              case "secret": {
-                if (f.name === "invite_command") {
-                  return <PasswordFieldWide defaultVisible name={`irc.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
-                }
-                return <PasswordFieldWide name={`irc.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
-              }
+            case "text": {
+              return (
+                <TextFieldWide
+                  key={idx}
+                  name={`irc.${f.name}`}
+                  label={f.label}
+                  required={f.required}
+                  help={f.help}
+                  autoComplete="off"
+                  validate={validateField(f)}
+                  tooltip={
+                    <div>
+                      <p>Please read our IRC guide if you are unfamiliar with IRC.</p>
+                      <DocsLink href="https://autobrr.com/configuration/irc" />
+                    </div>
+                  }
+                />
+              );
             }
+            case "secret": {
+              if (f.name === "invite_command") {
+                return <PasswordFieldWide defaultVisible name={`irc.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+              }
+              return <PasswordFieldWide name={`irc.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+            }
+          }
             return null;
           })}
         </div>
@@ -112,12 +112,12 @@ const TorznabFeedSettingFields = (ind: IndexerDefinition, indexer: string) => {
 
             {ind.torznab.settings.map((f: IndexerSetting, idx: number) => {
               switch (f.type) {
-                case "text": {
-                  return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
-                }
-                case "secret": {
-                  return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
-                }
+              case "text": {
+                return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
+              }
+              case "secret": {
+                return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+              }
               }
               return null;
             })}
@@ -153,12 +153,12 @@ const NewznabFeedSettingFields = (ind: IndexerDefinition, indexer: string) => {
 
             {ind.newznab.settings.map((f: IndexerSetting, idx: number) => {
               switch (f.type) {
-                case "text": {
-                  return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
-                }
-                case "secret": {
-                  return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
-                }
+              case "text": {
+                return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
+              }
+              case "secret": {
+                return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+              }
               }
               return null;
             })}
@@ -186,12 +186,12 @@ const RSSFeedSettingFields = (ind: IndexerDefinition, indexer: string) => {
 
             {ind.rss.settings.map((f: IndexerSetting, idx: number) => {
               switch (f.type) {
-                case "text": {
-                  return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
-                }
-                case "secret": {
-                  return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
-                }
+              case "text": {
+                return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
+              }
+              case "secret": {
+                return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+              }
               }
               return null;
             })}
@@ -216,30 +216,30 @@ const SettingFields = (ind: IndexerDefinition, indexer: string) => {
       <div key="opt">
         {ind && ind.settings && ind.settings.map((f, idx: number) => {
           switch (f.type) {
-            case "text": {
-              return (
-                <TextFieldWide name={`settings.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />
-              );
-            }
-            case "secret": {
-              return (
-                <PasswordFieldWide
-                  name={`settings.${f.name}`}
-                  label={f.label}
-                  required={f.required}
-                  key={idx}
-                  help={f.help}
-                  validate={validateField(f)}
-                  tooltip={
-                    <div>
-                      <p>This field does not take a full URL. Only use alphanumeric strings like <code>uqcdi67cibkx3an8cmdm</code>.</p>
-                      <br />
-                      <DocsLink href="https://autobrr.com/faqs#common-action-rejections" />
-                    </div>
-                  }
-                />
-              );
-            }
+          case "text": {
+            return (
+              <TextFieldWide name={`settings.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />
+            );
+          }
+          case "secret": {
+            return (
+              <PasswordFieldWide
+                name={`settings.${f.name}`}
+                label={f.label}
+                required={f.required}
+                key={idx}
+                help={f.help}
+                validate={validateField(f)}
+                tooltip={
+                  <div>
+                    <p>This field does not take a full URL. Only use alphanumeric strings like <code>uqcdi67cibkx3an8cmdm</code>.</p>
+                    <br />
+                    <DocsLink href="https://autobrr.com/faqs#common-action-rejections" />
+                  </div>
+                }
+              />
+            );
+          }
           }
           return null;
         })}
@@ -771,28 +771,28 @@ export function IndexerUpdateForm({ isOpen, toggle, data: indexer }: UpdateFormP
       <div key="opt">
         {settings.map((f: IndexerSetting, idx: number) => {
           switch (f.type) {
-            case "text": {
-              return (
-                <TextFieldWide name={`settings.${f.name}`} label={f.label} key={idx} help={f.help} />
-              );
-            }
-            case "secret": {
-              return (
-                <PasswordFieldWide
-                  key={idx}
-                  name={`settings.${f.name}`}
-                  label={f.label}
-                  help={f.help}
-                  tooltip={
-                    <div>
-                      <p>This field does not take a full URL. Only use alphanumeric strings like <code>uqcdi67cibkx3an8cmdm</code>.</p>
-                      <br />
-                      <DocsLink href="https://autobrr.com/faqs#common-action-rejections" />
-                    </div>
-                  }
-                />
-              );
-            }
+          case "text": {
+            return (
+              <TextFieldWide name={`settings.${f.name}`} label={f.label} key={idx} help={f.help} />
+            );
+          }
+          case "secret": {
+            return (
+              <PasswordFieldWide
+                key={idx}
+                name={`settings.${f.name}`}
+                label={f.label}
+                help={f.help}
+                tooltip={
+                  <div>
+                    <p>This field does not take a full URL. Only use alphanumeric strings like <code>uqcdi67cibkx3an8cmdm</code>.</p>
+                    <br />
+                    <DocsLink href="https://autobrr.com/faqs#common-action-rejections" />
+                  </div>
+                }
+              />
+            );
+          }
           }
           return null;
         })}
@@ -860,15 +860,15 @@ export function IndexerUpdateForm({ isOpen, toggle, data: indexer }: UpdateFormP
             tooltip={
               <div>
                 <p>External Identifier for use with ARRs to get features like seed limits working.</p>
-                <br />
+                <br/>
                 <p>This needs to match the indexer name in your ARR. If using Prowlarr it will likely be
                   "{indexer.name} (Prowlarr)"</p>
-                <br />
-                <DocsLink href="https://autobrr.com/configuration/indexers#setup" />
+                <br/>
+                <DocsLink href="https://autobrr.com/configuration/indexers#setup"/>
               </div>
             }
           />
-          <SwitchGroupWide name="enabled" label="Enabled" />
+          <SwitchGroupWide name="enabled" label="Enabled"/>
 
           {indexer.implementation == "irc" && (
             <SelectFieldCreatable

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -60,32 +60,32 @@ const IrcSettingFields = (ind: IndexerDefinition, indexer: string) => {
 
           {ind.irc.settings.map((f: IndexerSetting, idx: number) => {
             switch (f.type) {
-            case "text": {
-              return (
-                <TextFieldWide
-                  key={idx}
-                  name={`irc.${f.name}`}
-                  label={f.label}
-                  required={f.required}
-                  help={f.help}
-                  autoComplete="off"
-                  validate={validateField(f)}
-                  tooltip={
-                    <div>
-                      <p>Please read our IRC guide if you are unfamiliar with IRC.</p>
-                      <DocsLink href="https://autobrr.com/configuration/irc" />
-                    </div>
-                  }
-                />
-              );
-            }
-            case "secret": {
-              if (f.name === "invite_command") {
-                return <PasswordFieldWide defaultVisible name={`irc.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+              case "text": {
+                return (
+                  <TextFieldWide
+                    key={idx}
+                    name={`irc.${f.name}`}
+                    label={f.label}
+                    required={f.required}
+                    help={f.help}
+                    autoComplete="off"
+                    validate={validateField(f)}
+                    tooltip={
+                      <div>
+                        <p>Please read our IRC guide if you are unfamiliar with IRC.</p>
+                        <DocsLink href="https://autobrr.com/configuration/irc" />
+                      </div>
+                    }
+                  />
+                );
               }
-              return <PasswordFieldWide name={`irc.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+              case "secret": {
+                if (f.name === "invite_command") {
+                  return <PasswordFieldWide defaultVisible name={`irc.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+                }
+                return <PasswordFieldWide name={`irc.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+              }
             }
-          }
             return null;
           })}
         </div>
@@ -112,12 +112,12 @@ const TorznabFeedSettingFields = (ind: IndexerDefinition, indexer: string) => {
 
             {ind.torznab.settings.map((f: IndexerSetting, idx: number) => {
               switch (f.type) {
-              case "text": {
-                return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
-              }
-              case "secret": {
-                return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
-              }
+                case "text": {
+                  return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
+                }
+                case "secret": {
+                  return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+                }
               }
               return null;
             })}
@@ -153,12 +153,12 @@ const NewznabFeedSettingFields = (ind: IndexerDefinition, indexer: string) => {
 
             {ind.newznab.settings.map((f: IndexerSetting, idx: number) => {
               switch (f.type) {
-              case "text": {
-                return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
-              }
-              case "secret": {
-                return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
-              }
+                case "text": {
+                  return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
+                }
+                case "secret": {
+                  return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+                }
               }
               return null;
             })}
@@ -186,12 +186,12 @@ const RSSFeedSettingFields = (ind: IndexerDefinition, indexer: string) => {
 
             {ind.rss.settings.map((f: IndexerSetting, idx: number) => {
               switch (f.type) {
-              case "text": {
-                return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
-              }
-              case "secret": {
-                return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
-              }
+                case "text": {
+                  return <TextFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />;
+                }
+                case "secret": {
+                  return <PasswordFieldWide name={`feed.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} defaultValue={f.default} validate={validateField(f)} />;
+                }
               }
               return null;
             })}
@@ -216,30 +216,30 @@ const SettingFields = (ind: IndexerDefinition, indexer: string) => {
       <div key="opt">
         {ind && ind.settings && ind.settings.map((f, idx: number) => {
           switch (f.type) {
-          case "text": {
-            return (
-              <TextFieldWide name={`settings.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />
-            );
-          }
-          case "secret": {
-            return (
-              <PasswordFieldWide
-                name={`settings.${f.name}`}
-                label={f.label}
-                required={f.required}
-                key={idx}
-                help={f.help}
-                validate={validateField(f)}
-                tooltip={
-                  <div>
-                    <p>This field does not take a full URL. Only use alphanumeric strings like <code>uqcdi67cibkx3an8cmdm</code>.</p>
-                    <br />
-                    <DocsLink href="https://autobrr.com/faqs#common-action-rejections" />
-                  </div>
-                }
-              />
-            );
-          }
+            case "text": {
+              return (
+                <TextFieldWide name={`settings.${f.name}`} label={f.label} required={f.required} key={idx} help={f.help} autoComplete="off" validate={validateField(f)} />
+              );
+            }
+            case "secret": {
+              return (
+                <PasswordFieldWide
+                  name={`settings.${f.name}`}
+                  label={f.label}
+                  required={f.required}
+                  key={idx}
+                  help={f.help}
+                  validate={validateField(f)}
+                  tooltip={
+                    <div>
+                      <p>This field does not take a full URL. Only use alphanumeric strings like <code>uqcdi67cibkx3an8cmdm</code>.</p>
+                      <br />
+                      <DocsLink href="https://autobrr.com/faqs#common-action-rejections" />
+                    </div>
+                  }
+                />
+              );
+            }
           }
           return null;
         })}
@@ -771,28 +771,28 @@ export function IndexerUpdateForm({ isOpen, toggle, data: indexer }: UpdateFormP
       <div key="opt">
         {settings.map((f: IndexerSetting, idx: number) => {
           switch (f.type) {
-          case "text": {
-            return (
-              <TextFieldWide name={`settings.${f.name}`} label={f.label} key={idx} help={f.help} />
-            );
-          }
-          case "secret": {
-            return (
-              <PasswordFieldWide
-                key={idx}
-                name={`settings.${f.name}`}
-                label={f.label}
-                help={f.help}
-                tooltip={
-                  <div>
-                    <p>This field does not take a full URL. Only use alphanumeric strings like <code>uqcdi67cibkx3an8cmdm</code>.</p>
-                    <br />
-                    <DocsLink href="https://autobrr.com/faqs#common-action-rejections" />
-                  </div>
-                }
-              />
-            );
-          }
+            case "text": {
+              return (
+                <TextFieldWide name={`settings.${f.name}`} label={f.label} key={idx} help={f.help} />
+              );
+            }
+            case "secret": {
+              return (
+                <PasswordFieldWide
+                  key={idx}
+                  name={`settings.${f.name}`}
+                  label={f.label}
+                  help={f.help}
+                  tooltip={
+                    <div>
+                      <p>This field does not take a full URL. Only use alphanumeric strings like <code>uqcdi67cibkx3an8cmdm</code>.</p>
+                      <br />
+                      <DocsLink href="https://autobrr.com/faqs#common-action-rejections" />
+                    </div>
+                  }
+                />
+              );
+            }
           }
           return null;
         })}
@@ -860,15 +860,15 @@ export function IndexerUpdateForm({ isOpen, toggle, data: indexer }: UpdateFormP
             tooltip={
               <div>
                 <p>External Identifier for use with ARRs to get features like seed limits working.</p>
-                <br/>
+                <br />
                 <p>This needs to match the indexer name in your ARR. If using Prowlarr it will likely be
                   "{indexer.name} (Prowlarr)"</p>
-                <br/>
-                <DocsLink href="https://autobrr.com/configuration/indexers#setup"/>
+                <br />
+                <DocsLink href="https://autobrr.com/configuration/indexers#setup" />
               </div>
             }
           />
-          <SwitchGroupWide name="enabled" label="Enabled"/>
+          <SwitchGroupWide name="enabled" label="Enabled" />
 
           {indexer.implementation == "irc" && (
             <SelectFieldCreatable

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/settings/IrcForms.tsx
+++ b/web/src/forms/settings/IrcForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -34,55 +34,55 @@ const ChannelsFieldArray = ({ channels }: ChannelsFieldArrayProps) => (
       {({ remove, push }: FieldArrayRenderProps) => (
         <div className="flex flex-col space-y-2">
           {channels && channels.length > 0 ? (
-              channels.map((_, index) => (
-                <div key={index} className="flex justify-between border dark:border-gray-700 dark:bg-gray-815 p-2 rounded-md">
-                  <div className="flex gap-2">
-                    <Field name={`channels.${index}.name`}>
-                      {({ field, meta }: FieldProps) => (
-                        <input
-                          {...field}
-                          type="text"
-                          value={field.value ?? ""}
-                          onChange={field.onChange}
-                          className={classNames(
-                            meta.touched && meta.error
-                              ? "border-red-500 focus:ring-red-500 focus:border-red-500"
-                              : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500",
-                            "block w-full shadow-sm sm:text-sm rounded-md border py-2.5 bg-gray-100 dark:bg-gray-850 dark:text-gray-100"
-                          )}
-                        />
-                      )}
-                    </Field>
+            channels.map((_, index) => (
+              <div key={index} className="flex justify-between border dark:border-gray-700 dark:bg-gray-815 p-2 rounded-md">
+                <div className="flex gap-2">
+                  <Field name={`channels.${index}.name`}>
+                    {({ field, meta }: FieldProps) => (
+                      <input
+                        {...field}
+                        type="text"
+                        value={field.value ?? ""}
+                        onChange={field.onChange}
+                        className={classNames(
+                          meta.touched && meta.error
+                            ? "border-red-500 focus:ring-red-500 focus:border-red-500"
+                            : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500",
+                          "block w-full shadow-sm sm:text-sm rounded-md border py-2.5 bg-gray-100 dark:bg-gray-850 dark:text-gray-100"
+                        )}
+                      />
+                    )}
+                  </Field>
 
-                    <Field name={`channels.${index}.password`}>
-                      {({ field, meta }: FieldProps) => (
-                        <input
-                          {...field}
-                          type="text"
-                          value={field.value ?? ""}
-                          onChange={field.onChange}
-                          placeholder="Channel password"
-                          className={classNames(
-                            meta.touched && meta.error
-                              ? "border-red-500 focus:ring-red-500 focus:border-red-500"
-                              : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500",
-                            "block w-full shadow-sm sm:text-sm rounded-md border py-2.5 bg-gray-100 dark:bg-gray-850 dark:text-gray-100"
-                          )}
-                        />
-                      )}
-                    </Field>
-                  </div>
-
-                  <button
-                    type="button"
-                    className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                    onClick={() => remove(index)}
-                  >
-                    <span className="sr-only">Remove</span>
-                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-                  </button>
+                  <Field name={`channels.${index}.password`}>
+                    {({ field, meta }: FieldProps) => (
+                      <input
+                        {...field}
+                        type="text"
+                        value={field.value ?? ""}
+                        onChange={field.onChange}
+                        placeholder="Channel password"
+                        className={classNames(
+                          meta.touched && meta.error
+                            ? "border-red-500 focus:ring-red-500 focus:border-red-500"
+                            : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500",
+                          "block w-full shadow-sm sm:text-sm rounded-md border py-2.5 bg-gray-100 dark:bg-gray-850 dark:text-gray-100"
+                        )}
+                      />
+                    )}
+                  </Field>
                 </div>
-              ))
+
+                <button
+                  type="button"
+                  className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={() => remove(index)}
+                >
+                  <span className="sr-only">Remove</span>
+                  <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                </button>
+              </div>
+            ))
           ) : (
             <span className="text-center text-sm text-grey-darker dark:text-white">
               No channels!
@@ -101,15 +101,15 @@ const ChannelsFieldArray = ({ channels }: ChannelsFieldArrayProps) => (
   </div>
 );
 interface IrcNetworkAddFormValues {
-    name: string;
-    enabled: boolean;
-    server : string;
-    port: number;
-    tls: boolean;
-    pass: string;
-    nick: string;
-    auth: IrcAuth;
-    channels: IrcChannel[];
+  name: string;
+  enabled: boolean;
+  server: string;
+  port: number;
+  tls: boolean;
+  pass: string;
+  nick: string;
+  auth: IrcAuth;
+  channels: IrcChannel[];
 }
 
 export function IrcNetworkAddForm({ isOpen, toggle }: AddFormProps) {
@@ -242,22 +242,22 @@ const validateNetwork = (values: FormikValues) => {
 };
 
 interface IrcNetworkUpdateFormValues {
-    id: number;
-    name: string;
-    enabled: boolean;
-    server: string;
-    port: number;
-    tls: boolean;
-    pass: string;
-    nick: string;
-    auth?: IrcAuth;
-    invite_command: string;
-    use_bouncer: boolean;
-    bouncer_addr: string;
-    bot_mode: boolean;
-    channels: Array<IrcChannel>;
-    use_proxy: boolean;
-    proxy_id: number;
+  id: number;
+  name: string;
+  enabled: boolean;
+  server: string;
+  port: number;
+  tls: boolean;
+  pass: string;
+  nick: string;
+  auth?: IrcAuth;
+  invite_command: string;
+  use_bouncer: boolean;
+  bouncer_addr: string;
+  bot_mode: boolean;
+  channels: Array<IrcChannel>;
+  use_proxy: boolean;
+  proxy_id: number;
 }
 
 export function IrcNetworkUpdateForm({
@@ -334,7 +334,7 @@ export function IrcNetworkUpdateForm({
             required={true}
           />
 
-          <SwitchGroupWide name="enabled" label="Enabled"/>
+          <SwitchGroupWide name="enabled" label="Enabled" />
           <TextFieldWide
             name="server"
             label="Server"
@@ -348,7 +348,7 @@ export function IrcNetworkUpdateForm({
             required={true}
           />
 
-          <SwitchGroupWide name="tls" label="TLS"/>
+          <SwitchGroupWide name="tls" label="TLS" />
 
           <PasswordFieldWide
             name="pass"
@@ -363,7 +363,7 @@ export function IrcNetworkUpdateForm({
             required={true}
           />
 
-          <SwitchGroupWide name="use_bouncer" label="Bouncer (BNC)"/>
+          <SwitchGroupWide name="use_bouncer" label="Bouncer (BNC)" />
           {values.use_bouncer && (
             <TextFieldWide
               name="bouncer_addr"
@@ -372,7 +372,7 @@ export function IrcNetworkUpdateForm({
             />
           )}
 
-          <SwitchGroupWide name="bot_mode" label="IRCv3 Bot Mode"/>
+          <SwitchGroupWide name="bot_mode" label="IRCv3 Bot Mode" />
 
           <div className="border-t border-gray-200 dark:border-gray-700 py-4">
             <div className="flex justify-between px-4">
@@ -384,7 +384,7 @@ export function IrcNetworkUpdateForm({
                   Set a proxy to be used for connecting to the irc server.
                 </p>
               </div>
-              <SwitchButton name="use_proxy"/>
+              <SwitchButton name="use_proxy" />
             </div>
 
             {values.use_proxy === true && (
@@ -427,7 +427,7 @@ export function IrcNetworkUpdateForm({
             />
           </div>
 
-          <PasswordFieldWide name="invite_command" label="Invite command"/>
+          <PasswordFieldWide name="invite_command" label="Invite command" />
 
           <div className="border-t border-gray-200 dark:border-gray-700 py-5">
             <div className="px-4 space-y-1 mb-8">
@@ -437,7 +437,7 @@ export function IrcNetworkUpdateForm({
               </p>
             </div>
 
-            <ChannelsFieldArray channels={values.channels}/>
+            <ChannelsFieldArray channels={values.channels} />
           </div>
         </div>
       )}
@@ -466,9 +466,9 @@ export function SelectField<T>({ name, label, options, placeholder }: SelectFiel
       <div className="sm:col-span-2">
         <Field name={name} type="select">
           {({
-              field,
-              form: { setFieldValue }
-            }: FieldProps) => (
+            field,
+            form: { setFieldValue }
+          }: FieldProps) => (
             <Select
               {...field}
               id={name}

--- a/web/src/forms/settings/IrcForms.tsx
+++ b/web/src/forms/settings/IrcForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/settings/IrcForms.tsx
+++ b/web/src/forms/settings/IrcForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -34,55 +34,55 @@ const ChannelsFieldArray = ({ channels }: ChannelsFieldArrayProps) => (
       {({ remove, push }: FieldArrayRenderProps) => (
         <div className="flex flex-col space-y-2">
           {channels && channels.length > 0 ? (
-            channels.map((_, index) => (
-              <div key={index} className="flex justify-between border dark:border-gray-700 dark:bg-gray-815 p-2 rounded-md">
-                <div className="flex gap-2">
-                  <Field name={`channels.${index}.name`}>
-                    {({ field, meta }: FieldProps) => (
-                      <input
-                        {...field}
-                        type="text"
-                        value={field.value ?? ""}
-                        onChange={field.onChange}
-                        className={classNames(
-                          meta.touched && meta.error
-                            ? "border-red-500 focus:ring-red-500 focus:border-red-500"
-                            : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500",
-                          "block w-full shadow-sm sm:text-sm rounded-md border py-2.5 bg-gray-100 dark:bg-gray-850 dark:text-gray-100"
-                        )}
-                      />
-                    )}
-                  </Field>
+              channels.map((_, index) => (
+                <div key={index} className="flex justify-between border dark:border-gray-700 dark:bg-gray-815 p-2 rounded-md">
+                  <div className="flex gap-2">
+                    <Field name={`channels.${index}.name`}>
+                      {({ field, meta }: FieldProps) => (
+                        <input
+                          {...field}
+                          type="text"
+                          value={field.value ?? ""}
+                          onChange={field.onChange}
+                          className={classNames(
+                            meta.touched && meta.error
+                              ? "border-red-500 focus:ring-red-500 focus:border-red-500"
+                              : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500",
+                            "block w-full shadow-sm sm:text-sm rounded-md border py-2.5 bg-gray-100 dark:bg-gray-850 dark:text-gray-100"
+                          )}
+                        />
+                      )}
+                    </Field>
 
-                  <Field name={`channels.${index}.password`}>
-                    {({ field, meta }: FieldProps) => (
-                      <input
-                        {...field}
-                        type="text"
-                        value={field.value ?? ""}
-                        onChange={field.onChange}
-                        placeholder="Channel password"
-                        className={classNames(
-                          meta.touched && meta.error
-                            ? "border-red-500 focus:ring-red-500 focus:border-red-500"
-                            : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500",
-                          "block w-full shadow-sm sm:text-sm rounded-md border py-2.5 bg-gray-100 dark:bg-gray-850 dark:text-gray-100"
-                        )}
-                      />
-                    )}
-                  </Field>
+                    <Field name={`channels.${index}.password`}>
+                      {({ field, meta }: FieldProps) => (
+                        <input
+                          {...field}
+                          type="text"
+                          value={field.value ?? ""}
+                          onChange={field.onChange}
+                          placeholder="Channel password"
+                          className={classNames(
+                            meta.touched && meta.error
+                              ? "border-red-500 focus:ring-red-500 focus:border-red-500"
+                              : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500",
+                            "block w-full shadow-sm sm:text-sm rounded-md border py-2.5 bg-gray-100 dark:bg-gray-850 dark:text-gray-100"
+                          )}
+                        />
+                      )}
+                    </Field>
+                  </div>
+
+                  <button
+                    type="button"
+                    className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                    onClick={() => remove(index)}
+                  >
+                    <span className="sr-only">Remove</span>
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                  </button>
                 </div>
-
-                <button
-                  type="button"
-                  className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                  onClick={() => remove(index)}
-                >
-                  <span className="sr-only">Remove</span>
-                  <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-                </button>
-              </div>
-            ))
+              ))
           ) : (
             <span className="text-center text-sm text-grey-darker dark:text-white">
               No channels!
@@ -101,15 +101,15 @@ const ChannelsFieldArray = ({ channels }: ChannelsFieldArrayProps) => (
   </div>
 );
 interface IrcNetworkAddFormValues {
-  name: string;
-  enabled: boolean;
-  server: string;
-  port: number;
-  tls: boolean;
-  pass: string;
-  nick: string;
-  auth: IrcAuth;
-  channels: IrcChannel[];
+    name: string;
+    enabled: boolean;
+    server : string;
+    port: number;
+    tls: boolean;
+    pass: string;
+    nick: string;
+    auth: IrcAuth;
+    channels: IrcChannel[];
 }
 
 export function IrcNetworkAddForm({ isOpen, toggle }: AddFormProps) {
@@ -242,22 +242,22 @@ const validateNetwork = (values: FormikValues) => {
 };
 
 interface IrcNetworkUpdateFormValues {
-  id: number;
-  name: string;
-  enabled: boolean;
-  server: string;
-  port: number;
-  tls: boolean;
-  pass: string;
-  nick: string;
-  auth?: IrcAuth;
-  invite_command: string;
-  use_bouncer: boolean;
-  bouncer_addr: string;
-  bot_mode: boolean;
-  channels: Array<IrcChannel>;
-  use_proxy: boolean;
-  proxy_id: number;
+    id: number;
+    name: string;
+    enabled: boolean;
+    server: string;
+    port: number;
+    tls: boolean;
+    pass: string;
+    nick: string;
+    auth?: IrcAuth;
+    invite_command: string;
+    use_bouncer: boolean;
+    bouncer_addr: string;
+    bot_mode: boolean;
+    channels: Array<IrcChannel>;
+    use_proxy: boolean;
+    proxy_id: number;
 }
 
 export function IrcNetworkUpdateForm({
@@ -334,7 +334,7 @@ export function IrcNetworkUpdateForm({
             required={true}
           />
 
-          <SwitchGroupWide name="enabled" label="Enabled" />
+          <SwitchGroupWide name="enabled" label="Enabled"/>
           <TextFieldWide
             name="server"
             label="Server"
@@ -348,7 +348,7 @@ export function IrcNetworkUpdateForm({
             required={true}
           />
 
-          <SwitchGroupWide name="tls" label="TLS" />
+          <SwitchGroupWide name="tls" label="TLS"/>
 
           <PasswordFieldWide
             name="pass"
@@ -363,7 +363,7 @@ export function IrcNetworkUpdateForm({
             required={true}
           />
 
-          <SwitchGroupWide name="use_bouncer" label="Bouncer (BNC)" />
+          <SwitchGroupWide name="use_bouncer" label="Bouncer (BNC)"/>
           {values.use_bouncer && (
             <TextFieldWide
               name="bouncer_addr"
@@ -372,7 +372,7 @@ export function IrcNetworkUpdateForm({
             />
           )}
 
-          <SwitchGroupWide name="bot_mode" label="IRCv3 Bot Mode" />
+          <SwitchGroupWide name="bot_mode" label="IRCv3 Bot Mode"/>
 
           <div className="border-t border-gray-200 dark:border-gray-700 py-4">
             <div className="flex justify-between px-4">
@@ -384,7 +384,7 @@ export function IrcNetworkUpdateForm({
                   Set a proxy to be used for connecting to the irc server.
                 </p>
               </div>
-              <SwitchButton name="use_proxy" />
+              <SwitchButton name="use_proxy"/>
             </div>
 
             {values.use_proxy === true && (
@@ -427,7 +427,7 @@ export function IrcNetworkUpdateForm({
             />
           </div>
 
-          <PasswordFieldWide name="invite_command" label="Invite command" />
+          <PasswordFieldWide name="invite_command" label="Invite command"/>
 
           <div className="border-t border-gray-200 dark:border-gray-700 py-5">
             <div className="px-4 space-y-1 mb-8">
@@ -437,7 +437,7 @@ export function IrcNetworkUpdateForm({
               </p>
             </div>
 
-            <ChannelsFieldArray channels={values.channels} />
+            <ChannelsFieldArray channels={values.channels}/>
           </div>
         </div>
       )}
@@ -466,9 +466,9 @@ export function SelectField<T>({ name, label, options, placeholder }: SelectFiel
       <div className="sm:col-span-2">
         <Field name={name} type="select">
           {({
-            field,
-            form: { setFieldValue }
-          }: FieldProps) => (
+              field,
+              form: { setFieldValue }
+            }: FieldProps) => (
             <Select
               {...field}
               id={name}

--- a/web/src/forms/settings/ListForms.tsx
+++ b/web/src/forms/settings/ListForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -82,11 +82,11 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ListKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body="List added!" t={t} />);
+      toast.custom((t) => <Toast type="success" body="List added!" t={t}/>);
       toggle();
     },
     onError: () => {
-      toast.custom((t) => <Toast type="error" body="List could not be added" t={t} />);
+      toast.custom((t) => <Toast type="error" body="List could not be added" t={t}/>);
     }
   });
 
@@ -161,7 +161,7 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
                                 onClick={toggle}
                               >
                                 <span className="sr-only">Close panel</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                                <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
                               </button>
                             </div>
                           </div>
@@ -184,9 +184,9 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
                             <div className="sm:col-span-2">
                               <Field name="type" type="select">
                                 {({
-                                  field,
-                                  form: { setFieldValue }
-                                }: FieldProps) => (
+                                    field,
+                                    form: { setFieldValue }
+                                  }: FieldProps) => (
                                   <Select
                                     {...field}
                                     isClearable={true}
@@ -232,10 +232,10 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
                             </div>
                           </div>
 
-                          <SwitchGroupWide name="enabled" label="Enabled" />
+                          <SwitchGroupWide name="enabled" label="Enabled"/>
                         </div>
 
-                        <ListTypeForm listType={values.type} clients={clients ?? []} />
+                        <ListTypeForm listType={values.type} clients={clients ?? []}/>
 
                         <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
                           <div className="border-t border-gray-200 dark:border-gray-700 py-4">
@@ -267,7 +267,7 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
                         </div>
                       </div>
 
-                      <DEBUG values={values} />
+                      <DEBUG values={values}/>
                     </Form>
                   )}
                 </Formik>
@@ -300,7 +300,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ListKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`${data.name} was updated successfully`} t={t} />);
+      toast.custom((t) => <Toast type="success" body={`${data.name} was updated successfully`} t={t}/>);
 
       sleep(1500);
       toggle();
@@ -314,7 +314,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ListKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`${data.name} was deleted.`} t={t} />);
+      toast.custom((t) => <Toast type="success" body={`${data.name} was deleted.`} t={t}/>);
     }
   });
 
@@ -371,7 +371,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
                     include_alternate_titles: data.include_alternate_titles,
                   }}
                   onSubmit={onSubmit}
-                // validate={validate}
+                  // validate={validate}
                 >
                   {({ values }) => (
                     <Form className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto">
@@ -393,7 +393,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
                                 onClick={toggle}
                               >
                                 <span className="sr-only">Close panel</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                                <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
                               </button>
                             </div>
                           </div>
@@ -401,14 +401,14 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
 
                         <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
 
-                          <TextFieldWide name="name" label="Name" required={true} />
+                          <TextFieldWide name="name" label="Name" required={true}/>
 
                           <TextFieldWide name="type" label="Type" required={true} disabled={true} />
 
-                          <SwitchGroupWide name="enabled" label="Enabled" />
+                          <SwitchGroupWide name="enabled" label="Enabled"/>
 
                           <div className="space-y-2 divide-y divide-gray-200 dark:divide-gray-700">
-                            <ListTypeForm listType={values.type} clients={clientsQuery.data ?? []} />
+                            <ListTypeForm listType={values.type} clients={clientsQuery.data ?? []}/>
                           </div>
 
                           <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
@@ -425,7 +425,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
                               <ListFilterMultiSelectField name="filters" label="Filters" options={filterQuery.data?.map(f => ({
                                 value: f.id,
                                 label: f.name
-                              })) ?? []} />
+                              })) ?? []}/>
 
                             </div>
                           </div>
@@ -443,19 +443,19 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
                             Remove
                           </button>
                           <div className="flex space-x-3">
-                            <button
-                              type="button"
-                              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                              onClick={toggle}
-                            >
-                              Cancel
-                            </button>
-                            <SubmitButton isPending={mutation.isPending} isError={mutation.isError} isSuccess={mutation.isSuccess} />
+                          <button
+                            type="button"
+                            className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                            onClick={toggle}
+                          >
+                            Cancel
+                          </button>
+                          <SubmitButton isPending={mutation.isPending} isError={mutation.isError} isSuccess={mutation.isSuccess} />
                           </div>
                         </div>
                       </div>
 
-                      <DEBUG values={values} />
+                      <DEBUG values={values}/>
                     </Form>
                   )}
                 </Formik>
@@ -622,17 +622,17 @@ function ListTypeArr({ listType, clients }: ListTypeFormProps) {
           <ListArrTagsMultiSelectField name="tags_included" label="Tags Included" options={arrTagsQuery.data?.map(f => ({
             value: f.label,
             label: f.label
-          })) ?? []} />
+          })) ?? []}/>
 
           <ListArrTagsMultiSelectField name="tags_excluded" label="Tags Excluded" options={arrTagsQuery.data?.map(f => ({
             value: f.label,
             label: f.label
-          })) ?? []} />
+          })) ?? []}/>
         </>
       )}
 
       <div className="space-y-1">
-        <FilterOptionCheckBoxes listType={listType} clients={[]} />
+        <FilterOptionCheckBoxes listType={listType} clients={[]}/>
       </div>
     </div>
   )
@@ -689,8 +689,8 @@ function ListTypePlainText() {
         </p>
       </div>
 
-      <TextFieldWide
-        name="url"
+      <TextFieldWide 
+        name="url" 
         label="List URL"
         help="URL to a plain text file with one item per line"
         placeholder="https://example.com/list.txt"
@@ -718,7 +718,7 @@ function ListTypeSteam() {
         </p>
       </div>
 
-      <TextFieldWide name="url" label="URL" help={"Steam Wishlist URL"} placeholder="https://store.steampowered.com/wishlist/id/USERNAME/wishlistdata" />
+      <TextFieldWide name="url" label="URL" help={"Steam Wishlist URL"} placeholder="https://store.steampowered.com/wishlist/id/USERNAME/wishlistdata"/>
     </div>
   )
 }
@@ -803,10 +803,10 @@ function DownloadClientSelectCustom({ name, clientType, clients }: DownloadClien
       <div className="sm:col-span-2">
         <Field name={name} type="select">
           {({
-            field,
-            meta,
-            form: { setFieldValue }
-          }: FieldProps) => (
+              field,
+              meta,
+              form: { setFieldValue }
+            }: FieldProps) => (
             <Listbox
               value={field.value}
               onChange={(value) => setFieldValue(field?.name, value)}
@@ -819,16 +819,16 @@ function DownloadClientSelectCustom({ name, clientType, clients }: DownloadClien
                   <div className="relative">
                     <ListboxButton
                       className="block w-full shadow-sm sm:text-sm rounded-md border py-2 pl-3 pr-10 text-left focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-815 dark:text-gray-100">
-                      <span className="block truncate">
-                        {field.value
-                          ? clients.find((c) => c.id === field.value)?.name
-                          : "Choose a client"}
-                      </span>
+                    <span className="block truncate">
+                      {field.value
+                        ? clients.find((c) => c.id === field.value)?.name
+                        : "Choose a client"}
+                    </span>
                       <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                        <ChevronUpDownIcon
-                          className="h-5 w-5 text-gray-400 dark:text-gray-300"
-                          aria-hidden="true" />
-                      </span>
+                      <ChevronUpDownIcon
+                        className="h-5 w-5 text-gray-400 dark:text-gray-300"
+                        aria-hidden="true"/>
+                    </span>
                     </ListboxButton>
 
                     <Transition
@@ -857,14 +857,14 @@ function DownloadClientSelectCustom({ name, clientType, clients }: DownloadClien
                             >
                               {({ selected, focus }) => (
                                 <>
-                                  <span
-                                    className={classNames(
-                                      selected ? "font-semibold" : "font-normal",
-                                      "block truncate"
-                                    )}
-                                  >
-                                    {client.name}
-                                  </span>
+                                <span
+                                  className={classNames(
+                                    selected ? "font-semibold" : "font-normal",
+                                    "block truncate"
+                                  )}
+                                >
+                                  {client.name}
+                                </span>
 
                                   {selected ? (
                                     <span
@@ -873,10 +873,10 @@ function DownloadClientSelectCustom({ name, clientType, clients }: DownloadClien
                                         "absolute inset-y-0 right-0 flex items-center pr-4"
                                       )}
                                     >
-                                      <CheckIcon
-                                        className="h-5 w-5"
-                                        aria-hidden="true" />
-                                    </span>
+                                    <CheckIcon
+                                      className="h-5 w-5"
+                                      aria-hidden="true"/>
+                                  </span>
                                   ) : null}
                                 </>
                               )}
@@ -926,9 +926,9 @@ export function ListArrTagsMultiSelectField({ name, label, help, tooltip, option
       <div className="sm:col-span-2">
         <Field name={name} type="select">
           {({
-            field,
-            form: { setFieldValue }
-          }: FieldProps) => (
+              field,
+              form: { setFieldValue }
+            }: FieldProps) => (
             <>
               <RMSC
                 {...field}

--- a/web/src/forms/settings/ListForms.tsx
+++ b/web/src/forms/settings/ListForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/settings/ListForms.tsx
+++ b/web/src/forms/settings/ListForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -82,11 +82,11 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ListKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body="List added!" t={t}/>);
+      toast.custom((t) => <Toast type="success" body="List added!" t={t} />);
       toggle();
     },
     onError: () => {
-      toast.custom((t) => <Toast type="error" body="List could not be added" t={t}/>);
+      toast.custom((t) => <Toast type="error" body="List could not be added" t={t} />);
     }
   });
 
@@ -161,7 +161,7 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
                                 onClick={toggle}
                               >
                                 <span className="sr-only">Close panel</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
+                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                               </button>
                             </div>
                           </div>
@@ -184,9 +184,9 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
                             <div className="sm:col-span-2">
                               <Field name="type" type="select">
                                 {({
-                                    field,
-                                    form: { setFieldValue }
-                                  }: FieldProps) => (
+                                  field,
+                                  form: { setFieldValue }
+                                }: FieldProps) => (
                                   <Select
                                     {...field}
                                     isClearable={true}
@@ -232,10 +232,10 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
                             </div>
                           </div>
 
-                          <SwitchGroupWide name="enabled" label="Enabled"/>
+                          <SwitchGroupWide name="enabled" label="Enabled" />
                         </div>
 
-                        <ListTypeForm listType={values.type} clients={clients ?? []}/>
+                        <ListTypeForm listType={values.type} clients={clients ?? []} />
 
                         <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
                           <div className="border-t border-gray-200 dark:border-gray-700 py-4">
@@ -267,7 +267,7 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
                         </div>
                       </div>
 
-                      <DEBUG values={values}/>
+                      <DEBUG values={values} />
                     </Form>
                   )}
                 </Formik>
@@ -300,7 +300,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ListKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`${data.name} was updated successfully`} t={t}/>);
+      toast.custom((t) => <Toast type="success" body={`${data.name} was updated successfully`} t={t} />);
 
       sleep(1500);
       toggle();
@@ -314,7 +314,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ListKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`${data.name} was deleted.`} t={t}/>);
+      toast.custom((t) => <Toast type="success" body={`${data.name} was deleted.`} t={t} />);
     }
   });
 
@@ -371,7 +371,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
                     include_alternate_titles: data.include_alternate_titles,
                   }}
                   onSubmit={onSubmit}
-                  // validate={validate}
+                // validate={validate}
                 >
                   {({ values }) => (
                     <Form className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto">
@@ -393,7 +393,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
                                 onClick={toggle}
                               >
                                 <span className="sr-only">Close panel</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
+                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
                               </button>
                             </div>
                           </div>
@@ -401,14 +401,14 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
 
                         <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
 
-                          <TextFieldWide name="name" label="Name" required={true}/>
+                          <TextFieldWide name="name" label="Name" required={true} />
 
                           <TextFieldWide name="type" label="Type" required={true} disabled={true} />
 
-                          <SwitchGroupWide name="enabled" label="Enabled"/>
+                          <SwitchGroupWide name="enabled" label="Enabled" />
 
                           <div className="space-y-2 divide-y divide-gray-200 dark:divide-gray-700">
-                            <ListTypeForm listType={values.type} clients={clientsQuery.data ?? []}/>
+                            <ListTypeForm listType={values.type} clients={clientsQuery.data ?? []} />
                           </div>
 
                           <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
@@ -425,7 +425,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
                               <ListFilterMultiSelectField name="filters" label="Filters" options={filterQuery.data?.map(f => ({
                                 value: f.id,
                                 label: f.name
-                              })) ?? []}/>
+                              })) ?? []} />
 
                             </div>
                           </div>
@@ -443,19 +443,19 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
                             Remove
                           </button>
                           <div className="flex space-x-3">
-                          <button
-                            type="button"
-                            className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={toggle}
-                          >
-                            Cancel
-                          </button>
-                          <SubmitButton isPending={mutation.isPending} isError={mutation.isError} isSuccess={mutation.isSuccess} />
+                            <button
+                              type="button"
+                              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                              onClick={toggle}
+                            >
+                              Cancel
+                            </button>
+                            <SubmitButton isPending={mutation.isPending} isError={mutation.isError} isSuccess={mutation.isSuccess} />
                           </div>
                         </div>
                       </div>
 
-                      <DEBUG values={values}/>
+                      <DEBUG values={values} />
                     </Form>
                   )}
                 </Formik>
@@ -622,17 +622,17 @@ function ListTypeArr({ listType, clients }: ListTypeFormProps) {
           <ListArrTagsMultiSelectField name="tags_included" label="Tags Included" options={arrTagsQuery.data?.map(f => ({
             value: f.label,
             label: f.label
-          })) ?? []}/>
+          })) ?? []} />
 
           <ListArrTagsMultiSelectField name="tags_excluded" label="Tags Excluded" options={arrTagsQuery.data?.map(f => ({
             value: f.label,
             label: f.label
-          })) ?? []}/>
+          })) ?? []} />
         </>
       )}
 
       <div className="space-y-1">
-        <FilterOptionCheckBoxes listType={listType} clients={[]}/>
+        <FilterOptionCheckBoxes listType={listType} clients={[]} />
       </div>
     </div>
   )
@@ -689,8 +689,8 @@ function ListTypePlainText() {
         </p>
       </div>
 
-      <TextFieldWide 
-        name="url" 
+      <TextFieldWide
+        name="url"
         label="List URL"
         help="URL to a plain text file with one item per line"
         placeholder="https://example.com/list.txt"
@@ -718,7 +718,7 @@ function ListTypeSteam() {
         </p>
       </div>
 
-      <TextFieldWide name="url" label="URL" help={"Steam Wishlist URL"} placeholder="https://store.steampowered.com/wishlist/id/USERNAME/wishlistdata"/>
+      <TextFieldWide name="url" label="URL" help={"Steam Wishlist URL"} placeholder="https://store.steampowered.com/wishlist/id/USERNAME/wishlistdata" />
     </div>
   )
 }
@@ -803,10 +803,10 @@ function DownloadClientSelectCustom({ name, clientType, clients }: DownloadClien
       <div className="sm:col-span-2">
         <Field name={name} type="select">
           {({
-              field,
-              meta,
-              form: { setFieldValue }
-            }: FieldProps) => (
+            field,
+            meta,
+            form: { setFieldValue }
+          }: FieldProps) => (
             <Listbox
               value={field.value}
               onChange={(value) => setFieldValue(field?.name, value)}
@@ -819,16 +819,16 @@ function DownloadClientSelectCustom({ name, clientType, clients }: DownloadClien
                   <div className="relative">
                     <ListboxButton
                       className="block w-full shadow-sm sm:text-sm rounded-md border py-2 pl-3 pr-10 text-left focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-815 dark:text-gray-100">
-                    <span className="block truncate">
-                      {field.value
-                        ? clients.find((c) => c.id === field.value)?.name
-                        : "Choose a client"}
-                    </span>
+                      <span className="block truncate">
+                        {field.value
+                          ? clients.find((c) => c.id === field.value)?.name
+                          : "Choose a client"}
+                      </span>
                       <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                      <ChevronUpDownIcon
-                        className="h-5 w-5 text-gray-400 dark:text-gray-300"
-                        aria-hidden="true"/>
-                    </span>
+                        <ChevronUpDownIcon
+                          className="h-5 w-5 text-gray-400 dark:text-gray-300"
+                          aria-hidden="true" />
+                      </span>
                     </ListboxButton>
 
                     <Transition
@@ -857,14 +857,14 @@ function DownloadClientSelectCustom({ name, clientType, clients }: DownloadClien
                             >
                               {({ selected, focus }) => (
                                 <>
-                                <span
-                                  className={classNames(
-                                    selected ? "font-semibold" : "font-normal",
-                                    "block truncate"
-                                  )}
-                                >
-                                  {client.name}
-                                </span>
+                                  <span
+                                    className={classNames(
+                                      selected ? "font-semibold" : "font-normal",
+                                      "block truncate"
+                                    )}
+                                  >
+                                    {client.name}
+                                  </span>
 
                                   {selected ? (
                                     <span
@@ -873,10 +873,10 @@ function DownloadClientSelectCustom({ name, clientType, clients }: DownloadClien
                                         "absolute inset-y-0 right-0 flex items-center pr-4"
                                       )}
                                     >
-                                    <CheckIcon
-                                      className="h-5 w-5"
-                                      aria-hidden="true"/>
-                                  </span>
+                                      <CheckIcon
+                                        className="h-5 w-5"
+                                        aria-hidden="true" />
+                                    </span>
                                   ) : null}
                                 </>
                               )}
@@ -926,9 +926,9 @@ export function ListArrTagsMultiSelectField({ name, label, help, tooltip, option
       <div className="sm:col-span-2">
         <Field name={name} type="select">
           {({
-              field,
-              form: { setFieldValue }
-            }: FieldProps) => (
+            field,
+            form: { setFieldValue }
+          }: FieldProps) => (
             <>
               <RMSC
                 {...field}

--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -83,7 +83,7 @@ function FormFieldsLunaSea() {
           Settings
         </DialogTitle>
         <p className="text-sm text-gray-500 dark:text-gray-400">
-          LunaSea offers notifications across all devices linked to your account (User-Based) or to a single device without an account, using a unique webhook per device (Device-Based).
+        LunaSea offers notifications across all devices linked to your account (User-Based) or to a single device without an account, using a unique webhook per device (Device-Based).
         </p>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {"Read the "}
@@ -308,8 +308,8 @@ const componentMap: componentMapType = {
 };
 
 interface NotificationAddFormValues {
-  name: string;
-  enabled: boolean;
+    name: string;
+    enabled: boolean;
 }
 
 export function NotificationAddForm({ isOpen, toggle }: AddFormProps) {
@@ -585,7 +585,7 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: NotificationKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`${notification.name} was updated successfully`} t={t} />);
+      toast.custom((t) => <Toast type="success" body={`${notification.name} was updated successfully`} t={t}/>);
       toggle();
     }
   });
@@ -597,7 +597,7 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: NotificationKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`${notification.name} was deleted.`} t={t} />);
+      toast.custom((t) => <Toast type="success" body={`${notification.name} was deleted.`} t={t}/>);
     }
   });
 
@@ -641,7 +641,7 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
     >
       {(values) => (
         <div>
-          <TextFieldWide name="name" label="Name" required={true} />
+          <TextFieldWide name="name" label="Name" required={true}/>
 
           <div className="space-y-2 divide-y divide-gray-200 dark:divide-gray-700">
             <div className="py-4 flex items-center justify-between space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-4">
@@ -694,7 +694,7 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
                 </Field>
               </div>
             </div>
-            <SwitchGroupWide name="enabled" label="Enabled" />
+            <SwitchGroupWide name="enabled" label="Enabled"/>
             <div className="border-t border-gray-200 dark:border-gray-700 py-4">
               <div className="px-4 space-y-1">
                 <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">

--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -83,7 +83,7 @@ function FormFieldsLunaSea() {
           Settings
         </DialogTitle>
         <p className="text-sm text-gray-500 dark:text-gray-400">
-        LunaSea offers notifications across all devices linked to your account (User-Based) or to a single device without an account, using a unique webhook per device (Device-Based).
+          LunaSea offers notifications across all devices linked to your account (User-Based) or to a single device without an account, using a unique webhook per device (Device-Based).
         </p>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {"Read the "}
@@ -308,8 +308,8 @@ const componentMap: componentMapType = {
 };
 
 interface NotificationAddFormValues {
-    name: string;
-    enabled: boolean;
+  name: string;
+  enabled: boolean;
 }
 
 export function NotificationAddForm({ isOpen, toggle }: AddFormProps) {
@@ -585,7 +585,7 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: NotificationKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`${notification.name} was updated successfully`} t={t}/>);
+      toast.custom((t) => <Toast type="success" body={`${notification.name} was updated successfully`} t={t} />);
       toggle();
     }
   });
@@ -597,7 +597,7 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: NotificationKeys.lists() });
 
-      toast.custom((t) => <Toast type="success" body={`${notification.name} was deleted.`} t={t}/>);
+      toast.custom((t) => <Toast type="success" body={`${notification.name} was deleted.`} t={t} />);
     }
   });
 
@@ -641,7 +641,7 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
     >
       {(values) => (
         <div>
-          <TextFieldWide name="name" label="Name" required={true}/>
+          <TextFieldWide name="name" label="Name" required={true} />
 
           <div className="space-y-2 divide-y divide-gray-200 dark:divide-gray-700">
             <div className="py-4 flex items-center justify-between space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-4">
@@ -694,7 +694,7 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
                 </Field>
               </div>
             </div>
-            <SwitchGroupWide name="enabled" label="Enabled"/>
+            <SwitchGroupWide name="enabled" label="Enabled" />
             <div className="border-t border-gray-200 dark:border-gray-700 py-4">
               <div className="px-4 space-y-1">
                 <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">

--- a/web/src/forms/settings/ReleaseForms.tsx
+++ b/web/src/forms/settings/ReleaseForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -68,7 +68,7 @@ export function ReleaseProfileDuplicateAddForm({ isOpen, toggle }: AddFormProps)
     >
       {() => (
         <div className="py-2 space-y-6 sm:py-0 sm:space-y-0 divide-y divide-gray-200 dark:divide-gray-700">
-          <TextFieldWide required name="name" label="Name" />
+          <TextFieldWide required name="name" label="Name"/>
 
           <SwitchGroupWide name="release_name" label="Release name" description="Full release name" />
           <SwitchGroupWide name="hash" label="Hash" description="Normalized hash of the release name. Use with Release name for exact match" />
@@ -168,7 +168,7 @@ export function ReleaseProfileDuplicateUpdateForm({ isOpen, toggle, data: profil
     >
       {() => (
         <div className="py-2 space-y-6 sm:py-0 sm:space-y-0 divide-y divide-gray-200 dark:divide-gray-700">
-          <TextFieldWide required name="name" label="Name" />
+          <TextFieldWide required name="name" label="Name"/>
 
           <SwitchGroupWide name="release_name" label="Release name" description="Full release name" />
           <SwitchGroupWide name="hash" label="Hash" description="Normalized hash of the release name. Use with Release name for exact match" />

--- a/web/src/forms/settings/ReleaseForms.tsx
+++ b/web/src/forms/settings/ReleaseForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -68,7 +68,7 @@ export function ReleaseProfileDuplicateAddForm({ isOpen, toggle }: AddFormProps)
     >
       {() => (
         <div className="py-2 space-y-6 sm:py-0 sm:space-y-0 divide-y divide-gray-200 dark:divide-gray-700">
-          <TextFieldWide required name="name" label="Name"/>
+          <TextFieldWide required name="name" label="Name" />
 
           <SwitchGroupWide name="release_name" label="Release name" description="Full release name" />
           <SwitchGroupWide name="hash" label="Hash" description="Normalized hash of the release name. Use with Release name for exact match" />
@@ -168,7 +168,7 @@ export function ReleaseProfileDuplicateUpdateForm({ isOpen, toggle, data: profil
     >
       {() => (
         <div className="py-2 space-y-6 sm:py-0 sm:space-y-0 divide-y divide-gray-200 dark:divide-gray-700">
-          <TextFieldWide required name="name" label="Name"/>
+          <TextFieldWide required name="name" label="Name" />
 
           <SwitchGroupWide name="release_name" label="Release name" description="Full release name" />
           <SwitchGroupWide name="hash" label="Hash" description="Normalized hash of the release name. Use with Release name for exact match" />

--- a/web/src/forms/settings/ReleaseForms.tsx
+++ b/web/src/forms/settings/ReleaseForms.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/hooks/hooks.ts
+++ b/web/src/hooks/hooks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/hooks/hooks.ts
+++ b/web/src/hooks/hooks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -13,7 +13,7 @@ import { App } from "./App";
 import { InitializeGlobalContext } from "./utils/Context";
 
 declare global {
-  interface Window { APP: APP; }
+    interface Window { APP: APP; }
 }
 
 window.APP = window.APP || {};

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -13,7 +13,7 @@ import { App } from "./App";
 import { InitializeGlobalContext } from "./utils/Context";
 
 declare global {
-    interface Window { APP: APP; }
+  interface Window { APP: APP; }
 }
 
 window.APP = window.APP || {};

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/Dashboard.tsx
+++ b/web/src/screens/Dashboard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/Dashboard.tsx
+++ b/web/src/screens/Dashboard.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/Logs.tsx
+++ b/web/src/screens/Logs.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/Logs.tsx
+++ b/web/src/screens/Logs.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/Releases.tsx
+++ b/web/src/screens/Releases.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/Releases.tsx
+++ b/web/src/screens/Releases.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/Settings.tsx
+++ b/web/src/screens/Settings.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -60,7 +60,7 @@ function SubNavLink({ item }: NavLinkProps) {
       activeOptions={{ exact: item.exact }}
       search={{}}
       params={{}}
-      // aria-current={splitLocation[2] === item.href ? "page" : undefined}
+    // aria-current={splitLocation[2] === item.href ? "page" : undefined}
     >
       {({ isActive }) => {
         return (
@@ -110,8 +110,8 @@ export function Settings() {
       <div className="max-w-screen-xl mx-auto pb-6 px-2 sm:px-6 lg:pb-16 lg:px-8">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-table border border-gray-250 dark:border-gray-775">
           <div className="lg:grid lg:grid-cols-12">
-            <SidebarNav subNavigation={subNavigation}/>
-              <Outlet />
+            <SidebarNav subNavigation={subNavigation} />
+            <Outlet />
           </div>
         </div>
       </div>

--- a/web/src/screens/Settings.tsx
+++ b/web/src/screens/Settings.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -60,7 +60,7 @@ function SubNavLink({ item }: NavLinkProps) {
       activeOptions={{ exact: item.exact }}
       search={{}}
       params={{}}
-    // aria-current={splitLocation[2] === item.href ? "page" : undefined}
+      // aria-current={splitLocation[2] === item.href ? "page" : undefined}
     >
       {({ isActive }) => {
         return (
@@ -110,8 +110,8 @@ export function Settings() {
       <div className="max-w-screen-xl mx-auto pb-6 px-2 sm:px-6 lg:pb-16 lg:px-8">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-table border border-gray-250 dark:border-gray-775">
           <div className="lg:grid lg:grid-cols-12">
-            <SidebarNav subNavigation={subNavigation} />
-            <Outlet />
+            <SidebarNav subNavigation={subNavigation}/>
+              <Outlet />
           </div>
         </div>
       </div>

--- a/web/src/screens/Settings.tsx
+++ b/web/src/screens/Settings.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/auth/Login.tsx
+++ b/web/src/screens/auth/Login.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/auth/Login.tsx
+++ b/web/src/screens/auth/Login.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/auth/Onboarding.tsx
+++ b/web/src/screens/auth/Onboarding.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/auth/Onboarding.tsx
+++ b/web/src/screens/auth/Onboarding.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/auth/index.ts
+++ b/web/src/screens/auth/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/auth/index.ts
+++ b/web/src/screens/auth/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/dashboard/ActivityTable.tsx
+++ b/web/src/screens/dashboard/ActivityTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -36,7 +36,7 @@ function Table({ columns, data }: TableProps) {
       <div
         className="mt-4 mb-2 bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-table rounded-md overflow-auto">
         <div className="flex items-center justify-center py-16">
-          <EmptyListState text="No recent activity"/>
+          <EmptyListState text="No recent activity" />
         </div>
       </div>
     )
@@ -65,7 +65,7 @@ function Table({ columns, data }: TableProps) {
                         )}
                     </div>
                   </th>
-                  )
+                )
                 )}
               </tr>
             ))}
@@ -128,7 +128,7 @@ export const ActivityTable = () => {
           Recent activity
         </h3>
         <div className="animate-pulse text-black dark:text-white">
-          <EmptyListState text="Loading..."/>
+          <EmptyListState text="Loading..." />
         </div>
       </div>
     );
@@ -160,7 +160,7 @@ export const ActivityTable = () => {
         Recent activity
       </h3>
 
-      <Table columns={columns} data={displayData}/>
+      <Table columns={columns} data={displayData} />
 
       <button
         onClick={toggleReleaseNames}
@@ -169,9 +169,9 @@ export const ActivityTable = () => {
         title="Go incognito"
       >
         {showLinuxIsos ? (
-          <EyeIcon className="h-4 w-4"/>
+          <EyeIcon className="h-4 w-4" />
         ) : (
-          <EyeSlashIcon className="h-4 w-4"/>
+          <EyeSlashIcon className="h-4 w-4" />
         )}
       </button>
     </div>

--- a/web/src/screens/dashboard/ActivityTable.tsx
+++ b/web/src/screens/dashboard/ActivityTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -36,7 +36,7 @@ function Table({ columns, data }: TableProps) {
       <div
         className="mt-4 mb-2 bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-table rounded-md overflow-auto">
         <div className="flex items-center justify-center py-16">
-          <EmptyListState text="No recent activity" />
+          <EmptyListState text="No recent activity"/>
         </div>
       </div>
     )
@@ -65,7 +65,7 @@ function Table({ columns, data }: TableProps) {
                         )}
                     </div>
                   </th>
-                )
+                  )
                 )}
               </tr>
             ))}
@@ -128,7 +128,7 @@ export const ActivityTable = () => {
           Recent activity
         </h3>
         <div className="animate-pulse text-black dark:text-white">
-          <EmptyListState text="Loading..." />
+          <EmptyListState text="Loading..."/>
         </div>
       </div>
     );
@@ -160,7 +160,7 @@ export const ActivityTable = () => {
         Recent activity
       </h3>
 
-      <Table columns={columns} data={displayData} />
+      <Table columns={columns} data={displayData}/>
 
       <button
         onClick={toggleReleaseNames}
@@ -169,9 +169,9 @@ export const ActivityTable = () => {
         title="Go incognito"
       >
         {showLinuxIsos ? (
-          <EyeIcon className="h-4 w-4" />
+          <EyeIcon className="h-4 w-4"/>
         ) : (
-          <EyeSlashIcon className="h-4 w-4" />
+          <EyeSlashIcon className="h-4 w-4"/>
         )}
       </button>
     </div>

--- a/web/src/screens/dashboard/ActivityTable.tsx
+++ b/web/src/screens/dashboard/ActivityTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/dashboard/Stats.tsx
+++ b/web/src/screens/dashboard/Stats.tsx
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery} from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { classNames } from "@utils";
 import { LinkIcon } from "@heroicons/react/24/solid";
@@ -57,8 +57,8 @@ export const Stats = () => {
         <StatsItem name="Filtered Releases" to="/releases" value={data?.filtered_count ?? 0} />
         {/* <StatsItem name="Filter Rejected Releases" stat={data?.filter_rejected_count} /> */}
         <StatsItem name="Approved Pushes" to="/releases" eventType="PUSH_APPROVED" value={data?.push_approved_count ?? 0} />
-        <StatsItem name="Rejected Pushes" to="/releases" eventType="PUSH_REJECTED" value={data?.push_rejected_count ?? 0} />
-        <StatsItem name="Errored Pushes" to="/releases" eventType="PUSH_ERROR" value={data?.push_error_count ?? 0} />
+        <StatsItem name="Rejected Pushes" to="/releases" eventType="PUSH_REJECTED" value={data?.push_rejected_count ?? 0 } />
+        <StatsItem name="Errored Pushes" to="/releases" eventType="PUSH_ERROR"  value={data?.push_error_count ?? 0} />
       </dl>
     </div>
   );

--- a/web/src/screens/dashboard/Stats.tsx
+++ b/web/src/screens/dashboard/Stats.tsx
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useQuery} from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { classNames } from "@utils";
 import { LinkIcon } from "@heroicons/react/24/solid";
@@ -57,8 +57,8 @@ export const Stats = () => {
         <StatsItem name="Filtered Releases" to="/releases" value={data?.filtered_count ?? 0} />
         {/* <StatsItem name="Filter Rejected Releases" stat={data?.filter_rejected_count} /> */}
         <StatsItem name="Approved Pushes" to="/releases" eventType="PUSH_APPROVED" value={data?.push_approved_count ?? 0} />
-        <StatsItem name="Rejected Pushes" to="/releases" eventType="PUSH_REJECTED" value={data?.push_rejected_count ?? 0 } />
-        <StatsItem name="Errored Pushes" to="/releases" eventType="PUSH_ERROR"  value={data?.push_error_count ?? 0} />
+        <StatsItem name="Rejected Pushes" to="/releases" eventType="PUSH_REJECTED" value={data?.push_rejected_count ?? 0} />
+        <StatsItem name="Errored Pushes" to="/releases" eventType="PUSH_ERROR" value={data?.push_error_count ?? 0} />
       </dl>
     </div>
   );

--- a/web/src/screens/dashboard/Stats.tsx
+++ b/web/src/screens/dashboard/Stats.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/Details.tsx
+++ b/web/src/screens/filters/Details.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -55,20 +55,20 @@ function TabNavLink({ item }: NavLinkProps) {
       activeOptions={{ exact: item.exact }}
       search={{}}
       params={{}}
-      // aria-current={splitLocation[2] === item.href ? "page" : undefined}
-      // className="transition border-b-2 whitespace-nowrap py-4 duration-3000 px-1 font-medium text-sm first:rounded-tl-lg last:rounded-tr-lg"
+    // aria-current={splitLocation[2] === item.href ? "page" : undefined}
+    // className="transition border-b-2 whitespace-nowrap py-4 duration-3000 px-1 font-medium text-sm first:rounded-tl-lg last:rounded-tr-lg"
     >
       {({ isActive }) => {
         return (
           <span
             className={
-            classNames(
-              "transition border-b-2 whitespace-nowrap py-4 duration-3000 px-1 font-medium text-sm first:rounded-tl-lg last:rounded-tr-lg",
-              isActive
-                ? "text-blue-600 dark:text-white border-blue-600 dark:border-blue-500"
-                : "text-gray-550 hover:text-blue-500 dark:hover:text-white border-transparent"
-            )
-          }>
+              classNames(
+                "transition border-b-2 whitespace-nowrap py-4 duration-3000 px-1 font-medium text-sm first:rounded-tl-lg last:rounded-tr-lg",
+                isActive
+                  ? "text-blue-600 dark:text-white border-blue-600 dark:border-blue-500"
+                  : "text-gray-550 hover:text-blue-500 dark:hover:text-white border-transparent"
+              )
+            }>
             {item.name}
           </span>
         )
@@ -306,7 +306,7 @@ export const FilterDetails = () => {
   const navigate = useNavigate();
 
   const filterGetByIdRoute = getRouteApi("/auth/authenticated-routes/filters/$filterId");
-  const { queryClient } =  filterGetByIdRoute.useRouteContext();
+  const { queryClient } = filterGetByIdRoute.useRouteContext();
 
   const params = filterGetByIdRoute.useParams()
   const filterQuery = useSuspenseQuery(FilterByIdQueryOptions(params.filterId))
@@ -381,7 +381,7 @@ export const FilterDetails = () => {
           <div className="rounded-t-lg bg-gray-125 dark:bg-gray-850 border-b border-gray-200 dark:border-gray-750">
             <nav className="px-4 py-4 -mb-px flex space-x-6 sm:space-x-8 overflow-x-auto">
               {tabs.map((tab) => (
-                <TabNavLink key={tab.href} item={tab}  />
+                <TabNavLink key={tab.href} item={tab} />
               ))}
             </nav>
           </div>

--- a/web/src/screens/filters/Details.tsx
+++ b/web/src/screens/filters/Details.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/Details.tsx
+++ b/web/src/screens/filters/Details.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -55,20 +55,20 @@ function TabNavLink({ item }: NavLinkProps) {
       activeOptions={{ exact: item.exact }}
       search={{}}
       params={{}}
-    // aria-current={splitLocation[2] === item.href ? "page" : undefined}
-    // className="transition border-b-2 whitespace-nowrap py-4 duration-3000 px-1 font-medium text-sm first:rounded-tl-lg last:rounded-tr-lg"
+      // aria-current={splitLocation[2] === item.href ? "page" : undefined}
+      // className="transition border-b-2 whitespace-nowrap py-4 duration-3000 px-1 font-medium text-sm first:rounded-tl-lg last:rounded-tr-lg"
     >
       {({ isActive }) => {
         return (
           <span
             className={
-              classNames(
-                "transition border-b-2 whitespace-nowrap py-4 duration-3000 px-1 font-medium text-sm first:rounded-tl-lg last:rounded-tr-lg",
-                isActive
-                  ? "text-blue-600 dark:text-white border-blue-600 dark:border-blue-500"
-                  : "text-gray-550 hover:text-blue-500 dark:hover:text-white border-transparent"
-              )
-            }>
+            classNames(
+              "transition border-b-2 whitespace-nowrap py-4 duration-3000 px-1 font-medium text-sm first:rounded-tl-lg last:rounded-tr-lg",
+              isActive
+                ? "text-blue-600 dark:text-white border-blue-600 dark:border-blue-500"
+                : "text-gray-550 hover:text-blue-500 dark:hover:text-white border-transparent"
+            )
+          }>
             {item.name}
           </span>
         )
@@ -306,7 +306,7 @@ export const FilterDetails = () => {
   const navigate = useNavigate();
 
   const filterGetByIdRoute = getRouteApi("/auth/authenticated-routes/filters/$filterId");
-  const { queryClient } = filterGetByIdRoute.useRouteContext();
+  const { queryClient } =  filterGetByIdRoute.useRouteContext();
 
   const params = filterGetByIdRoute.useParams()
   const filterQuery = useSuspenseQuery(FilterByIdQueryOptions(params.filterId))
@@ -381,7 +381,7 @@ export const FilterDetails = () => {
           <div className="rounded-t-lg bg-gray-125 dark:bg-gray-850 border-b border-gray-200 dark:border-gray-750">
             <nav className="px-4 py-4 -mb-px flex space-x-6 sm:space-x-8 overflow-x-auto">
               {tabs.map((tab) => (
-                <TabNavLink key={tab.href} item={tab} />
+                <TabNavLink key={tab.href} item={tab}  />
               ))}
             </nav>
           </div>

--- a/web/src/screens/filters/Importer.tsx
+++ b/web/src/screens/filters/Importer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/Importer.tsx
+++ b/web/src/screens/filters/Importer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/List.tsx
+++ b/web/src/screens/filters/List.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -66,27 +66,27 @@ type Actions =
 
 const FilterListReducer = (state: FilterListState, action: Actions): FilterListState => {
   switch (action.type) {
-    case ActionType.INDEXER_FILTER_CHANGE: {
-      return { ...state, indexerFilter: action.payload };
-    }
-    case ActionType.INDEXER_FILTER_RESET: {
-      return { ...state, indexerFilter: [] };
-    }
-    case ActionType.SORT_ORDER_CHANGE: {
-      return { ...state, sortOrder: action.payload };
-    }
-    case ActionType.SORT_ORDER_RESET: {
-      return { ...state, sortOrder: "" };
-    }
-    case ActionType.STATUS_CHANGE: {
-      return { ...state, status: action.payload };
-    }
-    case ActionType.STATUS_RESET: {
-      return { ...state, status: "" };
-    }
-    default: {
-      throw new Error(`Unhandled action type: ${action}`);
-    }
+  case ActionType.INDEXER_FILTER_CHANGE: {
+    return { ...state, indexerFilter: action.payload };
+  }
+  case ActionType.INDEXER_FILTER_RESET: {
+    return { ...state, indexerFilter: [] };
+  }
+  case ActionType.SORT_ORDER_CHANGE: {
+    return { ...state, sortOrder: action.payload };
+  }
+  case ActionType.SORT_ORDER_RESET: {
+    return { ...state, sortOrder: "" };
+  }
+  case ActionType.STATUS_CHANGE: {
+    return { ...state, status: action.payload };
+  }
+  case ActionType.STATUS_RESET: {
+    return { ...state, status: "" };
+  }
+  default: {
+    throw new Error(`Unhandled action type: ${action}`);
+  }
   }
 };
 
@@ -223,17 +223,17 @@ function FilterList({ toggleCreateFilter }: any) {
         </div>
 
         {isLoading
-          ? <div className="flex items-center justify-center py-64"><RingResizeSpinner className="text-blue-500 size-24" /></div>
+          ? <div className="flex items-center justify-center py-64"><RingResizeSpinner className="text-blue-500 size-24"/></div>
           : data && data.length > 0 ? (
-            <ul className="min-w-full divide-y divide-gray-150 dark:divide-gray-775">
-              {filtered.filtered.length > 0
-                ? filtered.filtered.map((filter: Filter, idx) => <FilterListItem filter={filter} key={filter.id} idx={idx} />)
-                : <EmptyListState text={`No ${status} filters`} />
-              }
-            </ul>
-          ) : (
-            <EmptyListState text="No filters here.." buttonText="Add new" buttonOnClick={toggleCreateFilter} />
-          )
+              <ul className="min-w-full divide-y divide-gray-150 dark:divide-gray-775">
+                {filtered.filtered.length > 0
+                  ? filtered.filtered.map((filter: Filter, idx) => <FilterListItem filter={filter} key={filter.id} idx={idx}/>)
+                  : <EmptyListState text={`No ${status} filters`}/>
+                }
+              </ul>
+            ) : (
+              <EmptyListState text="No filters here.." buttonText="Add new" buttonOnClick={toggleCreateFilter}/>
+            )
         }
       </div>
     </div>
@@ -591,7 +591,7 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
           }}
           className="transition flex items-center w-full break-words whitespace-wrap text-sm font-bold text-gray-800 dark:text-gray-100 hover:text-black dark:hover:text-gray-350"
         >
-          {filter.name} {filter.is_auto_updated && <SparklesIcon title="This filter is automatically updated by a list" className="ml-1 w-4 h-4 text-amber-500 dark:text-amber-400" aria-hidden="true" />}
+          {filter.name} {filter.is_auto_updated && <SparklesIcon title="This filter is automatically updated by a list" className="ml-1 w-4 h-4 text-amber-500 dark:text-amber-400" aria-hidden="true"/>}
         </Link>
         <div className="flex items-center flex-wrap">
           <span className="mr-2 break-words whitespace-nowrap text-xs font-medium text-gray-600 dark:text-gray-400">
@@ -611,7 +611,7 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
                     className="flex items-center cursor-pointer hover:text-black dark:hover:text-gray-300"
                   >
                     <span className={filter.actions_count === 0 || filter.actions_enabled_count === 0 ? "text-red-500 hover:text-red-400 dark:hover:text-red-400" : ""}>
-                      Actions: {filter.actions_enabled_count}/{filter.actions_count}
+          Actions: {filter.actions_enabled_count}/{filter.actions_count}
                     </span>
                   </Link>
                 }
@@ -635,7 +635,7 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
                 className="flex items-center cursor-pointer hover:text-black dark:hover:text-gray-300"
               >
                 <span>
-                  Actions: {filter.actions_enabled_count}/{filter.actions_count}
+          Actions: {filter.actions_enabled_count}/{filter.actions_count}
                 </span>
               </Link>
             )}

--- a/web/src/screens/filters/List.tsx
+++ b/web/src/screens/filters/List.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -66,27 +66,27 @@ type Actions =
 
 const FilterListReducer = (state: FilterListState, action: Actions): FilterListState => {
   switch (action.type) {
-  case ActionType.INDEXER_FILTER_CHANGE: {
-    return { ...state, indexerFilter: action.payload };
-  }
-  case ActionType.INDEXER_FILTER_RESET: {
-    return { ...state, indexerFilter: [] };
-  }
-  case ActionType.SORT_ORDER_CHANGE: {
-    return { ...state, sortOrder: action.payload };
-  }
-  case ActionType.SORT_ORDER_RESET: {
-    return { ...state, sortOrder: "" };
-  }
-  case ActionType.STATUS_CHANGE: {
-    return { ...state, status: action.payload };
-  }
-  case ActionType.STATUS_RESET: {
-    return { ...state, status: "" };
-  }
-  default: {
-    throw new Error(`Unhandled action type: ${action}`);
-  }
+    case ActionType.INDEXER_FILTER_CHANGE: {
+      return { ...state, indexerFilter: action.payload };
+    }
+    case ActionType.INDEXER_FILTER_RESET: {
+      return { ...state, indexerFilter: [] };
+    }
+    case ActionType.SORT_ORDER_CHANGE: {
+      return { ...state, sortOrder: action.payload };
+    }
+    case ActionType.SORT_ORDER_RESET: {
+      return { ...state, sortOrder: "" };
+    }
+    case ActionType.STATUS_CHANGE: {
+      return { ...state, status: action.payload };
+    }
+    case ActionType.STATUS_RESET: {
+      return { ...state, status: "" };
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action}`);
+    }
   }
 };
 
@@ -223,17 +223,17 @@ function FilterList({ toggleCreateFilter }: any) {
         </div>
 
         {isLoading
-          ? <div className="flex items-center justify-center py-64"><RingResizeSpinner className="text-blue-500 size-24"/></div>
+          ? <div className="flex items-center justify-center py-64"><RingResizeSpinner className="text-blue-500 size-24" /></div>
           : data && data.length > 0 ? (
-              <ul className="min-w-full divide-y divide-gray-150 dark:divide-gray-775">
-                {filtered.filtered.length > 0
-                  ? filtered.filtered.map((filter: Filter, idx) => <FilterListItem filter={filter} key={filter.id} idx={idx}/>)
-                  : <EmptyListState text={`No ${status} filters`}/>
-                }
-              </ul>
-            ) : (
-              <EmptyListState text="No filters here.." buttonText="Add new" buttonOnClick={toggleCreateFilter}/>
-            )
+            <ul className="min-w-full divide-y divide-gray-150 dark:divide-gray-775">
+              {filtered.filtered.length > 0
+                ? filtered.filtered.map((filter: Filter, idx) => <FilterListItem filter={filter} key={filter.id} idx={idx} />)
+                : <EmptyListState text={`No ${status} filters`} />
+              }
+            </ul>
+          ) : (
+            <EmptyListState text="No filters here.." buttonText="Add new" buttonOnClick={toggleCreateFilter} />
+          )
         }
       </div>
     </div>
@@ -591,7 +591,7 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
           }}
           className="transition flex items-center w-full break-words whitespace-wrap text-sm font-bold text-gray-800 dark:text-gray-100 hover:text-black dark:hover:text-gray-350"
         >
-          {filter.name} {filter.is_auto_updated && <SparklesIcon title="This filter is automatically updated by a list" className="ml-1 w-4 h-4 text-amber-500 dark:text-amber-400" aria-hidden="true"/>}
+          {filter.name} {filter.is_auto_updated && <SparklesIcon title="This filter is automatically updated by a list" className="ml-1 w-4 h-4 text-amber-500 dark:text-amber-400" aria-hidden="true" />}
         </Link>
         <div className="flex items-center flex-wrap">
           <span className="mr-2 break-words whitespace-nowrap text-xs font-medium text-gray-600 dark:text-gray-400">
@@ -611,7 +611,7 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
                     className="flex items-center cursor-pointer hover:text-black dark:hover:text-gray-300"
                   >
                     <span className={filter.actions_count === 0 || filter.actions_enabled_count === 0 ? "text-red-500 hover:text-red-400 dark:hover:text-red-400" : ""}>
-          Actions: {filter.actions_enabled_count}/{filter.actions_count}
+                      Actions: {filter.actions_enabled_count}/{filter.actions_count}
                     </span>
                   </Link>
                 }
@@ -635,7 +635,7 @@ function FilterListItem({ filter, idx }: FilterListItemProps) {
                 className="flex items-center cursor-pointer hover:text-black dark:hover:text-gray-300"
               >
                 <span>
-          Actions: {filter.actions_enabled_count}/{filter.actions_count}
+                  Actions: {filter.actions_enabled_count}/{filter.actions_count}
                 </span>
               </Link>
             )}

--- a/web/src/screens/filters/List.tsx
+++ b/web/src/screens/filters/List.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/NotFound.tsx
+++ b/web/src/screens/filters/NotFound.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -15,7 +15,7 @@ export const FilterNotFound = () => {
   return (
     <div className="mt-20 flex flex-col justify-center">
       <div className="flex justify-center">
-        <Logo className="h-24 sm:h-48"/>
+        <Logo className="h-24 sm:h-48" />
       </div>
       <h2 className="text-2xl text-center font-bold text-gray-900 dark:text-gray-200 my-8 px-2">
         Status 404

--- a/web/src/screens/filters/NotFound.tsx
+++ b/web/src/screens/filters/NotFound.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -15,7 +15,7 @@ export const FilterNotFound = () => {
   return (
     <div className="mt-20 flex flex-col justify-center">
       <div className="flex justify-center">
-        <Logo className="h-24 sm:h-48" />
+        <Logo className="h-24 sm:h-48"/>
       </div>
       <h2 className="text-2xl text-center font-bold text-gray-900 dark:text-gray-200 my-8 px-2">
         Status 404

--- a/web/src/screens/filters/NotFound.tsx
+++ b/web/src/screens/filters/NotFound.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/_configParser.ts
+++ b/web/src/screens/filters/_configParser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/_configParser.ts
+++ b/web/src/screens/filters/_configParser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/_const.ts
+++ b/web/src/screens/filters/_const.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/_const.ts
+++ b/web/src/screens/filters/_const.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/index.ts
+++ b/web/src/screens/filters/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/index.ts
+++ b/web/src/screens/filters/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/Actions.tsx
+++ b/web/src/screens/filters/sections/Actions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -147,40 +147,40 @@ const TypeForm = (props: ClientActionProps) => {
   }, [action.type, idx, prevActionType, setFieldValue]);
 
   switch (action.type) {
-    // torrent clients
-    case "QBITTORRENT":
-      return <QBittorrent {...props} />;
-    case "DELUGE_V1":
-    case "DELUGE_V2":
-      return <Deluge {...props} />;
-    case "RTORRENT":
-      return <RTorrent {...props} />;
-    case "TRANSMISSION":
-      return <Transmission {...props} />;
-    case "PORLA":
-      return <Porla {...props} />;
-    // arrs
-    case "RADARR":
-    case "SONARR":
-    case "LIDARR":
-    case "WHISPARR":
-    case "READARR":
-      return <Arr {...props} />;
-    // nzb
-    case "SABNZBD":
-      return <SABnzbd {...props} />;
-    // autobrr actions
-    case "TEST":
-      return <Test />;
-    case "EXEC":
-      return <Exec {...props} />;
-    case "WATCH_FOLDER":
-      return <WatchFolder {...props} />;
-    case "WEBHOOK":
-      return <WebHook {...props} />;
-    default:
-      // TODO(stacksmash76): Indicate error
-      return null;
+  // torrent clients
+  case "QBITTORRENT":
+    return <QBittorrent {...props} />;
+  case "DELUGE_V1":
+  case "DELUGE_V2":
+    return <Deluge {...props} />;
+  case "RTORRENT":
+    return <RTorrent {...props} />;
+  case "TRANSMISSION":
+    return <Transmission {...props} />;
+  case "PORLA":
+    return <Porla {...props} />;
+  // arrs
+  case "RADARR":
+  case "SONARR":
+  case "LIDARR":
+  case "WHISPARR":
+  case "READARR":
+    return <Arr {...props} />;
+  // nzb
+  case "SABNZBD":
+    return <SABnzbd {...props} />;
+  // autobrr actions
+  case "TEST":
+    return <Test />;
+  case "EXEC":
+    return <Exec {...props} />;
+  case "WATCH_FOLDER":
+    return <WatchFolder {...props} />;
+  case "WEBHOOK":
+    return <WebHook {...props} />;
+  default:
+    // TODO(stacksmash76): Indicate error
+    return null;
   }
 };
 

--- a/web/src/screens/filters/sections/Actions.tsx
+++ b/web/src/screens/filters/sections/Actions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -147,40 +147,40 @@ const TypeForm = (props: ClientActionProps) => {
   }, [action.type, idx, prevActionType, setFieldValue]);
 
   switch (action.type) {
-  // torrent clients
-  case "QBITTORRENT":
-    return <QBittorrent {...props} />;
-  case "DELUGE_V1":
-  case "DELUGE_V2":
-    return <Deluge {...props} />;
-  case "RTORRENT":
-    return <RTorrent {...props} />;
-  case "TRANSMISSION":
-    return <Transmission {...props} />;
-  case "PORLA":
-    return <Porla {...props} />;
-  // arrs
-  case "RADARR":
-  case "SONARR":
-  case "LIDARR":
-  case "WHISPARR":
-  case "READARR":
-    return <Arr {...props} />;
-  // nzb
-  case "SABNZBD":
-    return <SABnzbd {...props} />;
-  // autobrr actions
-  case "TEST":
-    return <Test />;
-  case "EXEC":
-    return <Exec {...props} />;
-  case "WATCH_FOLDER":
-    return <WatchFolder {...props} />;
-  case "WEBHOOK":
-    return <WebHook {...props} />;
-  default:
-    // TODO(stacksmash76): Indicate error
-    return null;
+    // torrent clients
+    case "QBITTORRENT":
+      return <QBittorrent {...props} />;
+    case "DELUGE_V1":
+    case "DELUGE_V2":
+      return <Deluge {...props} />;
+    case "RTORRENT":
+      return <RTorrent {...props} />;
+    case "TRANSMISSION":
+      return <Transmission {...props} />;
+    case "PORLA":
+      return <Porla {...props} />;
+    // arrs
+    case "RADARR":
+    case "SONARR":
+    case "LIDARR":
+    case "WHISPARR":
+    case "READARR":
+      return <Arr {...props} />;
+    // nzb
+    case "SABNZBD":
+      return <SABnzbd {...props} />;
+    // autobrr actions
+    case "TEST":
+      return <Test />;
+    case "EXEC":
+      return <Exec {...props} />;
+    case "WATCH_FOLDER":
+      return <WatchFolder {...props} />;
+    case "WEBHOOK":
+      return <WebHook {...props} />;
+    default:
+      // TODO(stacksmash76): Indicate error
+      return null;
   }
 };
 

--- a/web/src/screens/filters/sections/Actions.tsx
+++ b/web/src/screens/filters/sections/Actions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/Advanced.tsx
+++ b/web/src/screens/filters/sections/Advanced.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/Advanced.tsx
+++ b/web/src/screens/filters/sections/Advanced.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/External.tsx
+++ b/web/src/screens/filters/sections/External.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -252,121 +252,121 @@ interface TypeFormProps {
 
 const TypeForm = ({ external, idx }: TypeFormProps) => {
   switch (external.type) {
-    case "EXEC": {
-      return (
+  case "EXEC": {
+    return (
+      <FilterSection
+        title="Execute"
+        subtitle="Specify the executable, the argument and the expected exit status to run as a pre-filter"
+      >
+        <FilterLayout>
+          <TextAreaAutoResize
+            name={`external.${idx}.exec_cmd`}
+            label="Path to Executable"
+            columns={5}
+            placeholder="Absolute path to executable eg. /bin/test"
+            tooltip={
+              <div>
+                <p>
+                  For custom commands you should specify the full path to the binary/program
+                  you want to run. And you can include your own static variables:
+                </p>
+                <DocsLink href="https://autobrr.com/filters/actions#custom-commands--exec" />
+              </div>
+            }
+          />
+          <TextAreaAutoResize
+            name={`external.${idx}.exec_args`}
+            label="Exec Arguments"
+            columns={5}
+            placeholder={"Arguments eg. --test \"{{ .TorrentName }}\""}
+          />
+          <div className="col-span-12 sm:col-span-2">
+            <NumberField
+              name={`external.${idx}.exec_expect_status`}
+              label="Expected exit status"
+              placeholder="0"
+            />
+          </div>
+        </FilterLayout>
+      </FilterSection>
+    );
+  }
+  case "WEBHOOK": {
+    return (
+      <>
         <FilterSection
-          title="Execute"
-          subtitle="Specify the executable, the argument and the expected exit status to run as a pre-filter"
+          title="Request"
+          subtitle="Specify your request destination endpoint, headers and expected return status"
+        >
+          <FilterLayout>
+            <TextField
+              name={`external.${idx}.webhook_host`}
+              label="Endpoint"
+              columns={6}
+              placeholder="Host eg. http://localhost/webhook"
+              tooltip={<p>URL or IP to your API. Pass params and set API tokens etc.</p>}
+            />
+            <Select
+              name={`external.${idx}.webhook_method`}
+              label="HTTP method"
+              optionDefaultText="Select http method"
+              options={ExternalFilterWebhookMethodOptions}
+              tooltip={<div><p>Select the HTTP method for this webhook. Defaults to POST</p></div>}
+            />
+            <TextField
+              name={`external.${idx}.webhook_headers`}
+              label="HTTP Request Headers"
+              columns={6}
+              placeholder="HEADER=custom1,HEADER2=custom2"
+            />
+            <NumberField
+              name={`external.${idx}.webhook_expect_status`}
+              label="Expected HTTP status code"
+              placeholder="200"
+            />
+          </FilterLayout>
+        </FilterSection>
+        <FilterSection
+          title="Retry"
+          subtitle="Retry behavior on request failure"
+        >
+          <FilterLayout>
+            <TextField
+              name={`external.${idx}.webhook_retry_status`}
+              label="Retry http status code(s)"
+              placeholder="Retry on status eg. 202, 204"
+              columns={6}
+            />
+            <NumberField
+              name={`external.${idx}.webhook_retry_attempts`}
+              label="Maximum retry attempts"
+              placeholder="10"
+            />
+            <NumberField
+              name={`external.${idx}.webhook_retry_delay_seconds`}
+              label="Retry delay in seconds"
+              placeholder="1"
+            />
+          </FilterLayout>
+        </FilterSection>
+        <FilterSection
+          title="Payload"
+          subtitle="Specify your JSON payload"
         >
           <FilterLayout>
             <TextAreaAutoResize
-              name={`external.${idx}.exec_cmd`}
-              label="Path to Executable"
-              columns={5}
-              placeholder="Absolute path to executable eg. /bin/test"
-              tooltip={
-                <div>
-                  <p>
-                    For custom commands you should specify the full path to the binary/program
-                    you want to run. And you can include your own static variables:
-                  </p>
-                  <DocsLink href="https://autobrr.com/filters/actions#custom-commands--exec" />
-                </div>
-              }
+              name={`external.${idx}.webhook_data`}
+              label="Data (json)"
+              placeholder={"Request data: { \"key\": \"value\" }"}
             />
-            <TextAreaAutoResize
-              name={`external.${idx}.exec_args`}
-              label="Exec Arguments"
-              columns={5}
-              placeholder={"Arguments eg. --test \"{{ .TorrentName }}\""}
-            />
-            <div className="col-span-12 sm:col-span-2">
-              <NumberField
-                name={`external.${idx}.exec_expect_status`}
-                label="Expected exit status"
-                placeholder="0"
-              />
-            </div>
           </FilterLayout>
         </FilterSection>
-      );
-    }
-    case "WEBHOOK": {
-      return (
-        <>
-          <FilterSection
-            title="Request"
-            subtitle="Specify your request destination endpoint, headers and expected return status"
-          >
-            <FilterLayout>
-              <TextField
-                name={`external.${idx}.webhook_host`}
-                label="Endpoint"
-                columns={6}
-                placeholder="Host eg. http://localhost/webhook"
-                tooltip={<p>URL or IP to your API. Pass params and set API tokens etc.</p>}
-              />
-              <Select
-                name={`external.${idx}.webhook_method`}
-                label="HTTP method"
-                optionDefaultText="Select http method"
-                options={ExternalFilterWebhookMethodOptions}
-                tooltip={<div><p>Select the HTTP method for this webhook. Defaults to POST</p></div>}
-              />
-              <TextField
-                name={`external.${idx}.webhook_headers`}
-                label="HTTP Request Headers"
-                columns={6}
-                placeholder="HEADER=custom1,HEADER2=custom2"
-              />
-              <NumberField
-                name={`external.${idx}.webhook_expect_status`}
-                label="Expected HTTP status code"
-                placeholder="200"
-              />
-            </FilterLayout>
-          </FilterSection>
-          <FilterSection
-            title="Retry"
-            subtitle="Retry behavior on request failure"
-          >
-            <FilterLayout>
-              <TextField
-                name={`external.${idx}.webhook_retry_status`}
-                label="Retry http status code(s)"
-                placeholder="Retry on status eg. 202, 204"
-                columns={6}
-              />
-              <NumberField
-                name={`external.${idx}.webhook_retry_attempts`}
-                label="Maximum retry attempts"
-                placeholder="10"
-              />
-              <NumberField
-                name={`external.${idx}.webhook_retry_delay_seconds`}
-                label="Retry delay in seconds"
-                placeholder="1"
-              />
-            </FilterLayout>
-          </FilterSection>
-          <FilterSection
-            title="Payload"
-            subtitle="Specify your JSON payload"
-          >
-            <FilterLayout>
-              <TextAreaAutoResize
-                name={`external.${idx}.webhook_data`}
-                label="Data (json)"
-                placeholder={"Request data: { \"key\": \"value\" }"}
-              />
-            </FilterLayout>
-          </FilterSection>
-        </>
-      );
-    }
+      </>
+    );
+  }
 
-    default: {
-      return null;
-    }
+  default: {
+    return null;
+  }
   }
 };

--- a/web/src/screens/filters/sections/External.tsx
+++ b/web/src/screens/filters/sections/External.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/External.tsx
+++ b/web/src/screens/filters/sections/External.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -252,121 +252,121 @@ interface TypeFormProps {
 
 const TypeForm = ({ external, idx }: TypeFormProps) => {
   switch (external.type) {
-  case "EXEC": {
-    return (
-      <FilterSection
-        title="Execute"
-        subtitle="Specify the executable, the argument and the expected exit status to run as a pre-filter"
-      >
-        <FilterLayout>
-          <TextAreaAutoResize
-            name={`external.${idx}.exec_cmd`}
-            label="Path to Executable"
-            columns={5}
-            placeholder="Absolute path to executable eg. /bin/test"
-            tooltip={
-              <div>
-                <p>
-                  For custom commands you should specify the full path to the binary/program
-                  you want to run. And you can include your own static variables:
-                </p>
-                <DocsLink href="https://autobrr.com/filters/actions#custom-commands--exec" />
-              </div>
-            }
-          />
-          <TextAreaAutoResize
-            name={`external.${idx}.exec_args`}
-            label="Exec Arguments"
-            columns={5}
-            placeholder={"Arguments eg. --test \"{{ .TorrentName }}\""}
-          />
-          <div className="col-span-12 sm:col-span-2">
-            <NumberField
-              name={`external.${idx}.exec_expect_status`}
-              label="Expected exit status"
-              placeholder="0"
-            />
-          </div>
-        </FilterLayout>
-      </FilterSection>
-    );
-  }
-  case "WEBHOOK": {
-    return (
-      <>
+    case "EXEC": {
+      return (
         <FilterSection
-          title="Request"
-          subtitle="Specify your request destination endpoint, headers and expected return status"
-        >
-          <FilterLayout>
-            <TextField
-              name={`external.${idx}.webhook_host`}
-              label="Endpoint"
-              columns={6}
-              placeholder="Host eg. http://localhost/webhook"
-              tooltip={<p>URL or IP to your API. Pass params and set API tokens etc.</p>}
-            />
-            <Select
-              name={`external.${idx}.webhook_method`}
-              label="HTTP method"
-              optionDefaultText="Select http method"
-              options={ExternalFilterWebhookMethodOptions}
-              tooltip={<div><p>Select the HTTP method for this webhook. Defaults to POST</p></div>}
-            />
-            <TextField
-              name={`external.${idx}.webhook_headers`}
-              label="HTTP Request Headers"
-              columns={6}
-              placeholder="HEADER=custom1,HEADER2=custom2"
-            />
-            <NumberField
-              name={`external.${idx}.webhook_expect_status`}
-              label="Expected HTTP status code"
-              placeholder="200"
-            />
-          </FilterLayout>
-        </FilterSection>
-        <FilterSection
-          title="Retry"
-          subtitle="Retry behavior on request failure"
-        >
-          <FilterLayout>
-            <TextField
-              name={`external.${idx}.webhook_retry_status`}
-              label="Retry http status code(s)"
-              placeholder="Retry on status eg. 202, 204"
-              columns={6}
-            />
-            <NumberField
-              name={`external.${idx}.webhook_retry_attempts`}
-              label="Maximum retry attempts"
-              placeholder="10"
-            />
-            <NumberField
-              name={`external.${idx}.webhook_retry_delay_seconds`}
-              label="Retry delay in seconds"
-              placeholder="1"
-            />
-          </FilterLayout>
-        </FilterSection>
-        <FilterSection
-          title="Payload"
-          subtitle="Specify your JSON payload"
+          title="Execute"
+          subtitle="Specify the executable, the argument and the expected exit status to run as a pre-filter"
         >
           <FilterLayout>
             <TextAreaAutoResize
-              name={`external.${idx}.webhook_data`}
-              label="Data (json)"
-              placeholder={"Request data: { \"key\": \"value\" }"}
+              name={`external.${idx}.exec_cmd`}
+              label="Path to Executable"
+              columns={5}
+              placeholder="Absolute path to executable eg. /bin/test"
+              tooltip={
+                <div>
+                  <p>
+                    For custom commands you should specify the full path to the binary/program
+                    you want to run. And you can include your own static variables:
+                  </p>
+                  <DocsLink href="https://autobrr.com/filters/actions#custom-commands--exec" />
+                </div>
+              }
             />
+            <TextAreaAutoResize
+              name={`external.${idx}.exec_args`}
+              label="Exec Arguments"
+              columns={5}
+              placeholder={"Arguments eg. --test \"{{ .TorrentName }}\""}
+            />
+            <div className="col-span-12 sm:col-span-2">
+              <NumberField
+                name={`external.${idx}.exec_expect_status`}
+                label="Expected exit status"
+                placeholder="0"
+              />
+            </div>
           </FilterLayout>
         </FilterSection>
-      </>
-    );
-  }
+      );
+    }
+    case "WEBHOOK": {
+      return (
+        <>
+          <FilterSection
+            title="Request"
+            subtitle="Specify your request destination endpoint, headers and expected return status"
+          >
+            <FilterLayout>
+              <TextField
+                name={`external.${idx}.webhook_host`}
+                label="Endpoint"
+                columns={6}
+                placeholder="Host eg. http://localhost/webhook"
+                tooltip={<p>URL or IP to your API. Pass params and set API tokens etc.</p>}
+              />
+              <Select
+                name={`external.${idx}.webhook_method`}
+                label="HTTP method"
+                optionDefaultText="Select http method"
+                options={ExternalFilterWebhookMethodOptions}
+                tooltip={<div><p>Select the HTTP method for this webhook. Defaults to POST</p></div>}
+              />
+              <TextField
+                name={`external.${idx}.webhook_headers`}
+                label="HTTP Request Headers"
+                columns={6}
+                placeholder="HEADER=custom1,HEADER2=custom2"
+              />
+              <NumberField
+                name={`external.${idx}.webhook_expect_status`}
+                label="Expected HTTP status code"
+                placeholder="200"
+              />
+            </FilterLayout>
+          </FilterSection>
+          <FilterSection
+            title="Retry"
+            subtitle="Retry behavior on request failure"
+          >
+            <FilterLayout>
+              <TextField
+                name={`external.${idx}.webhook_retry_status`}
+                label="Retry http status code(s)"
+                placeholder="Retry on status eg. 202, 204"
+                columns={6}
+              />
+              <NumberField
+                name={`external.${idx}.webhook_retry_attempts`}
+                label="Maximum retry attempts"
+                placeholder="10"
+              />
+              <NumberField
+                name={`external.${idx}.webhook_retry_delay_seconds`}
+                label="Retry delay in seconds"
+                placeholder="1"
+              />
+            </FilterLayout>
+          </FilterSection>
+          <FilterSection
+            title="Payload"
+            subtitle="Specify your JSON payload"
+          >
+            <FilterLayout>
+              <TextAreaAutoResize
+                name={`external.${idx}.webhook_data`}
+                label="Data (json)"
+                placeholder={"Request data: { \"key\": \"value\" }"}
+              />
+            </FilterLayout>
+          </FilterSection>
+        </>
+      );
+    }
 
-  default: {
-    return null;
-  }
+    default: {
+      return null;
+    }
   }
 };

--- a/web/src/screens/filters/sections/General.tsx
+++ b/web/src/screens/filters/sections/General.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -140,7 +140,7 @@ export const General = () => {
             name={`release_profile_duplicate_id`}
             label="Skip Duplicates profile"
             optionDefaultText="Select profile"
-            options={[{label: "Select profile", value: null}, ...duplicateProfilesOptions]}
+            options={[{ label: "Select profile", value: null }, ...duplicateProfilesOptions]}
             tooltip={<div><p>Select the skip duplicate profile.</p></div>}
           />
         </FilterLayout>

--- a/web/src/screens/filters/sections/General.tsx
+++ b/web/src/screens/filters/sections/General.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/General.tsx
+++ b/web/src/screens/filters/sections/General.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -140,7 +140,7 @@ export const General = () => {
             name={`release_profile_duplicate_id`}
             label="Skip Duplicates profile"
             optionDefaultText="Select profile"
-            options={[{ label: "Select profile", value: null }, ...duplicateProfilesOptions]}
+            options={[{label: "Select profile", value: null}, ...duplicateProfilesOptions]}
             tooltip={<div><p>Select the skip duplicate profile.</p></div>}
           />
         </FilterLayout>

--- a/web/src/screens/filters/sections/MoviesAndTV.tsx
+++ b/web/src/screens/filters/sections/MoviesAndTV.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -41,7 +41,7 @@ const SeasonsAndEpisodes = () => (
         tooltip={
           <div>
             <p>See docs for information about how to <b>only</b> grab episodes:</p>
-            <DocsLink href="https://autobrr.com/filters/examples#only-episodes-skip-season-packs" />
+            <DocsLink href="https://autobrr.com/filters/examples#only-episodes-skip-season-packs"/>
           </div>
         }
       />
@@ -54,7 +54,7 @@ const SeasonsAndEpisodes = () => (
         tooltip={
           <div>
             <p>This field takes a range of years and/or comma separated single years.</p>
-            <DocsLink href="https://autobrr.com/filters#tvmovies" />
+            <DocsLink href="https://autobrr.com/filters#tvmovies"/>
           </div>
         }
       />
@@ -66,7 +66,7 @@ const SeasonsAndEpisodes = () => (
         tooltip={
           <div>
             <p>This field takes a range of years and/or comma separated single months.</p>
-            <DocsLink href="https://autobrr.com/filters#tvmovies" />
+            <DocsLink href="https://autobrr.com/filters#tvmovies"/>
           </div>
         }
       />
@@ -78,7 +78,7 @@ const SeasonsAndEpisodes = () => (
         tooltip={
           <div>
             <p>This field takes a range of years and/or comma separated single days.</p>
-            <DocsLink href="https://autobrr.com/filters#tvmovies" />
+            <DocsLink href="https://autobrr.com/filters#tvmovies"/>
           </div>
         }
       />

--- a/web/src/screens/filters/sections/MoviesAndTV.tsx
+++ b/web/src/screens/filters/sections/MoviesAndTV.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -41,7 +41,7 @@ const SeasonsAndEpisodes = () => (
         tooltip={
           <div>
             <p>See docs for information about how to <b>only</b> grab episodes:</p>
-            <DocsLink href="https://autobrr.com/filters/examples#only-episodes-skip-season-packs"/>
+            <DocsLink href="https://autobrr.com/filters/examples#only-episodes-skip-season-packs" />
           </div>
         }
       />
@@ -54,7 +54,7 @@ const SeasonsAndEpisodes = () => (
         tooltip={
           <div>
             <p>This field takes a range of years and/or comma separated single years.</p>
-            <DocsLink href="https://autobrr.com/filters#tvmovies"/>
+            <DocsLink href="https://autobrr.com/filters#tvmovies" />
           </div>
         }
       />
@@ -66,7 +66,7 @@ const SeasonsAndEpisodes = () => (
         tooltip={
           <div>
             <p>This field takes a range of years and/or comma separated single months.</p>
-            <DocsLink href="https://autobrr.com/filters#tvmovies"/>
+            <DocsLink href="https://autobrr.com/filters#tvmovies" />
           </div>
         }
       />
@@ -78,7 +78,7 @@ const SeasonsAndEpisodes = () => (
         tooltip={
           <div>
             <p>This field takes a range of years and/or comma separated single days.</p>
-            <DocsLink href="https://autobrr.com/filters#tvmovies"/>
+            <DocsLink href="https://autobrr.com/filters#tvmovies" />
           </div>
         }
       />

--- a/web/src/screens/filters/sections/MoviesAndTV.tsx
+++ b/web/src/screens/filters/sections/MoviesAndTV.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/Music.tsx
+++ b/web/src/screens/filters/sections/Music.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/Music.tsx
+++ b/web/src/screens/filters/sections/Music.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/_components.tsx
+++ b/web/src/screens/filters/sections/_components.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/_components.tsx
+++ b/web/src/screens/filters/sections/_components.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/ActionDeluge.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionDeluge.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -47,7 +47,7 @@ export const Deluge = ({ idx, action, clients }: ClientActionProps) => (
           />
         </FilterHalfRow>
         <FilterHalfRow>
-          <SwitchGroup
+        <SwitchGroup
             name={`actions.${idx}.skip_hash_check`}
             label="Skip hash check"
             description="Add torrent and skip hash check"

--- a/web/src/screens/filters/sections/action_components/ActionDeluge.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionDeluge.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -47,7 +47,7 @@ export const Deluge = ({ idx, action, clients }: ClientActionProps) => (
           />
         </FilterHalfRow>
         <FilterHalfRow>
-        <SwitchGroup
+          <SwitchGroup
             name={`actions.${idx}.skip_hash_check`}
             label="Skip hash check"
             description="Add torrent and skip hash check"

--- a/web/src/screens/filters/sections/action_components/ActionDeluge.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionDeluge.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/ActionPorla.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionPorla.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/ActionPorla.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionPorla.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/ActionQBittorrent.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionQBittorrent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/ActionQBittorrent.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionQBittorrent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/ActionRTorrent.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionRTorrent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/ActionRTorrent.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionRTorrent.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/ActionTransmission.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionTransmission.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/ActionTransmission.tsx
+++ b/web/src/screens/filters/sections/action_components/ActionTransmission.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/OtherActions.tsx
+++ b/web/src/screens/filters/sections/action_components/OtherActions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/OtherActions.tsx
+++ b/web/src/screens/filters/sections/action_components/OtherActions.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/index.ts
+++ b/web/src/screens/filters/sections/action_components/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/index.ts
+++ b/web/src/screens/filters/sections/action_components/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/shared.d.ts
+++ b/web/src/screens/filters/sections/action_components/shared.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/action_components/shared.d.ts
+++ b/web/src/screens/filters/sections/action_components/shared.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/index.ts
+++ b/web/src/screens/filters/sections/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/filters/sections/index.ts
+++ b/web/src/screens/filters/sections/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/releases/ReleaseFilters.tsx
+++ b/web/src/screens/releases/ReleaseFilters.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -15,11 +15,11 @@ import { PushStatusOptions } from "@domain/constants";
 import { ReleasesIndexersQueryOptions } from "@api/queries";
 
 interface ListboxFilterProps {
-    id: string;
-    label: string;
-    currentValue: string;
-    onChange: (newValue: string) => void;
-    children: React.ReactNode;
+  id: string;
+  label: string;
+  currentValue: string;
+  onChange: (newValue: string) => void;
+  children: React.ReactNode;
 }
 
 const ListboxFilter = ({
@@ -85,8 +85,8 @@ export const IndexerSelectColumnFilter = ({ column }: { column: Column<Release, 
 };
 
 interface FilterOptionProps {
-    label: string;
-    value?: string;
+  label: string;
+  value?: string;
 }
 
 const FilterOption = ({ label, value }: FilterOptionProps) => (

--- a/web/src/screens/releases/ReleaseFilters.tsx
+++ b/web/src/screens/releases/ReleaseFilters.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -15,11 +15,11 @@ import { PushStatusOptions } from "@domain/constants";
 import { ReleasesIndexersQueryOptions } from "@api/queries";
 
 interface ListboxFilterProps {
-  id: string;
-  label: string;
-  currentValue: string;
-  onChange: (newValue: string) => void;
-  children: React.ReactNode;
+    id: string;
+    label: string;
+    currentValue: string;
+    onChange: (newValue: string) => void;
+    children: React.ReactNode;
 }
 
 const ListboxFilter = ({
@@ -85,8 +85,8 @@ export const IndexerSelectColumnFilter = ({ column }: { column: Column<Release, 
 };
 
 interface FilterOptionProps {
-  label: string;
-  value?: string;
+    label: string;
+    value?: string;
 }
 
 const FilterOption = ({ label, value }: FilterOptionProps) => (

--- a/web/src/screens/releases/ReleaseFilters.tsx
+++ b/web/src/screens/releases/ReleaseFilters.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/releases/ReleaseTable.tsx
+++ b/web/src/screens/releases/ReleaseTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -44,17 +44,17 @@ const EmptyReleaseList = () => (
     className="bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-table rounded-md overflow-auto">
     <table className="min-w-full rounded-md divide-y divide-gray-200 dark:divide-gray-750">
       <thead className="bg-gray-100 dark:bg-gray-850 border-b border-gray-200 dark:border-gray-750">
-      <tr>
-        <th>
-          <div className="flex items-center justify-between">
-            <span className="h-10"/>
-          </div>
-        </th>
-      </tr>
+        <tr>
+          <th>
+            <div className="flex items-center justify-between">
+              <span className="h-10" />
+            </div>
+          </th>
+        </tr>
       </thead>
     </table>
     <div className="flex items-center justify-center py-52">
-      <EmptyListState text="No results"/>
+      <EmptyListState text="No results" />
     </div>
   </div>
 );
@@ -64,13 +64,13 @@ function Filter({ column }: { column: Column<Release, unknown> }) {
 
   switch (filterVariant) {
     case "search":
-      return <SearchColumnFilter column={column}/>
+      return <SearchColumnFilter column={column} />
 
     case "indexerSelect":
-      return <IndexerSelectColumnFilter column={column}/>
+      return <IndexerSelectColumnFilter column={column} />
 
     case "actionPushStatus":
-      return <PushStatusSelectColumnFilter column={column}/>
+      return <PushStatusSelectColumnFilter column={column} />
 
     default:
       return null;
@@ -223,7 +223,7 @@ export const ReleaseTable = () => {
           {tableInstance.getHeaderGroups().map((headerGroup) =>
             headerGroup.headers.map((header) => (
               header.column.getCanFilter() ? (
-                <Filter key={header.column.id} column={header.column}/>
+                <Filter key={header.column.id} column={header.column} />
               ) : null
             ))
           )}
@@ -231,10 +231,10 @@ export const ReleaseTable = () => {
         <div
           className="bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-lg rounded-md mt-4">
           <div className="bg-gray-100 dark:bg-gray-850 border-b border-gray-200 dark:border-gray-750">
-            <div className="flex h-10"/>
+            <div className="flex h-10" />
           </div>
           <div className="flex items-center justify-center py-64">
-            <RingResizeSpinner className="text-blue-500 size-24"/>
+            <RingResizeSpinner className="text-blue-500 size-24" />
           </div>
         </div>
       </div>
@@ -247,74 +247,74 @@ export const ReleaseTable = () => {
         {tableInstance.getHeaderGroups().map((headerGroup) =>
           headerGroup.headers.map((header) => (
             header.column.getCanFilter() ? (
-              <Filter key={header.column.id} column={header.column}/>
+              <Filter key={header.column.id} column={header.column} />
             ) : null
           ))
         )}
       </div>
       <div className="relative">
         {displayData.length === 0
-          ? <EmptyReleaseList/>
+          ? <EmptyReleaseList />
           : (
             <div
               className="bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-table rounded-md overflow-auto">
               <table className="min-w-full rounded-md divide-y divide-gray-200 dark:divide-gray-750">
                 <thead className="bg-gray-100 dark:bg-gray-850">
-                {tableInstance.getHeaderGroups().map((headerGroup) => (
-                  <tr key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <th
-                        key={header.id}
-                        scope="col"
-                        colSpan={header.colSpan}
-                        className="first:pl-5 first:rounded-tl-md last:rounded-tr-md pl-3 pr-3 py-3 text-xs font-medium tracking-wider text-left uppercase group text-gray-600 dark:text-gray-400 transition hover:bg-gray-200 dark:hover:bg-gray-775"
-                      >
-                        <div className="flex items-center justify-between">
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
-                          {/*<>{header.render("Header")}</>*/}
-                          {/*/!* Add a sort direction indicator *!/*/}
-                          {/*<span>*/}
-                          {/*  {header.isSorted ? (*/}
-                          {/*    header.isSortedDesc ? (*/}
-                          {/*      <SortDownIcon className="w-4 h-4 text-gray-400"/>*/}
-                          {/*    ) : (*/}
-                          {/*      <SortUpIcon className="w-4 h-4 text-gray-400"/>*/}
-                          {/*    )*/}
-                          {/*  ) : (*/}
-                          {/*    <SortIcon className="w-4 h-4 text-gray-400 opacity-0 group-hover:opacity-100"/>*/}
-                          {/*  )}*/}
-                          {/*</span>*/}
-                        </div>
-                      </th>
-                    ))}
-                  </tr>
-                ))}
+                  {tableInstance.getHeaderGroups().map((headerGroup) => (
+                    <tr key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <th
+                          key={header.id}
+                          scope="col"
+                          colSpan={header.colSpan}
+                          className="first:pl-5 first:rounded-tl-md last:rounded-tr-md pl-3 pr-3 py-3 text-xs font-medium tracking-wider text-left uppercase group text-gray-600 dark:text-gray-400 transition hover:bg-gray-200 dark:hover:bg-gray-775"
+                        >
+                          <div className="flex items-center justify-between">
+                            {header.isPlaceholder
+                              ? null
+                              : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext()
+                              )}
+                            {/*<>{header.render("Header")}</>*/}
+                            {/*/!* Add a sort direction indicator *!/*/}
+                            {/*<span>*/}
+                            {/*  {header.isSorted ? (*/}
+                            {/*    header.isSortedDesc ? (*/}
+                            {/*      <SortDownIcon className="w-4 h-4 text-gray-400"/>*/}
+                            {/*    ) : (*/}
+                            {/*      <SortUpIcon className="w-4 h-4 text-gray-400"/>*/}
+                            {/*    )*/}
+                            {/*  ) : (*/}
+                            {/*    <SortIcon className="w-4 h-4 text-gray-400 opacity-0 group-hover:opacity-100"/>*/}
+                            {/*  )}*/}
+                            {/*</span>*/}
+                          </div>
+                        </th>
+                      ))}
+                    </tr>
+                  ))}
                 </thead>
 
                 <tbody className="divide-y divide-gray-150 dark:divide-gray-750">
-                {tableInstance.getRowModel().rows.map((row) => (
-                  <tr key={row.id}>
-                    {row.getVisibleCells().map((cell) => (
-                      <td
-                        key={cell.id}
-                        className="first:pl-5 pl-3 pr-3 whitespace-nowrap"
-                        role="cell"
-                      >
-                        <>
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
-                          )}
-                        </>
-                      </td>
-                    ))}
-                  </tr>
-                ))}
+                  {tableInstance.getRowModel().rows.map((row) => (
+                    <tr key={row.id}>
+                      {row.getVisibleCells().map((cell) => (
+                        <td
+                          key={cell.id}
+                          className="first:pl-5 pl-3 pr-3 whitespace-nowrap"
+                          role="cell"
+                        >
+                          <>
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
                 </tbody>
               </table>
 
@@ -326,10 +326,10 @@ export const ReleaseTable = () => {
                 </div>
                 <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
                   <div className="flex items-baseline gap-x-2">
-                  <span className="text-sm text-gray-700 dark:text-gray-500">
-                  Page <span className="font-medium">{tableInstance.getState().pagination.pageIndex + 1}</span> of <span
-                    className="font-medium">{tableInstance.getPageCount()}</span>
-                  </span>
+                    <span className="text-sm text-gray-700 dark:text-gray-500">
+                      Page <span className="font-medium">{tableInstance.getState().pagination.pageIndex + 1}</span> of <span
+                        className="font-medium">{tableInstance.getPageCount()}</span>
+                    </span>
                     <label>
                       <span className="sr-only bg-gray-700">Items Per Page</span>
                       <select
@@ -355,14 +355,14 @@ export const ReleaseTable = () => {
                         disabled={!tableInstance.getCanPreviousPage()}
                       >
                         <span className="sr-only">First</span>
-                        <ChevronDoubleLeftIcon className="w-4 h-4" aria-hidden="true"/>
+                        <ChevronDoubleLeftIcon className="w-4 h-4" aria-hidden="true" />
                       </TablePageButton>
                       <TablePageButton
                         className="pl-1 pr-2"
                         onClick={() => tableInstance.previousPage()}
                         disabled={!tableInstance.getCanPreviousPage()}
                       >
-                        <ChevronLeftIcon className="w-4 h-4 mr-1" aria-hidden="true"/>
+                        <ChevronLeftIcon className="w-4 h-4 mr-1" aria-hidden="true" />
                         <span>Prev</span>
                       </TablePageButton>
                       <TablePageButton
@@ -370,14 +370,14 @@ export const ReleaseTable = () => {
                         onClick={() => tableInstance.nextPage()}
                         disabled={!tableInstance.getCanNextPage()}>
                         <span>Next</span>
-                        <ChevronRightIcon className="w-4 h-4 ml-1" aria-hidden="true"/>
+                        <ChevronRightIcon className="w-4 h-4 ml-1" aria-hidden="true" />
                       </TablePageButton>
                       <TablePageButton
                         className="rounded-r-md"
                         onClick={() => tableInstance.lastPage()}
                         disabled={!tableInstance.getCanNextPage()}
                       >
-                        <ChevronDoubleRightIcon className="w-4 h-4" aria-hidden="true"/>
+                        <ChevronDoubleRightIcon className="w-4 h-4" aria-hidden="true" />
                         <span className="sr-only">Last</span>
                       </TablePageButton>
                     </nav>
@@ -393,9 +393,9 @@ export const ReleaseTable = () => {
                   title="Go incognito"
                 >
                   {showLinuxIsos ? (
-                    <EyeIcon className="h-4 w-4"/>
+                    <EyeIcon className="h-4 w-4" />
                   ) : (
-                    <EyeSlashIcon className="h-4 w-4"/>
+                    <EyeSlashIcon className="h-4 w-4" />
                   )}
                 </button>
               </div>

--- a/web/src/screens/releases/ReleaseTable.tsx
+++ b/web/src/screens/releases/ReleaseTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -44,17 +44,17 @@ const EmptyReleaseList = () => (
     className="bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-table rounded-md overflow-auto">
     <table className="min-w-full rounded-md divide-y divide-gray-200 dark:divide-gray-750">
       <thead className="bg-gray-100 dark:bg-gray-850 border-b border-gray-200 dark:border-gray-750">
-        <tr>
-          <th>
-            <div className="flex items-center justify-between">
-              <span className="h-10" />
-            </div>
-          </th>
-        </tr>
+      <tr>
+        <th>
+          <div className="flex items-center justify-between">
+            <span className="h-10"/>
+          </div>
+        </th>
+      </tr>
       </thead>
     </table>
     <div className="flex items-center justify-center py-52">
-      <EmptyListState text="No results" />
+      <EmptyListState text="No results"/>
     </div>
   </div>
 );
@@ -64,13 +64,13 @@ function Filter({ column }: { column: Column<Release, unknown> }) {
 
   switch (filterVariant) {
     case "search":
-      return <SearchColumnFilter column={column} />
+      return <SearchColumnFilter column={column}/>
 
     case "indexerSelect":
-      return <IndexerSelectColumnFilter column={column} />
+      return <IndexerSelectColumnFilter column={column}/>
 
     case "actionPushStatus":
-      return <PushStatusSelectColumnFilter column={column} />
+      return <PushStatusSelectColumnFilter column={column}/>
 
     default:
       return null;
@@ -223,7 +223,7 @@ export const ReleaseTable = () => {
           {tableInstance.getHeaderGroups().map((headerGroup) =>
             headerGroup.headers.map((header) => (
               header.column.getCanFilter() ? (
-                <Filter key={header.column.id} column={header.column} />
+                <Filter key={header.column.id} column={header.column}/>
               ) : null
             ))
           )}
@@ -231,10 +231,10 @@ export const ReleaseTable = () => {
         <div
           className="bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-lg rounded-md mt-4">
           <div className="bg-gray-100 dark:bg-gray-850 border-b border-gray-200 dark:border-gray-750">
-            <div className="flex h-10" />
+            <div className="flex h-10"/>
           </div>
           <div className="flex items-center justify-center py-64">
-            <RingResizeSpinner className="text-blue-500 size-24" />
+            <RingResizeSpinner className="text-blue-500 size-24"/>
           </div>
         </div>
       </div>
@@ -247,74 +247,74 @@ export const ReleaseTable = () => {
         {tableInstance.getHeaderGroups().map((headerGroup) =>
           headerGroup.headers.map((header) => (
             header.column.getCanFilter() ? (
-              <Filter key={header.column.id} column={header.column} />
+              <Filter key={header.column.id} column={header.column}/>
             ) : null
           ))
         )}
       </div>
       <div className="relative">
         {displayData.length === 0
-          ? <EmptyReleaseList />
+          ? <EmptyReleaseList/>
           : (
             <div
               className="bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-table rounded-md overflow-auto">
               <table className="min-w-full rounded-md divide-y divide-gray-200 dark:divide-gray-750">
                 <thead className="bg-gray-100 dark:bg-gray-850">
-                  {tableInstance.getHeaderGroups().map((headerGroup) => (
-                    <tr key={headerGroup.id}>
-                      {headerGroup.headers.map((header) => (
-                        <th
-                          key={header.id}
-                          scope="col"
-                          colSpan={header.colSpan}
-                          className="first:pl-5 first:rounded-tl-md last:rounded-tr-md pl-3 pr-3 py-3 text-xs font-medium tracking-wider text-left uppercase group text-gray-600 dark:text-gray-400 transition hover:bg-gray-200 dark:hover:bg-gray-775"
-                        >
-                          <div className="flex items-center justify-between">
-                            {header.isPlaceholder
-                              ? null
-                              : flexRender(
-                                header.column.columnDef.header,
-                                header.getContext()
-                              )}
-                            {/*<>{header.render("Header")}</>*/}
-                            {/*/!* Add a sort direction indicator *!/*/}
-                            {/*<span>*/}
-                            {/*  {header.isSorted ? (*/}
-                            {/*    header.isSortedDesc ? (*/}
-                            {/*      <SortDownIcon className="w-4 h-4 text-gray-400"/>*/}
-                            {/*    ) : (*/}
-                            {/*      <SortUpIcon className="w-4 h-4 text-gray-400"/>*/}
-                            {/*    )*/}
-                            {/*  ) : (*/}
-                            {/*    <SortIcon className="w-4 h-4 text-gray-400 opacity-0 group-hover:opacity-100"/>*/}
-                            {/*  )}*/}
-                            {/*</span>*/}
-                          </div>
-                        </th>
-                      ))}
-                    </tr>
-                  ))}
+                {tableInstance.getHeaderGroups().map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <th
+                        key={header.id}
+                        scope="col"
+                        colSpan={header.colSpan}
+                        className="first:pl-5 first:rounded-tl-md last:rounded-tr-md pl-3 pr-3 py-3 text-xs font-medium tracking-wider text-left uppercase group text-gray-600 dark:text-gray-400 transition hover:bg-gray-200 dark:hover:bg-gray-775"
+                      >
+                        <div className="flex items-center justify-between">
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext()
+                            )}
+                          {/*<>{header.render("Header")}</>*/}
+                          {/*/!* Add a sort direction indicator *!/*/}
+                          {/*<span>*/}
+                          {/*  {header.isSorted ? (*/}
+                          {/*    header.isSortedDesc ? (*/}
+                          {/*      <SortDownIcon className="w-4 h-4 text-gray-400"/>*/}
+                          {/*    ) : (*/}
+                          {/*      <SortUpIcon className="w-4 h-4 text-gray-400"/>*/}
+                          {/*    )*/}
+                          {/*  ) : (*/}
+                          {/*    <SortIcon className="w-4 h-4 text-gray-400 opacity-0 group-hover:opacity-100"/>*/}
+                          {/*  )}*/}
+                          {/*</span>*/}
+                        </div>
+                      </th>
+                    ))}
+                  </tr>
+                ))}
                 </thead>
 
                 <tbody className="divide-y divide-gray-150 dark:divide-gray-750">
-                  {tableInstance.getRowModel().rows.map((row) => (
-                    <tr key={row.id}>
-                      {row.getVisibleCells().map((cell) => (
-                        <td
-                          key={cell.id}
-                          className="first:pl-5 pl-3 pr-3 whitespace-nowrap"
-                          role="cell"
-                        >
-                          <>
-                            {flexRender(
-                              cell.column.columnDef.cell,
-                              cell.getContext()
-                            )}
-                          </>
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
+                {tableInstance.getRowModel().rows.map((row) => (
+                  <tr key={row.id}>
+                    {row.getVisibleCells().map((cell) => (
+                      <td
+                        key={cell.id}
+                        className="first:pl-5 pl-3 pr-3 whitespace-nowrap"
+                        role="cell"
+                      >
+                        <>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </>
+                      </td>
+                    ))}
+                  </tr>
+                ))}
                 </tbody>
               </table>
 
@@ -326,10 +326,10 @@ export const ReleaseTable = () => {
                 </div>
                 <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
                   <div className="flex items-baseline gap-x-2">
-                    <span className="text-sm text-gray-700 dark:text-gray-500">
-                      Page <span className="font-medium">{tableInstance.getState().pagination.pageIndex + 1}</span> of <span
-                        className="font-medium">{tableInstance.getPageCount()}</span>
-                    </span>
+                  <span className="text-sm text-gray-700 dark:text-gray-500">
+                  Page <span className="font-medium">{tableInstance.getState().pagination.pageIndex + 1}</span> of <span
+                    className="font-medium">{tableInstance.getPageCount()}</span>
+                  </span>
                     <label>
                       <span className="sr-only bg-gray-700">Items Per Page</span>
                       <select
@@ -355,14 +355,14 @@ export const ReleaseTable = () => {
                         disabled={!tableInstance.getCanPreviousPage()}
                       >
                         <span className="sr-only">First</span>
-                        <ChevronDoubleLeftIcon className="w-4 h-4" aria-hidden="true" />
+                        <ChevronDoubleLeftIcon className="w-4 h-4" aria-hidden="true"/>
                       </TablePageButton>
                       <TablePageButton
                         className="pl-1 pr-2"
                         onClick={() => tableInstance.previousPage()}
                         disabled={!tableInstance.getCanPreviousPage()}
                       >
-                        <ChevronLeftIcon className="w-4 h-4 mr-1" aria-hidden="true" />
+                        <ChevronLeftIcon className="w-4 h-4 mr-1" aria-hidden="true"/>
                         <span>Prev</span>
                       </TablePageButton>
                       <TablePageButton
@@ -370,14 +370,14 @@ export const ReleaseTable = () => {
                         onClick={() => tableInstance.nextPage()}
                         disabled={!tableInstance.getCanNextPage()}>
                         <span>Next</span>
-                        <ChevronRightIcon className="w-4 h-4 ml-1" aria-hidden="true" />
+                        <ChevronRightIcon className="w-4 h-4 ml-1" aria-hidden="true"/>
                       </TablePageButton>
                       <TablePageButton
                         className="rounded-r-md"
                         onClick={() => tableInstance.lastPage()}
                         disabled={!tableInstance.getCanNextPage()}
                       >
-                        <ChevronDoubleRightIcon className="w-4 h-4" aria-hidden="true" />
+                        <ChevronDoubleRightIcon className="w-4 h-4" aria-hidden="true"/>
                         <span className="sr-only">Last</span>
                       </TablePageButton>
                     </nav>
@@ -393,9 +393,9 @@ export const ReleaseTable = () => {
                   title="Go incognito"
                 >
                   {showLinuxIsos ? (
-                    <EyeIcon className="h-4 w-4" />
+                    <EyeIcon className="h-4 w-4"/>
                   ) : (
-                    <EyeSlashIcon className="h-4 w-4" />
+                    <EyeSlashIcon className="h-4 w-4"/>
                   )}
                 </button>
               </div>

--- a/web/src/screens/releases/ReleaseTable.tsx
+++ b/web/src/screens/releases/ReleaseTable.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Account.tsx
+++ b/web/src/screens/settings/Account.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Account.tsx
+++ b/web/src/screens/settings/Account.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Api.tsx
+++ b/web/src/screens/settings/Api.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Api.tsx
+++ b/web/src/screens/settings/Api.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Application.tsx
+++ b/web/src/screens/settings/Application.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Application.tsx
+++ b/web/src/screens/settings/Application.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -21,9 +21,9 @@ function ApplicationSettings() {
   const [settings, setSettings] = SettingsContext.use();
 
   const settingsIndexRoute = getRouteApi("/auth/authenticated-routes/settings/");
-  const { queryClient } =  settingsIndexRoute.useRouteContext();
+  const { queryClient } = settingsIndexRoute.useRouteContext();
 
-  const { isError:isConfigError, error: configError, data } = useQuery(ConfigQueryOptions());
+  const { isError: isConfigError, error: configError, data } = useQuery(ConfigQueryOptions());
   if (isConfigError) {
     console.log(configError);
   }

--- a/web/src/screens/settings/Application.tsx
+++ b/web/src/screens/settings/Application.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -21,9 +21,9 @@ function ApplicationSettings() {
   const [settings, setSettings] = SettingsContext.use();
 
   const settingsIndexRoute = getRouteApi("/auth/authenticated-routes/settings/");
-  const { queryClient } = settingsIndexRoute.useRouteContext();
+  const { queryClient } =  settingsIndexRoute.useRouteContext();
 
-  const { isError: isConfigError, error: configError, data } = useQuery(ConfigQueryOptions());
+  const { isError:isConfigError, error: configError, data } = useQuery(ConfigQueryOptions());
   if (isConfigError) {
     console.log(configError);
   }

--- a/web/src/screens/settings/DownloadClient.tsx
+++ b/web/src/screens/settings/DownloadClient.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/DownloadClient.tsx
+++ b/web/src/screens/settings/DownloadClient.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Feed.tsx
+++ b/web/src/screens/settings/Feed.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Feed.tsx
+++ b/web/src/screens/settings/Feed.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -318,8 +318,8 @@ const FeedItemDropdown = ({
         leaveTo="transform opacity-0 scale-95"
       >
         <MenuItems
-            anchor={{ to: 'bottom end', padding: '8px' }} // padding: '8px' === m-2
-            className="absolute w-56 bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
+          anchor={{ to: 'bottom end', padding: '8px' }} // padding: '8px' === m-2
+          className="absolute w-56 bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
         >
           <div className="px-1 py-1">
             <MenuItem>
@@ -380,7 +380,7 @@ const FeedItemDropdown = ({
                     )}
                     aria-hidden="true"
                   />
-            Force run
+                  Force run
                 </button>
               )}
             </MenuItem>

--- a/web/src/screens/settings/Feed.tsx
+++ b/web/src/screens/settings/Feed.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -318,8 +318,8 @@ const FeedItemDropdown = ({
         leaveTo="transform opacity-0 scale-95"
       >
         <MenuItems
-          anchor={{ to: 'bottom end', padding: '8px' }} // padding: '8px' === m-2
-          className="absolute w-56 bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
+            anchor={{ to: 'bottom end', padding: '8px' }} // padding: '8px' === m-2
+            className="absolute w-56 bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
         >
           <div className="px-1 py-1">
             <MenuItem>
@@ -380,7 +380,7 @@ const FeedItemDropdown = ({
                     )}
                     aria-hidden="true"
                   />
-                  Force run
+            Force run
                 </button>
               )}
             </MenuItem>

--- a/web/src/screens/settings/Indexer.tsx
+++ b/web/src/screens/settings/Indexer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Indexer.tsx
+++ b/web/src/screens/settings/Indexer.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -478,8 +478,8 @@ const ListItemDropdown = ({
         leaveTo="transform opacity-0 scale-95"
       >
         <MenuItems
-          anchor={{ to: 'bottom end', padding: '8px' }} // padding: '8px' === m-2
-          className="absolute w-56 bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
+            anchor={{ to: 'bottom end', padding: '8px' }} // padding: '8px' === m-2
+            className="absolute w-56 bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
         >
           <div className="px-1 py-1">
             <MenuItem>
@@ -538,8 +538,8 @@ const ListItemDropdown = ({
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={classNames(
                     "w-5 h-5 mr-2",
                     network.enabled
-                      ? active ? "text-white" : "text-blue-500 dark:text-blue-500"
-                      : "text-gray-600 dark:text-gray-500"
+                    ? active ? "text-white" : "text-blue-500 dark:text-blue-500"
+                    : "text-gray-600 dark:text-gray-500"
                   )}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M5.636 5.636a9 9 0 1012.728 0M12 3v9" />
                   </svg>
@@ -609,12 +609,12 @@ const ReprocessAnnounceButton = ({ networkId, channel, msg }: ReprocessAnnounceP
 
   return (
     <div className="block">
-      <button className="flex items-center justify-center size-5 mr-1 p-1 rounded transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600" onClick={reprocessAnnounce} title="Re-process announce">
-        {mutation.isPending
-          ? <RingResizeSpinner className="text-blue-500 iconHeight" aria-hidden="true" />
-          : <ArrowPathIcon />
-        }
-      </button>
+    <button className="flex items-center justify-center size-5 mr-1 p-1 rounded transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600" onClick={reprocessAnnounce} title="Re-process announce">
+      {mutation.isPending
+        ? <RingResizeSpinner className="text-blue-500 iconHeight" aria-hidden="true" />
+        : <ArrowPathIcon />
+      }
+    </button>
     </div>
   );
 

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -478,8 +478,8 @@ const ListItemDropdown = ({
         leaveTo="transform opacity-0 scale-95"
       >
         <MenuItems
-            anchor={{ to: 'bottom end', padding: '8px' }} // padding: '8px' === m-2
-            className="absolute w-56 bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
+          anchor={{ to: 'bottom end', padding: '8px' }} // padding: '8px' === m-2
+          className="absolute w-56 bg-white dark:bg-gray-825 divide-y divide-gray-200 dark:divide-gray-750 rounded-md shadow-lg border border-gray-250 dark:border-gray-750 focus:outline-none z-10"
         >
           <div className="px-1 py-1">
             <MenuItem>
@@ -538,8 +538,8 @@ const ListItemDropdown = ({
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={classNames(
                     "w-5 h-5 mr-2",
                     network.enabled
-                    ? active ? "text-white" : "text-blue-500 dark:text-blue-500"
-                    : "text-gray-600 dark:text-gray-500"
+                      ? active ? "text-white" : "text-blue-500 dark:text-blue-500"
+                      : "text-gray-600 dark:text-gray-500"
                   )}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M5.636 5.636a9 9 0 1012.728 0M12 3v9" />
                   </svg>
@@ -609,12 +609,12 @@ const ReprocessAnnounceButton = ({ networkId, channel, msg }: ReprocessAnnounceP
 
   return (
     <div className="block">
-    <button className="flex items-center justify-center size-5 mr-1 p-1 rounded transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600" onClick={reprocessAnnounce} title="Re-process announce">
-      {mutation.isPending
-        ? <RingResizeSpinner className="text-blue-500 iconHeight" aria-hidden="true" />
-        : <ArrowPathIcon />
-      }
-    </button>
+      <button className="flex items-center justify-center size-5 mr-1 p-1 rounded transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600" onClick={reprocessAnnounce} title="Re-process announce">
+        {mutation.isPending
+          ? <RingResizeSpinner className="text-blue-500 iconHeight" aria-hidden="true" />
+          : <ArrowPathIcon />
+        }
+      </button>
     </div>
   );
 

--- a/web/src/screens/settings/Lists.tsx
+++ b/web/src/screens/settings/Lists.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Lists.tsx
+++ b/web/src/screens/settings/Lists.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -36,7 +36,7 @@ function ListsSettings() {
           onClick={toggleAddList}
           className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
         >
-          <PlusIcon className="h-5 w-5 mr-1" />
+          <PlusIcon className="h-5 w-5 mr-1"/>
           Add new
         </button>
       }
@@ -69,7 +69,7 @@ function ListsSettings() {
               </div>
             </li>
             {lists.map((list) => (
-              <ListItem list={list} key={list.id} />
+              <ListItem list={list} key={list.id}/>
             ))}
           </ul>
         ) : (
@@ -135,7 +135,7 @@ function ListItem({ list }: ListItemProps) {
 
       <div className="grid grid-cols-12 items-center py-2">
         <div className="col-span-2 sm:col-span-1 pl-1 py-0.5 sm:pl-6 flex items-center">
-          <Checkbox value={list.enabled ?? false} setValue={onToggleMutation} />
+          <Checkbox value={list.enabled ?? false} setValue={onToggleMutation}/>
         </div>
         <div
           className="col-span-8 sm:col-span-4 lg:col-span-4 pl-10 sm:pl-12 pr-6 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">

--- a/web/src/screens/settings/Lists.tsx
+++ b/web/src/screens/settings/Lists.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -36,7 +36,7 @@ function ListsSettings() {
           onClick={toggleAddList}
           className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
         >
-          <PlusIcon className="h-5 w-5 mr-1"/>
+          <PlusIcon className="h-5 w-5 mr-1" />
           Add new
         </button>
       }
@@ -69,7 +69,7 @@ function ListsSettings() {
               </div>
             </li>
             {lists.map((list) => (
-              <ListItem list={list} key={list.id}/>
+              <ListItem list={list} key={list.id} />
             ))}
           </ul>
         ) : (
@@ -135,7 +135,7 @@ function ListItem({ list }: ListItemProps) {
 
       <div className="grid grid-cols-12 items-center py-2">
         <div className="col-span-2 sm:col-span-1 pl-1 py-0.5 sm:pl-6 flex items-center">
-          <Checkbox value={list.enabled ?? false} setValue={onToggleMutation}/>
+          <Checkbox value={list.enabled ?? false} setValue={onToggleMutation} />
         </div>
         <div
           className="col-span-8 sm:col-span-4 lg:col-span-4 pl-10 sm:pl-12 pr-6 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">

--- a/web/src/screens/settings/Logs.tsx
+++ b/web/src/screens/settings/Logs.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -59,7 +59,7 @@ const SelectWrapper = ({ id, value, onChange, options }: SelectWrapperProps) => 
 
 function LogSettings() {
   const settingsLogRoute = getRouteApi("/auth/authenticated-routes/settings/logs");
-  const { queryClient} =  settingsLogRoute.useRouteContext();
+  const { queryClient } = settingsLogRoute.useRouteContext();
 
   const configQuery = useSuspenseQuery(ConfigQueryOptions())
 
@@ -83,7 +83,7 @@ function LogSettings() {
         <div className="divide-y divide-gray-200 dark:divide-gray-750">
           {!configQuery.isLoading && config && (
             <form className="divide-y divide-gray-200 dark:divide-gray-750" action="#" method="POST">
-              <RowItem label="Path" value={config?.log_path} title="Set in config.toml" emptyText="Not set!"/>
+              <RowItem label="Path" value={config?.log_path} title="Set in config.toml" emptyText="Not set!" />
               <RowItem
                 className="sm:col-span-1"
                 label="Level"
@@ -97,13 +97,13 @@ function LogSettings() {
                   />
                 }
               />
-              <RowItem label="Max Size" value={config?.log_max_size} title="Set in config.toml" rightSide="MB"/>
-              <RowItem label="Max Backups" value={config?.log_max_backups} title="Set in config.toml"/>
+              <RowItem label="Max Size" value={config?.log_max_size} title="Set in config.toml" rightSide="MB" />
+              <RowItem label="Max Backups" value={config?.log_max_backups} title="Set in config.toml" />
             </form>
           )}
 
           <div className="px-6 pt-4">
-            <LogFiles/>
+            <LogFiles />
           </div>
         </div>
       </div>

--- a/web/src/screens/settings/Logs.tsx
+++ b/web/src/screens/settings/Logs.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Logs.tsx
+++ b/web/src/screens/settings/Logs.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -59,7 +59,7 @@ const SelectWrapper = ({ id, value, onChange, options }: SelectWrapperProps) => 
 
 function LogSettings() {
   const settingsLogRoute = getRouteApi("/auth/authenticated-routes/settings/logs");
-  const { queryClient } = settingsLogRoute.useRouteContext();
+  const { queryClient} =  settingsLogRoute.useRouteContext();
 
   const configQuery = useSuspenseQuery(ConfigQueryOptions())
 
@@ -83,7 +83,7 @@ function LogSettings() {
         <div className="divide-y divide-gray-200 dark:divide-gray-750">
           {!configQuery.isLoading && config && (
             <form className="divide-y divide-gray-200 dark:divide-gray-750" action="#" method="POST">
-              <RowItem label="Path" value={config?.log_path} title="Set in config.toml" emptyText="Not set!" />
+              <RowItem label="Path" value={config?.log_path} title="Set in config.toml" emptyText="Not set!"/>
               <RowItem
                 className="sm:col-span-1"
                 label="Level"
@@ -97,13 +97,13 @@ function LogSettings() {
                   />
                 }
               />
-              <RowItem label="Max Size" value={config?.log_max_size} title="Set in config.toml" rightSide="MB" />
-              <RowItem label="Max Backups" value={config?.log_max_backups} title="Set in config.toml" />
+              <RowItem label="Max Size" value={config?.log_max_size} title="Set in config.toml" rightSide="MB"/>
+              <RowItem label="Max Backups" value={config?.log_max_backups} title="Set in config.toml"/>
             </form>
           )}
 
           <div className="px-6 pt-4">
-            <LogFiles />
+            <LogFiles/>
           </div>
         </div>
       </div>

--- a/web/src/screens/settings/Notifications.tsx
+++ b/web/src/screens/settings/Notifications.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Notifications.tsx
+++ b/web/src/screens/settings/Notifications.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/RegexPlayground.tsx
+++ b/web/src/screens/settings/RegexPlayground.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -52,7 +52,7 @@ const RegexPlayground = () => {
       }
 
       if (lastIndex > 0)
-        results.push(<br key={`line-delim-${index}`}/>);
+        results.push(<br key={`line-delim-${index}`} />);
     });
 
     setOutput(results);

--- a/web/src/screens/settings/RegexPlayground.tsx
+++ b/web/src/screens/settings/RegexPlayground.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -52,7 +52,7 @@ const RegexPlayground = () => {
       }
 
       if (lastIndex > 0)
-        results.push(<br key={`line-delim-${index}`} />);
+        results.push(<br key={`line-delim-${index}`}/>);
     });
 
     setOutput(results);

--- a/web/src/screens/settings/RegexPlayground.tsx
+++ b/web/src/screens/settings/RegexPlayground.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Releases.tsx
+++ b/web/src/screens/settings/Releases.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -23,12 +23,12 @@ import { classNames } from "@utils";
 
 const ReleaseSettings = () => (
   <div className="lg:col-span-9">
-    <ReleaseProfileDuplicates />
+    <ReleaseProfileDuplicates/>
 
     <div className="py-6 px-4 sm:p-6">
       <div className="border border-red-500 rounded">
         <div className="py-6 px-4 sm:p-6">
-          <DeleteReleases />
+          <DeleteReleases/>
         </div>
       </div>
     </div>
@@ -45,7 +45,7 @@ function ReleaseProfileListItem({ profile }: ReleaseProfileProps) {
   return (
     <li>
       <div className="grid grid-cols-12 items-center py-2">
-        <ReleaseProfileDuplicateUpdateForm isOpen={updatePanelIsOpen} toggle={toggleUpdatePanel} data={profile} />
+        <ReleaseProfileDuplicateUpdateForm isOpen={updatePanelIsOpen} toggle={toggleUpdatePanel} data={profile}/>
         <div
           className="col-span-2 sm:col-span-2 lg:col-span-2 pl-4 sm:pl-4 pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate"
           title={profile.name}>
@@ -88,9 +88,9 @@ function ReleaseProfileListItem({ profile }: ReleaseProfileProps) {
 }
 
 interface PillProps {
-  value: boolean;
-  label: string;
-  title: string;
+ value: boolean;
+ label: string;
+ title: string;
 }
 
 const EnabledPill = ({ value, label, title }: PillProps) => (
@@ -114,12 +114,12 @@ function ReleaseProfileDuplicates() {
           className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
           onClick={toggleAdd}
         >
-          <PlusIcon className="h-5 w-5 mr-1" />
+          <PlusIcon className="h-5 w-5 mr-1"/>
           Add new
         </button>
       }
     >
-      <ReleaseProfileDuplicateAddForm isOpen={addPanelIsOpen} toggle={toggleAdd} />
+      <ReleaseProfileDuplicateAddForm isOpen={addPanelIsOpen} toggle={toggleAdd}/>
 
       <div className="flex flex-col">
         {releaseProfileQuery.data.length > 0 ? (
@@ -148,12 +148,12 @@ function ReleaseProfileDuplicates() {
               {/*</div>*/}
             </li>
             {releaseProfileQuery.data.map((profile) => (
-              <ReleaseProfileListItem key={profile.id} profile={profile} />
+              <ReleaseProfileListItem key={profile.id} profile={profile}/>
             ))}
           </ul>
         ) : (
           <EmptySimple title="No duplicate rlease profiles" subtitle="" buttonText="Add new profile"
-            buttonAction={toggleAdd} />
+                       buttonAction={toggleAdd}/>
         )}
       </div>
     </Section>
@@ -216,12 +216,12 @@ function DeleteReleases() {
     onSuccess: () => {
       if (parsedDuration === 0) {
         toast.custom((t) => (
-          <Toast type="success" body={"All releases based on criteria were deleted."} t={t} />
+          <Toast type="success" body={"All releases based on criteria were deleted."} t={t}/>
         ));
       } else {
         toast.custom((t) => (
           <Toast type="success" body={`Releases older than ${getDurationLabel(parsedDuration ?? 0)} were deleted.`}
-            t={t} />
+                 t={t}/>
         ));
       }
 
@@ -231,7 +231,7 @@ function DeleteReleases() {
 
   const deleteOlderReleases = () => {
     if (parsedDuration === undefined || isNaN(parsedDuration) || parsedDuration < 0) {
-      toast.custom((t) => <Toast type="error" body={"Please select a valid age."} t={t} />);
+      toast.custom((t) => <Toast type="error" body={"Please select a valid age."} t={t}/>);
       return;
     }
 
@@ -260,18 +260,18 @@ function DeleteReleases() {
             Select the criteria below to permanently delete release history records that are older than the chosen age
             and optionally match the selected indexers and release statuses:
           </p>
-          <ul className="list-disc pl-5 my-4 text-sm text-gray-500 dark:text-gray-400">
-            <li>
-              Older than (e.g., 6 months - all records older than 6 months will be deleted) - <strong
+            <ul className="list-disc pl-5 my-4 text-sm text-gray-500 dark:text-gray-400">
+              <li>
+                Older than (e.g., 6 months - all records older than 6 months will be deleted) - <strong
                 className="text-gray-600 dark:text-gray-300">Required</strong>
-            </li>
-            <li>Indexers - Optional (if none selected, applies to all indexers)</li>
-            <li>Release statuses - Optional (if none selected, applies to all release statuses)</li>
-          </ul>
-          <span className="pt-2 text-red-600 dark:text-red-500">
-            <strong>Warning:</strong> If no indexers or release statuses are selected, all release history records
-            older than the selected age will be permanently deleted, regardless of indexer or status.
-          </span>
+              </li>
+              <li>Indexers - Optional (if none selected, applies to all indexers)</li>
+              <li>Release statuses - Optional (if none selected, applies to all release statuses)</li>
+            </ul>
+            <span className="pt-2 text-red-600 dark:text-red-500">
+              <strong>Warning:</strong> If no indexers or release statuses are selected, all release history records
+              older than the selected age will be permanently deleted, regardless of indexer or status.
+            </span>
         </div>
 
         <div className="flex flex-col sm:flex-row gap-2 pt-4 items-center text-sm">
@@ -283,18 +283,18 @@ function DeleteReleases() {
                   <span className="text-red-600 dark:text-red-500"> *</span>
                 </span>
               ),
-              content: <AgeSelect duration={duration} setDuration={setDuration} setParsedDuration={setParsedDuration} />
+              content: <AgeSelect duration={duration} setDuration={setDuration} setParsedDuration={setParsedDuration}/>
             },
             {
               label: 'Indexers:',
               content: <RMSC
                 options={indexerOptions?.map(option => ({ value: option.identifier, label: option.name })) || []}
-                value={indexers} onChange={setIndexers} labelledBy="Select indexers" />
+                value={indexers} onChange={setIndexers} labelledBy="Select indexers"/>
             },
             {
               label: 'Release statuses:',
               content: <RMSC options={releaseStatusOptions} value={releaseStatuses} onChange={setReleaseStatuses}
-                labelledBy="Select release statuses" />
+                             labelledBy="Select release statuses"/>
             }
           ].map((item, index) => (
             <div key={index} className="flex flex-col w-full">

--- a/web/src/screens/settings/Releases.tsx
+++ b/web/src/screens/settings/Releases.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/Releases.tsx
+++ b/web/src/screens/settings/Releases.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -23,12 +23,12 @@ import { classNames } from "@utils";
 
 const ReleaseSettings = () => (
   <div className="lg:col-span-9">
-    <ReleaseProfileDuplicates/>
+    <ReleaseProfileDuplicates />
 
     <div className="py-6 px-4 sm:p-6">
       <div className="border border-red-500 rounded">
         <div className="py-6 px-4 sm:p-6">
-          <DeleteReleases/>
+          <DeleteReleases />
         </div>
       </div>
     </div>
@@ -45,7 +45,7 @@ function ReleaseProfileListItem({ profile }: ReleaseProfileProps) {
   return (
     <li>
       <div className="grid grid-cols-12 items-center py-2">
-        <ReleaseProfileDuplicateUpdateForm isOpen={updatePanelIsOpen} toggle={toggleUpdatePanel} data={profile}/>
+        <ReleaseProfileDuplicateUpdateForm isOpen={updatePanelIsOpen} toggle={toggleUpdatePanel} data={profile} />
         <div
           className="col-span-2 sm:col-span-2 lg:col-span-2 pl-4 sm:pl-4 pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate"
           title={profile.name}>
@@ -88,9 +88,9 @@ function ReleaseProfileListItem({ profile }: ReleaseProfileProps) {
 }
 
 interface PillProps {
- value: boolean;
- label: string;
- title: string;
+  value: boolean;
+  label: string;
+  title: string;
 }
 
 const EnabledPill = ({ value, label, title }: PillProps) => (
@@ -114,12 +114,12 @@ function ReleaseProfileDuplicates() {
           className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
           onClick={toggleAdd}
         >
-          <PlusIcon className="h-5 w-5 mr-1"/>
+          <PlusIcon className="h-5 w-5 mr-1" />
           Add new
         </button>
       }
     >
-      <ReleaseProfileDuplicateAddForm isOpen={addPanelIsOpen} toggle={toggleAdd}/>
+      <ReleaseProfileDuplicateAddForm isOpen={addPanelIsOpen} toggle={toggleAdd} />
 
       <div className="flex flex-col">
         {releaseProfileQuery.data.length > 0 ? (
@@ -148,12 +148,12 @@ function ReleaseProfileDuplicates() {
               {/*</div>*/}
             </li>
             {releaseProfileQuery.data.map((profile) => (
-              <ReleaseProfileListItem key={profile.id} profile={profile}/>
+              <ReleaseProfileListItem key={profile.id} profile={profile} />
             ))}
           </ul>
         ) : (
           <EmptySimple title="No duplicate rlease profiles" subtitle="" buttonText="Add new profile"
-                       buttonAction={toggleAdd}/>
+            buttonAction={toggleAdd} />
         )}
       </div>
     </Section>
@@ -216,12 +216,12 @@ function DeleteReleases() {
     onSuccess: () => {
       if (parsedDuration === 0) {
         toast.custom((t) => (
-          <Toast type="success" body={"All releases based on criteria were deleted."} t={t}/>
+          <Toast type="success" body={"All releases based on criteria were deleted."} t={t} />
         ));
       } else {
         toast.custom((t) => (
           <Toast type="success" body={`Releases older than ${getDurationLabel(parsedDuration ?? 0)} were deleted.`}
-                 t={t}/>
+            t={t} />
         ));
       }
 
@@ -231,7 +231,7 @@ function DeleteReleases() {
 
   const deleteOlderReleases = () => {
     if (parsedDuration === undefined || isNaN(parsedDuration) || parsedDuration < 0) {
-      toast.custom((t) => <Toast type="error" body={"Please select a valid age."} t={t}/>);
+      toast.custom((t) => <Toast type="error" body={"Please select a valid age."} t={t} />);
       return;
     }
 
@@ -260,18 +260,18 @@ function DeleteReleases() {
             Select the criteria below to permanently delete release history records that are older than the chosen age
             and optionally match the selected indexers and release statuses:
           </p>
-            <ul className="list-disc pl-5 my-4 text-sm text-gray-500 dark:text-gray-400">
-              <li>
-                Older than (e.g., 6 months - all records older than 6 months will be deleted) - <strong
+          <ul className="list-disc pl-5 my-4 text-sm text-gray-500 dark:text-gray-400">
+            <li>
+              Older than (e.g., 6 months - all records older than 6 months will be deleted) - <strong
                 className="text-gray-600 dark:text-gray-300">Required</strong>
-              </li>
-              <li>Indexers - Optional (if none selected, applies to all indexers)</li>
-              <li>Release statuses - Optional (if none selected, applies to all release statuses)</li>
-            </ul>
-            <span className="pt-2 text-red-600 dark:text-red-500">
-              <strong>Warning:</strong> If no indexers or release statuses are selected, all release history records
-              older than the selected age will be permanently deleted, regardless of indexer or status.
-            </span>
+            </li>
+            <li>Indexers - Optional (if none selected, applies to all indexers)</li>
+            <li>Release statuses - Optional (if none selected, applies to all release statuses)</li>
+          </ul>
+          <span className="pt-2 text-red-600 dark:text-red-500">
+            <strong>Warning:</strong> If no indexers or release statuses are selected, all release history records
+            older than the selected age will be permanently deleted, regardless of indexer or status.
+          </span>
         </div>
 
         <div className="flex flex-col sm:flex-row gap-2 pt-4 items-center text-sm">
@@ -283,18 +283,18 @@ function DeleteReleases() {
                   <span className="text-red-600 dark:text-red-500"> *</span>
                 </span>
               ),
-              content: <AgeSelect duration={duration} setDuration={setDuration} setParsedDuration={setParsedDuration}/>
+              content: <AgeSelect duration={duration} setDuration={setDuration} setParsedDuration={setParsedDuration} />
             },
             {
               label: 'Indexers:',
               content: <RMSC
                 options={indexerOptions?.map(option => ({ value: option.identifier, label: option.name })) || []}
-                value={indexers} onChange={setIndexers} labelledBy="Select indexers"/>
+                value={indexers} onChange={setIndexers} labelledBy="Select indexers" />
             },
             {
               label: 'Release statuses:',
               content: <RMSC options={releaseStatusOptions} value={releaseStatuses} onChange={setReleaseStatuses}
-                             labelledBy="Select release statuses"/>
+                labelledBy="Select release statuses" />
             }
           ].map((item, index) => (
             <div key={index} className="flex flex-col w-full">

--- a/web/src/screens/settings/_components.tsx
+++ b/web/src/screens/settings/_components.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/_components.tsx
+++ b/web/src/screens/settings/_components.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/index.ts
+++ b/web/src/screens/settings/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/screens/settings/index.ts
+++ b/web/src/screens/settings/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/API.d.ts
+++ b/web/src/types/API.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/API.d.ts
+++ b/web/src/types/API.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Config.d.ts
+++ b/web/src/types/Config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Config.d.ts
+++ b/web/src/types/Config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Download.d.ts
+++ b/web/src/types/Download.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Download.d.ts
+++ b/web/src/types/Download.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Feed.d.ts
+++ b/web/src/types/Feed.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Feed.d.ts
+++ b/web/src/types/Feed.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Filter.d.ts
+++ b/web/src/types/Filter.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Filter.d.ts
+++ b/web/src/types/Filter.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Global.d.ts
+++ b/web/src/types/Global.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Global.d.ts
+++ b/web/src/types/Global.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Indexer.d.ts
+++ b/web/src/types/Indexer.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Indexer.d.ts
+++ b/web/src/types/Indexer.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Irc.d.ts
+++ b/web/src/types/Irc.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Irc.d.ts
+++ b/web/src/types/Irc.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/List.d.ts
+++ b/web/src/types/List.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/List.d.ts
+++ b/web/src/types/List.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Notification.d.ts
+++ b/web/src/types/Notification.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Notification.d.ts
+++ b/web/src/types/Notification.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Proxy.d.ts
+++ b/web/src/types/Proxy.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Proxy.d.ts
+++ b/web/src/types/Proxy.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Release.d.ts
+++ b/web/src/types/Release.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Release.d.ts
+++ b/web/src/types/Release.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Update.d.ts
+++ b/web/src/types/Update.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/types/Update.d.ts
+++ b/web/src/types/Update.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2024, Ludvig Lundgren and the autobrr contributors.
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 


### PR DESCRIPTION
Looks like maybe gofmt sorted a couple of imports in a few files in the process.

Added missing headers to files in https://github.com/autobrr/autobrr/pull/1929/commits/ce53b9d798cbaad8c747e8fcf93fdd10a5f68e2c