### PR TITLE
refactor(lists): title variation processing

### DIFF
--- a/internal/list/title_test.go
+++ b/internal/list/title_test.go
@@ -277,6 +277,14 @@ func Test_processTitle(t *testing.T) {
 			},
 			want: []string{"pok?mon"},
 		},
+		{
+			name: "test_33",
+			args: args{
+				title:        "What If…?",
+				matchRelease: true,
+			},
+			want: []string{"*What?If*"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Refactored the title processing for lists to get rid of a lot of code duplication.
Also fixed an issue with `Add` logic to make sure we don't end up with multiple wildcards at the end of processed titles when `matchRelease` is set to `true`. Added a new test case for that as well.