### PR TITLE
Update uploadcx torrent url (download link)

### DIFF
--- a/internal/indexer/definitions/uploadcx.yaml
+++ b/internal/indexer/definitions/uploadcx.yaml
@@ -97,4 +97,4 @@ irc:
 
     match:
       infourl: "/torrents/{{ .torrentId }}"
-      torrenturl: "/torrent/download/{{ .torrentId }}.{{ .rsskey }}"
+      torrenturl: "/torrents/download/{{ .torrentId }}.{{ .rsskey }}"


### PR DESCRIPTION
The torrent file download url for Upload.cx _may_ have changed from [/torrent/download/] to [/torrents/download/].
I'm getting 404 with [/torrent/download/] on all my autobrr filter matches.

Might close #2037 (pending: need help on testing this)