### PR TITLE
docs(indexers): update MAM cookie help text

### DIFF
--- a/internal/indexer/definitions/myanonamouse.yaml
+++ b/internal/indexer/definitions/myanonamouse.yaml
@@ -17,7 +17,7 @@ settings:
     type: secret
     required: true
     label: Cookie (mam_id)
-    help: "Check how to get cookies in your browser and find the mam_id cookie. Changes monthly. Format mam_id=$ID;"
+    help: "Under your username, go to preferences then security and generate a session using the IP address Autobrr runs on. Changes monthly. Format mam_id=$ID;"
 
 irc:
   network: MyAnonamouse


### PR DESCRIPTION
Updated the help text to include how to generate the session properly tied to the IP address that Autobrr is running from.