### PR TITLE
feat(lists): read Plaintext from file on disk

### DIFF
--- a/internal/list/process_list_plaintext.go
+++ b/internal/list/process_list_plaintext.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -23,33 +25,66 @@ func (s *service) plaintext(ctx context.Context, list *domain.List) error {
 
 	l.Debug().Msgf("fetching titles from %s", list.URL)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, list.URL, nil)
+	// Parse the URL to determine if it's a file or HTTP scheme
+	parsedURL, err := url.Parse(list.URL)
 	if err != nil {
-		return errors.Wrapf(err, "could not make new request for URL: %s", list.URL)
+		return errors.Wrapf(err, "failed to parse URL: %s", list.URL)
 	}
 
-	list.SetRequestHeaders(req)
+	var body []byte
 
-	//setUserAgent(req)
+	// Handle different URL schemes
+	switch parsedURL.Scheme {
+	case "file":
+		// Read from filesystem for file:// URLs
+		filePath := parsedURL.Path
+		// On Windows, remove leading slash from path if needed
+		if len(filePath) > 0 && filePath[0] == '/' && len(parsedURL.Host) > 0 {
+			filePath = parsedURL.Host + filePath
+		} else if len(filePath) > 0 && filePath[0] == '/' {
+			filePath = filePath[1:]
+		}
 
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return errors.Wrapf(err, "failed to fetch titles from URL: %s", list.URL)
-	}
-	defer resp.Body.Close()
+		l.Debug().Msgf("reading from file: %s", filePath)
 
-	if resp.StatusCode != http.StatusOK {
-		return errors.Wrapf(err, "failed to fetch titles from URL: %s", list.URL)
-	}
+		body, err = os.ReadFile(filePath)
+		if err != nil {
+			return errors.Wrapf(err, "failed to read file: %s", filePath)
+		}
 
-	contentType := resp.Header.Get("Content-Type")
-	if !strings.HasPrefix(contentType, "text/plain") {
-		return errors.Wrapf(err, "unexpected content type for URL: %s expected text/plain got %s", list.URL, contentType)
-	}
+	case "http", "https":
+		// Use HTTP client for http:// or https:// URLs
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, list.URL, nil)
+		if err != nil {
+			return errors.Wrapf(err, "could not make new request for URL: %s", list.URL)
+		}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return errors.Wrapf(err, "failed to read response body from URL: %s", list.URL)
+		list.SetRequestHeaders(req)
+
+		//setUserAgent(req)
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return errors.Wrapf(err, "failed to fetch titles from URL: %s", list.URL)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return errors.Wrapf(err, "failed to fetch titles from URL: %s with status code: %d", list.URL, resp.StatusCode)
+		}
+
+		contentType := resp.Header.Get("Content-Type")
+		if !strings.HasPrefix(contentType, "text/plain") {
+			return errors.Errorf("unexpected content type for URL: %s expected text/plain got %s", list.URL, contentType)
+		}
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(err, "failed to read response body from URL: %s", list.URL)
+		}
+
+	default:
+		return errors.Errorf("unsupported URL scheme: %s", parsedURL.Scheme)
 	}
 
 	var titles []string
@@ -74,7 +109,7 @@ func (s *service) plaintext(ctx context.Context, list *domain.List) error {
 
 	joinedTitles := strings.Join(filterTitles, ",")
 
-	l.Trace().Str("titles", joinedTitles).Msgf("found %d titles", len(joinedTitles))
+	l.Trace().Str("titles", joinedTitles).Msgf("found %d titles", len(filterTitles))
 
 	filterUpdate := domain.FilterUpdate{Shows: &joinedTitles}
 

--- a/web/src/forms/settings/ListForms.tsx
+++ b/web/src/forms/settings/ListForms.tsx
@@ -63,6 +63,7 @@ import { DocsTooltip } from "@components/tooltips/DocsTooltip";
 import { MultiSelect as RMSC } from "react-multi-select-component";
 import { useToggle } from "@hooks/hooks.ts";
 import { DeleteModal } from "@components/modals";
+import {DocsLink} from "@components/ExternalLink.tsx";
 
 interface ListAddFormValues {
   name: string;
@@ -729,6 +730,16 @@ function ListTypePlainText() {
         label="List URL"
         help="URL to a plain text file with one item per line"
         placeholder="https://example.com/list.txt"
+        tooltip={
+            <div>
+                <p>Plaintext list can read from both http urls and local files on disk.</p>
+                <br />
+                <p>Remote: https://service.com/file.txt</p>
+                <br />
+                <p>Local: file:///home/username/file.txt</p>
+                <DocsLink href="https://autobrr.com/filters/lists" />
+            </div>
+        }
       />
 
       <div className="space-y-1">


### PR DESCRIPTION
Add support to read plaintext lists from file on disk with URL as `file:///home/user/list.txt`.