### PR TITLE
Adding support for new announcer name (Speedapp.io)

### DIFF
--- a/internal/indexer/definitions/speedapp.yaml
+++ b/internal/indexer/definitions/speedapp.yaml
@@ -27,6 +27,7 @@ irc:
     - "#speedapp"
   announcers:
     - speedapp-announcer
+    - speedapp-announcer4
   settings:
     - name: nick
       type: text


### PR DESCRIPTION
As per issue 1971 - https://github.com/autobrr/autobrr/issues/1971

Announcer name has changed for Speedapp.io - this changes the definition to support the new name