### PR TITLE
fix(oidc): fetch claims from Userinfo endpoint

### DIFF
--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -258,6 +258,7 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) (*O
 			Username string `json:"preferred_username"`
 			Name     string `json:"name"`
 			Nickname string `json:"nickname"`
+			Picture  string `json:"picture"`
 		}
 		if err := userInfo.Claims(&userInfoClaims); err != nil {
 			h.log.Warn().Err(err).Msg("failed to parse claims from userinfo endpoint, proceeding with ID token claims if available")
@@ -275,6 +276,9 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) (*O
 			}
 			if userInfoClaims.Nickname != "" {
 				claims.Nickname = userInfoClaims.Nickname
+			}
+			if userInfoClaims.Picture != "" {
+				claims.Picture = userInfoClaims.Picture
 			}
 		}
 	}

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -234,10 +234,6 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) (st
 	userInfo, err := h.provider.UserInfo(r.Context(), oauth2.StaticTokenSource(oauth2Token))
 	if err != nil {
 		h.log.Error().Err(err).Msg("failed to get userinfo")
-		// Depending on the provider, this might be optional.
-		// For now, log the error but continue, as ID token claims might be sufficient.
-		// If userinfo is strictly required, return an error here.
-		// return "", errors.Wrap(err, "failed to get userinfo")
 	}
 
 	var claims struct {
@@ -252,8 +248,6 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) (st
 	// try parsing claims from the ID token
 	if err := idToken.Claims(&claims); err != nil {
 		h.log.Error().Err(err).Msg("failed to parse claims from ID token")
-		// If ID token parsing fails, we might still rely on Userinfo
-		// return "", errors.Wrap(err, "failed to parse claims from ID token")
 	}
 
 	if userInfo != nil {

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -292,7 +292,7 @@ func (h *OIDCHandler) HandleCallback(w http.ResponseWriter, r *http.Request) (st
 		}
 	}
 
-	h.log.Debug().Str("username", username).Str("claim_email", claims.Email).Str("claim_preferred_username", claims.Username).Str("claim_nickname", claims.Nickname).Str("claim_name", claims.Name).Str("claim_sub", claims.Sub).Msg("successfully processed and merged OIDC claims")
+	h.log.Debug().Str("username", username).Str("email", claims.Email).Str("preferred_username", claims.Username).Str("nickname", claims.Nickname).Str("name", claims.Name).Str("sub", claims.Sub).Msg("successfully processed OIDC claims")
 
 	return username, nil
 }


### PR DESCRIPTION
Adds call to OIDC Userinfo endpoint to retrieve user claims. Merges these with ID Token claims, prioritizing Userinfo for attributes like `preferred_username`.

This ensures user details are correctly obtained even when the provider does not include them directly in the ID Token, resolving issues where the username defaulted to the 'sub' claim.

Tested with Pocket ID by commenting out claims from ID Token, and it correctly fetched from Userinfo endpoint.

Fixes #2013