### PR TITLE
feat(macros): implement template cache

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -18,7 +18,6 @@ import (
 
 var templateCache = ttlcache.New(
 	ttlcache.Options[string, *template.Template]{}.
-		SetTimerResolution(5 * time.Minute).
 		SetDefaultTTL(15 * time.Minute),
 )
 
@@ -190,7 +189,7 @@ func (m Macro) Parse(text string) (string, error) {
 		if err != nil {
 			return "", errors.Wrap(err, "could not parse macro template")
 		}
-		templateCache.Set(text, tmpl, ttlcache.NoTTL)
+		templateCache.Set(text, tmpl, ttlcache.DefaultTTL)
 	}
 
 	var tpl bytes.Buffer
@@ -216,7 +215,7 @@ func (m Macro) MustParse(text string) string {
 		if err != nil {
 			return ""
 		}
-		templateCache.Set(text, tmpl, ttlcache.NoTTL)
+		templateCache.Set(text, tmpl, ttlcache.DefaultTTL)
 	}
 
 	var tpl bytes.Buffer

--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -216,7 +216,7 @@ func (m Macro) MustParse(text string) string {
 		if err != nil {
 			return ""
 		}
-		templateCache.Set(text, tmpl, ttlcache.DefaultTTL)
+		templateCache.Set(text, tmpl, ttlcache.NoTTL)
 	}
 
 	var tpl bytes.Buffer

--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -188,7 +188,7 @@ func (m Macro) Parse(text string) (string, error) {
 		var err error
 		tmpl, err = template.New("macro").Funcs(sprig.TxtFuncMap()).Parse(text)
 		if err != nil {
-			return "", errors.Wrap(err, "could parse macro template")
+			return "", errors.Wrap(err, "could not parse macro template")
 		}
 		templateCache.Set(text, tmpl, ttlcache.NoTTL)
 	}

--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -18,6 +18,7 @@ import (
 
 var templateCache = ttlcache.New(
 	ttlcache.Options[string, *template.Template]{}.
+		SetTimerResolution(5 * time.Minute).
 		SetDefaultTTL(15 * time.Minute),
 )
 

--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -10,9 +10,16 @@ import (
 	"time"
 
 	"github.com/autobrr/autobrr/pkg/errors"
+	"github.com/autobrr/autobrr/pkg/ttlcache"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/dustin/go-humanize"
+)
+
+var templateCache = ttlcache.New(
+	ttlcache.Options[string, *template.Template]{}.
+		SetTimerResolution(5 * time.Minute).
+		SetDefaultTTL(15 * time.Minute),
 )
 
 type Macro struct {
@@ -175,16 +182,19 @@ func (m Macro) Parse(text string) (string, error) {
 		return "", nil
 	}
 
-	// TODO implement template cache
-
-	// setup template
-	tmpl, err := template.New("macro").Funcs(sprig.TxtFuncMap()).Parse(text)
-	if err != nil {
-		return "", errors.Wrap(err, "could parse macro template")
+	// get template from cache or create new
+	tmpl, ok := templateCache.Get(text)
+	if !ok {
+		var err error
+		tmpl, err = template.New("macro").Funcs(sprig.TxtFuncMap()).Parse(text)
+		if err != nil {
+			return "", errors.Wrap(err, "could parse macro template")
+		}
+		templateCache.Set(text, tmpl, ttlcache.NoTTL)
 	}
 
 	var tpl bytes.Buffer
-	err = tmpl.Execute(&tpl, m)
+	err := tmpl.Execute(&tpl, m)
 	if err != nil {
 		return "", errors.Wrap(err, "could not parse macro")
 	}
@@ -198,14 +208,19 @@ func (m Macro) MustParse(text string) string {
 		return ""
 	}
 
-	// setup template
-	tmpl, err := template.New("macro").Funcs(sprig.TxtFuncMap()).Parse(text)
-	if err != nil {
-		return ""
+	// get template from cache or create new
+	tmpl, ok := templateCache.Get(text)
+	if !ok {
+		var err error
+		tmpl, err = template.New("macro").Funcs(sprig.TxtFuncMap()).Parse(text)
+		if err != nil {
+			return ""
+		}
+		templateCache.Set(text, tmpl, ttlcache.NoTTL)
 	}
 
 	var tpl bytes.Buffer
-	err = tmpl.Execute(&tpl, m)
+	err := tmpl.Execute(&tpl, m)
 	if err != nil {
 		return ""
 	}

--- a/internal/domain/macros_test.go
+++ b/internal/domain/macros_test.go
@@ -290,3 +290,28 @@ func TestMacros_Parse(t *testing.T) {
 		})
 	}
 }
+
+func TestMacros_TemplateCache(t *testing.T) {
+	t.Parallel()
+
+	release := Release{
+		TorrentName: "Test Movie 2024",
+		Year:        2024,
+	}
+
+	m := NewMacro(release)
+	template := "{{.TorrentName}} ({{.Year}})"
+
+	// parse and cache
+	got1, err := m.Parse(template)
+	assert.NoError(t, err)
+	assert.Equal(t, "Test Movie 2024 (2024)", got1)
+
+	// use cached template
+	got2, err := m.Parse(template)
+	assert.NoError(t, err)
+	assert.Equal(t, "Test Movie 2024 (2024)", got2)
+
+	_, ok := templateCache.Get(template)
+	assert.True(t, ok, "template should be in cache")
+}


### PR DESCRIPTION
Implements a template cache for macro parsing. Using ttlcache.

![CleanShot 2025-04-27 at 07 03 47@2x](https://github.com/user-attachments/assets/be715959-7043-48e1-b098-194ddfef2fad)
