### PR TITLE
feat(indexers): add T66y

### DIFF
--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -433,11 +433,6 @@ func (p *IndexerIRCParse) Parse(def *IndexerDefinition, vars map[string]string, 
 		return errors.Wrap(err, "could not parse release name")
 	}
 
-	// parse torrent hash
-	if err := def.IRC.Parse.Match.ParseTorrentHash(mergedVars, rls); err != nil {
-		return errors.Wrap(err, "could not parse release hash")
-	}
-
 	var parser IRCParser
 
 	switch def.Identifier {

--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -364,24 +364,6 @@ func (p *IndexerIRCParseMatch) ParseTorrentName(vars map[string]string, rls *Rel
 	return nil
 }
 
-func (p *IndexerIRCParseMatch) ParseTorrentHash(vars map[string]string, rls *Release) error {
-	if p.TorrentHash != "" {
-		tmplTorrentHash, err := template.New("torrenthash").Funcs(sprig.TxtFuncMap()).Parse(p.TorrentHash)
-		if err != nil {
-			return err
-		}
-
-		var torrentHashBytes bytes.Buffer
-		if err := tmplTorrentHash.Execute(&torrentHashBytes, &vars); err != nil {
-			return errors.New("could not write torrent hash template output")
-		}
-
-		rls.TorrentHash = torrentHashBytes.String()
-	}
-
-	return nil
-}
-
 func (p *IndexerIRCParse) MapCustomVariables(vars map[string]string) error {
 	for varsKey, varsKeyMap := range p.Mappings {
 		varsValue, ok := vars[varsKey]

--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -250,7 +250,6 @@ type IndexerIRCParseLine struct {
 type IndexerIRCParseMatch struct {
 	TorrentURL  string   `json:"torrenturl"`
 	TorrentName string   `json:"torrentname"`
-	TorrentHash string   `json:"torrenthash"`
 	MagnetURI   string   `json:"magneturi"`
 	InfoURL     string   `json:"infourl"`
 	Encode      []string `json:"encode"`

--- a/internal/domain/indexer_test.go
+++ b/internal/domain/indexer_test.go
@@ -14,6 +14,7 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 	type fields struct {
 		TorrentURL  string
 		TorrentName string
+		MagnetURI   string
 		InfoURL     string
 		Encode      []string
 	}
@@ -150,16 +151,34 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 				DownloadURL: "https://mock.local/rss/?action=download&key=KEY&token=TOKEN&hash=240860011&title=The+Show+2019+S03E08+2160p+DV+WEBRip+6CH+x265+HEVC-GROUP",
 			},
 		},
+		{
+			name: "magnet_uri",
+			fields: fields{
+				MagnetURI: "magnet:?xt=urn:btih:{{ .torrentHash }}&dn={{ urlquery .torrentName }}",
+			},
+			args: args{
+				vars: map[string]string{
+					"torrentHash": "81c758d0eca5372d59e43879ecf2e2bce33a06c4",
+					"torrentName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
+				},
+				rls: &Release{},
+			},
+			want: &Release{
+				MagnetURI: "magnet:?xt=urn:btih:81c758d0eca5372d59e43879ecf2e2bce33a06c4&dn=The+Show+2019+S03E08+2160p+DV+WEBRip+6CH+x265+HEVC-GROUP",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &IndexerIRCParseMatch{
 				TorrentURL:  tt.fields.TorrentURL,
 				TorrentName: tt.fields.TorrentName,
+				MagnetURI:   tt.fields.MagnetURI,
 				InfoURL:     tt.fields.InfoURL,
 				Encode:      tt.fields.Encode,
 			}
-			p.ParseURLs(tt.args.baseURL, tt.args.vars, tt.args.rls)
+			err := p.ParseURLs(tt.args.baseURL, tt.args.vars, tt.args.rls)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, tt.args.rls)
 		})
 	}

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -161,10 +161,14 @@ type IRCParser interface {
 
 type IRCParserDefault struct{}
 
-func (p IRCParserDefault) Parse(rls *Release, _ map[string]string) error {
+func (p IRCParserDefault) Parse(rls *Release, vars map[string]string) error {
 	// parse fields
 	// run before ParseMatch to not potentially use a reconstructed TorrentName
 	rls.ParseString(rls.TorrentName)
+
+	if vars["torrenthash"] != "" {
+		rls.TorrentHash = vars["torrenthash"]
+	}
 
 	return nil
 }

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -166,10 +166,6 @@ func (p IRCParserDefault) Parse(rls *Release, vars map[string]string) error {
 	// run before ParseMatch to not potentially use a reconstructed TorrentName
 	rls.ParseString(rls.TorrentName)
 
-	if vars["torrenthash"] != "" {
-		rls.TorrentHash = vars["torrenthash"]
-	}
-
 	return nil
 }
 

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -161,7 +161,7 @@ type IRCParser interface {
 
 type IRCParserDefault struct{}
 
-func (p IRCParserDefault) Parse(rls *Release, vars map[string]string) error {
+func (p IRCParserDefault) Parse(rls *Release, _ map[string]string) error {
 	// parse fields
 	// run before ParseMatch to not potentially use a reconstructed TorrentName
 	rls.ParseString(rls.TorrentName)

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -964,6 +964,10 @@ func (r *Release) MapVars(def *IndexerDefinition, varMap map[string]string) erro
 		r.TorrentName = html.UnescapeString(torrentName)
 	}
 
+	if torrentHash, err := getStringMapValue(varMap, "torrentHash"); err == nil {
+		r.TorrentHash = torrentHash
+	}
+
 	if torrentID, err := getStringMapValue(varMap, "torrentId"); err == nil {
 		r.TorrentID = torrentID
 	}

--- a/internal/indexer/definitions/t66y.yaml
+++ b/internal/indexer/definitions/t66y.yaml
@@ -1,0 +1,76 @@
+---
+#id: t66y
+name: T66y
+identifier: t66y
+description: T66y is an indexer for the Caoliu Community.
+language: en-us
+urls:
+  - https://t66y.com/
+privacy: public
+protocol: torrent
+supports:
+  - irc
+#source: custom
+
+irc:
+  network: Rizon
+  server: irc.rizon.net
+  port: 6697
+  tls: true
+  channels:
+    - '#t66y'
+  announcers:
+    - 'ty'
+  settings:
+    - name: nick
+      type: text
+      required: true
+      label: Nick
+      help: Bot nick. Eg. user_bot
+
+    - name: auth.account
+      type: text
+      required: false
+      label: NickServ Account
+      help: NickServ account. Make sure to group your main user and bot.
+
+    - name: auth.password
+      type: secret
+      required: false
+      label: NickServ Password
+      help: NickServ password
+
+  parse:
+    type: single
+    lines:
+      - tests:
+          - line: '6769288 28 f3df71e5bdf2ca66168be7c1390e5685742bf6a8 [MP4/3.81G]JUR-274【破壊版】会社の地味な人妻経理を≪濃厚マゾ潮≫吹き散らかす、俺専用の愛人に仕立て上げた―。 椎名ゆな    em(6769288)'
+            expect:
+              postId: 6769288
+              category: 28
+              torrentHash: f4a122e2684045f45ed10f4ca803852fd94e70e7
+              torrentName: '[MP4/3.81G]JUR-274【破壊版】会社の地味な人妻経理を≪濃厚マゾ潮≫吹き散らかす、俺専用の愛人に仕立て上げた―。 椎名ゆな    em(6769288)'
+
+          - line: '6768519 4 39d9edb94572e82dd534547b785c98fe2df7ea51 [MP4/FHD]RARBG1023625-第一视角催情SPA性交'
+            expect:
+              postId: 6768519
+              category: 4
+              torrentHash: f4a122e2684045f45ed10f4ca803852fd94e70e7
+              torrentName: '[MP4/FHD]RARBG1023650-足交后入'
+
+          - line: '6768127 2 81c758d0eca5372d59e43879ecf2e2bce33a06c4 [MP4/3.83G]fc2-ppv-3270070 幼さが残る18才の黒髪清楚の女の子。 夢の為にAV撮影、はじめての中出しまで    em(6768127)'
+            expect:
+              postId: 6768127
+              category: 2
+              torrentHash: f4a122e2684045f45ed10f4ca803852fd94e70e7
+              torrentName: '[MP4/3.83G]fc2-ppv-3270070 幼さが残る18才の黒髪清楚の女の子。 夢の為にAV撮影、はじめての中出しまで    em(6768127)'
+
+        pattern: '(\d+)\ (\d+)\ ([a-z0-9]{40})\ (.*)'
+        vars:
+          - postId
+          - category
+          - torrentHash
+          - torrentName
+
+    match:
+      magneturi: 'magnet:?xt=urn:btih:{{ .torrentHash }}&dn={{ urlquery .torrentName }}&tr=http://sukebei.tracker.wf:8888/announce&tr=udp://tracker.opentrackr.org:1337/announce&tr=http://tracker.bt4g.com:2095/announce&tr=http://1337.abcvg.info/announce&tr=http://tracker.opentrackr.org:1337/announce&tr=http://93.158.213.92:1337/announce&tr=udp://open.stealth.si:80/announce&tr=udp://exodus.desync.com:6969/announce&tr=udp://tracker.torrent.eu.org:451/announce'

--- a/internal/indexer/definitions/t66y.yaml
+++ b/internal/indexer/definitions/t66y.yaml
@@ -73,4 +73,4 @@ irc:
           - torrentName
 
     match:
-      magneturi: 'magnet:?xt=urn:btih:{{ .torrentHash }}&dn={{ urlquery .torrentName }}&tr=http://sukebei.tracker.wf:8888/announce&tr=udp://tracker.opentrackr.org:1337/announce&tr=http://tracker.bt4g.com:2095/announce&tr=http://1337.abcvg.info/announce&tr=http://tracker.opentrackr.org:1337/announce&tr=http://93.158.213.92:1337/announce&tr=udp://open.stealth.si:80/announce&tr=udp://exodus.desync.com:6969/announce&tr=udp://tracker.torrent.eu.org:451/announce'
+      magneturi: 'magnet:?xt=urn:btih:{{ .torrentHash }}&dn={{ urlquery .torrentName }}'

--- a/internal/indexer/definitions/t66y.yaml
+++ b/internal/indexer/definitions/t66y.yaml
@@ -55,14 +55,14 @@ irc:
             expect:
               postId: 6768519
               category: 4
-              torrentHash: f4a122e2684045f45ed10f4ca803852fd94e70e7
+              torrentHash: 39d9edb94572e82dd534547b785c98fe2df7ea51
               torrentName: '[MP4/FHD]RARBG1023650-足交后入'
 
           - line: '6768127 2 81c758d0eca5372d59e43879ecf2e2bce33a06c4 [MP4/3.83G]fc2-ppv-3270070 幼さが残る18才の黒髪清楚の女の子。 夢の為にAV撮影、はじめての中出しまで    em(6768127)'
             expect:
               postId: 6768127
               category: 2
-              torrentHash: f4a122e2684045f45ed10f4ca803852fd94e70e7
+              torrentHash: 81c758d0eca5372d59e43879ecf2e2bce33a06c4
               torrentName: '[MP4/3.83G]fc2-ppv-3270070 幼さが残る18才の黒髪清楚の女の子。 夢の為にAV撮影、はじめての中出しまで    em(6768127)'
 
         pattern: '(\d+)\ (\d+)\ ([a-z0-9]{40})\ (.*)'

--- a/internal/indexer/definitions/t66y.yaml
+++ b/internal/indexer/definitions/t66y.yaml
@@ -44,26 +44,26 @@ irc:
     type: single
     lines:
       - tests:
-          - line: '6769288 28 f3df71e5bdf2ca66168be7c1390e5685742bf6a8 [MP4/3.81G]JUR-274【破壊版】会社の地味な人妻経理を≪濃厚マゾ潮≫吹き散らかす、俺専用の愛人に仕立て上げた―。 椎名ゆな    em(6769288)'
+          - line: '6769288 28 f3df71e5bdf2ca66168be7c1390e5685742bf6a8 [MP4/3.81G]JUR-274【破壊版】会社の地味な人妻経理を≪濃厚マゾ潮≫吹き散らかす、俺専用の愛人に仕立て上げた―。 椎名ゆな'
             expect:
               postId: 6769288
               category: 28
-              torrentHash: f4a122e2684045f45ed10f4ca803852fd94e70e7
-              torrentName: '[MP4/3.81G]JUR-274【破壊版】会社の地味な人妻経理を≪濃厚マゾ潮≫吹き散らかす、俺専用の愛人に仕立て上げた―。 椎名ゆな    em(6769288)'
+              torrentHash: f3df71e5bdf2ca66168be7c1390e5685742bf6a8
+              torrentName: '[MP4/3.81G]JUR-274【破壊版】会社の地味な人妻経理を≪濃厚マゾ潮≫吹き散らかす、俺専用の愛人に仕立て上げた―。 椎名ゆな'
 
           - line: '6768519 4 39d9edb94572e82dd534547b785c98fe2df7ea51 [MP4/FHD]RARBG1023625-第一视角催情SPA性交'
             expect:
               postId: 6768519
               category: 4
               torrentHash: 39d9edb94572e82dd534547b785c98fe2df7ea51
-              torrentName: '[MP4/FHD]RARBG1023650-足交后入'
+              torrentName: '[MP4/FHD]RARBG1023625-第一视角催情SPA性交'
 
-          - line: '6768127 2 81c758d0eca5372d59e43879ecf2e2bce33a06c4 [MP4/3.83G]fc2-ppv-3270070 幼さが残る18才の黒髪清楚の女の子。 夢の為にAV撮影、はじめての中出しまで    em(6768127)'
+          - line: '6768127 2 81c758d0eca5372d59e43879ecf2e2bce33a06c4 [MP4/3.83G]fc2-ppv-3270070 幼さが残る18才の黒髪清楚の女の子。 夢の為にAV撮影、はじめての中出しまで'
             expect:
               postId: 6768127
               category: 2
               torrentHash: 81c758d0eca5372d59e43879ecf2e2bce33a06c4
-              torrentName: '[MP4/3.83G]fc2-ppv-3270070 幼さが残る18才の黒髪清楚の女の子。 夢の為にAV撮影、はじめての中出しまで    em(6768127)'
+              torrentName: '[MP4/3.83G]fc2-ppv-3270070 幼さが残る18才の黒髪清楚の女の子。 夢の為にAV撮影、はじめての中出しまで'
 
         pattern: '(\d+)\ (\d+)\ ([a-z0-9]{40})\ (.*)'
         vars:


### PR DESCRIPTION
## What

This adds supports for t66y.com (Caoliu Community) which is a forum aggregating mostly Chinese/Japanese adult content.

## Changes

* Adds a new `T66y` indexer using IRC (Rizon.net on #t66y).
* Adds the ability for IRC indexer definitions to templatize `torrenthash` and `magneturi`.
* Adds tests.

## Note

The categories on the forum don't map to anything common/generic on the releases so they are kept to their original numeric form.