### PR TITLE
fix(metrics): irc channel enabled gauge

### DIFF
--- a/internal/metrics/collector/irc.go
+++ b/internal/metrics/collector/irc.go
@@ -59,7 +59,7 @@ func (collector *ircCollector) Collect(ch chan<- prometheus.Metric) {
 		channelsEnabled := 0
 		channelsMonitoring := 0
 		for _, c := range n.Channels {
-			if c.Enabled {
+			if n.Enabled && c.Enabled {
 				channelsEnabled++
 			}
 			if c.Monitoring {


### PR DESCRIPTION
Plz see https://github.com/autobrr/autobrr/discussions/2035

Currently a channel is only considered enabled if it's enabled in the db.

However when you disable an IRC server, its channel remains enabled in the db but should be considered disabled in the metrics.