### PR TITLE
fix(http): change onboarding unavailable log level

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -199,8 +199,8 @@ func (h authHandler) onboardEligible(ctx context.Context) (int, error) {
 	}
 
 	if userCount > 0 {
-		h.log.Trace().Msg("onboarding unavailable")
-		return http.StatusServiceUnavailable, errors.New("onboarding unavailable")
+		h.log.Trace().Msg("onboarding unavailable: user already registered")
+		return http.StatusServiceUnavailable, errors.New("onboarding unavailable: user already registered")
 	}
 
 	return http.StatusOK, nil

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -179,7 +179,7 @@ func (h authHandler) onboard(w http.ResponseWriter, r *http.Request) {
 func (h authHandler) canOnboard(w http.ResponseWriter, r *http.Request) {
 	if status, err := h.onboardEligible(r.Context()); err != nil {
 		if status == http.StatusServiceUnavailable {
-			h.encoder.StatusWarning(w, status, err.Error())
+			h.encoder.StatusResponse(w, status, err.Error())
 			return
 		}
 		h.encoder.StatusError(w, status, err)

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -199,6 +199,7 @@ func (h authHandler) onboardEligible(ctx context.Context) (int, error) {
 	}
 
 	if userCount > 0 {
+		h.log.Trace().Msg("onboarding unavailable")
 		return http.StatusServiceUnavailable, errors.New("onboarding unavailable")
 	}
 

--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -6,6 +6,7 @@ package http
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
 
 	"github.com/rs/zerolog"
 )
@@ -137,7 +138,13 @@ func (e encoder) StatusWarning(w http.ResponseWriter, status int, message string
 		Message: message,
 	}
 
-	e.log.Warn().Str("warning", message).Int("status", status).Msg("server warning")
+	var messages = []string{
+		"onboarding unavailable",
+	}
+
+	if !slices.Contains(messages, message) {
+		e.log.Warn().Str("warning", message).Int("status", status).Msg("server warning")
+	}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)

--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -6,7 +6,6 @@ package http
 import (
 	"encoding/json"
 	"net/http"
-	"slices"
 
 	"github.com/rs/zerolog"
 )
@@ -138,13 +137,7 @@ func (e encoder) StatusWarning(w http.ResponseWriter, status int, message string
 		Message: message,
 	}
 
-	var messages = []string{
-		"onboarding unavailable",
-	}
-
-	if !slices.Contains(messages, message) {
-		e.log.Warn().Str("warning", message).Int("status", status).Msg("server warning")
-	}
+	e.log.Warn().Str("warning", message).Int("status", status).Msg("server warning")
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)


### PR DESCRIPTION
This PR changes the log level for the `onboarding unavailable` log message,
since we experienced an upsurge in support workload due to people asking about this warning.