### PR TITLE
feat(indexers): MAM filter VIP with release tags

### DIFF
--- a/internal/indexer/definitions/myanonamouse.yaml
+++ b/internal/indexer/definitions/myanonamouse.yaml
@@ -61,7 +61,7 @@ irc:
             language: English
             baseUrl: https://www.myanonamouse.net/
             torrentId: "000000"
-            freeleech: ""
+            releaseTags: ""
         - line: 'New Torrent: Some famous book By: Author name Category: ( Ebooks - Science Fiction ) Size: ( 2.11 MiB ) Filetype: ( epub, mobi ) Language: ( English ) Link: ( https://www.myanonamouse.net/t/000000 ) VIP'
           expect:
             torrentName: Some famous book
@@ -72,7 +72,7 @@ irc:
             language: English
             baseUrl: https://www.myanonamouse.net/
             torrentId: "000000"
-            freeleech: VIP
+            releaseTags: VIP
         pattern: 'New Torrent: (.*) By: (.*) Category: \( (.*) \) Size: \( (.*) \) Filetype: \( (.*) \) Language: \( (.*) \) Link: \( (https?\:\/\/[^\/]+\/).*?(\d+)\s*\)\s*(VIP)?'
         vars:
           - torrentName
@@ -83,7 +83,12 @@ irc:
           - language
           - baseUrl
           - torrentId
-          - freeleech
+          - releaseTags
+
+    mappings:
+      releaseTags:
+        "VIP":
+          freeleech: VIP
 
     match:
       infourl: "/t/{{ .torrentId }}"


### PR DESCRIPTION
This PR changes the parsing of `VIP` on `MAM` to be captured by `releaseTags` which makes it easy to filter for or ignore with `Match Release Tags` and `Except Release Tags`.

This is backwards compatible thanks to the variable mapping which still sets freeleech if it's flagged as VIP.

Ref discussion https://github.com/autobrr/autobrr/discussions/1666