### PR TITLE
fix(macros): set HasLog when Log Score is missing in announce

### DIFF
--- a/internal/domain/releasetags.go
+++ b/internal/domain/releasetags.go
@@ -488,6 +488,12 @@ func ParseReleaseTagString(tags string) ReleaseTags {
 				continue
 			}
 
+			if info.Tag() == "Log" {
+				releaseTags.HasLog = true
+				releaseTags.Audio = append(releaseTags.Audio, info.Tag())
+				continue
+			}
+
 			if info.Tag() == "LogScore" {
 				m := info.FindMatch(tags)
 				if len(m) == 2 {

--- a/internal/domain/releasetags_test.go
+++ b/internal/domain/releasetags_test.go
@@ -39,12 +39,13 @@ func TestParseReleaseTagString(t *testing.T) {
 		args args
 		want ReleaseTags
 	}{
-		{name: "music_1", args: args{tags: "FLAC / Lossless / Log / 80% / Cue / CD"}, want: ReleaseTags{Audio: []string{"Cue", "FLAC", "Lossless", "Log"}, AudioBitrate: "Lossless", AudioFormat: "FLAC", Source: "CD", HasCue: true}},
+		{name: "music_1", args: args{tags: "FLAC / Lossless / Log / 80% / Cue / CD"}, want: ReleaseTags{Audio: []string{"Cue", "FLAC", "Lossless", "Log"}, AudioBitrate: "Lossless", AudioFormat: "FLAC", Source: "CD", HasLog: true, HasCue: true}},
 		{name: "music_2", args: args{tags: "FLAC Lossless Log 80% Cue CD"}, want: ReleaseTags{Audio: []string{"Cue", "FLAC", "Lossless", "Log80", "Log"}, AudioBitrate: "Lossless", AudioFormat: "FLAC", Source: "CD", HasLog: true, LogScore: 80, HasCue: true}},
 		{name: "music_3", args: args{tags: "FLAC Lossless Log 100% Cue CD"}, want: ReleaseTags{Audio: []string{"Cue", "FLAC", "Lossless", "Log100", "Log"}, AudioBitrate: "Lossless", AudioFormat: "FLAC", Source: "CD", HasLog: true, LogScore: 100, HasCue: true}},
 		{name: "music_4", args: args{tags: "FLAC 24bit Lossless Log 100% Cue CD"}, want: ReleaseTags{Audio: []string{"24BIT Lossless", "Cue", "FLAC", "Log100", "Log"}, AudioBitrate: "24BIT Lossless", AudioFormat: "FLAC", Source: "CD", HasLog: true, LogScore: 100, HasCue: true}},
 		{name: "music_5", args: args{tags: "MP3 320 WEB"}, want: ReleaseTags{Audio: []string{"320", "MP3"}, AudioBitrate: "320", AudioFormat: "MP3", Source: "WEB"}},
 		{name: "music_6", args: args{tags: "FLAC Lossless Log (100%) Cue CD"}, want: ReleaseTags{Audio: []string{"Cue", "FLAC", "Lossless", "Log100", "Log"}, AudioBitrate: "Lossless", AudioFormat: "FLAC", Source: "CD", HasCue: true, HasLog: true, LogScore: 100}},
+		{name: "music_7", args: args{tags: "FLAC / Lossless / Log / Cue / CD"}, want: ReleaseTags{Audio: []string{"Cue", "FLAC", "Lossless", "Log"}, AudioBitrate: "Lossless", AudioFormat: "FLAC", Source: "CD", HasLog: true, HasCue: true}},
 		{name: "movies_1", args: args{tags: "x264 Blu-ray MKV 1080p"}, want: ReleaseTags{Codec: "x264", Source: "BluRay", Resolution: "1080p", Container: "mkv"}},
 		{name: "movies_2", args: args{tags: "HEVC HDR Blu-ray mp4 2160p"}, want: ReleaseTags{Codec: "HEVC", Source: "BluRay", Resolution: "2160p", Container: "mp4", HDR: []string{"HDR"}}},
 		{name: "movies_3", args: args{tags: "HEVC HDR DV Blu-ray mp4 2160p"}, want: ReleaseTags{Codec: "HEVC", Source: "BluRay", Resolution: "2160p", Container: "mp4", HDR: []string{"HDR", "DV"}}},

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -329,6 +329,37 @@ func TestIndexersParseAndFilter(t *testing.T) {
 					},
 					match: false,
 				},
+				{
+					name: "announce_6",
+					args: args{
+						announceLines: []string{"The best artist - Album No 1 [2017] [Album] - FLAC / Lossless / Log / Cue / CD - https://redacted.sh/torrents.php?id=0000000 / https://redacted.sh/torrents.php?action=download&id=0000000 - Hip.Hop,Estonian,2010s"},
+						filters: []filterTest{
+							{
+								filter: &domain.Filter{
+									Name:            "filter_1",
+									MatchCategories: "Album",
+									Years:           "2017",
+									Quality:         []string{"Lossless"},
+									Sources:         []string{"CD"},
+									Formats:         []string{"FLAC"},
+									Log:             true,
+									Cue:             true,
+								},
+								match: true,
+							},
+							{
+								filter: &domain.Filter{
+									Name:            "filter_2",
+									MatchCategories: "Album",
+									PerfectFlac:     true,
+								},
+								match:      false,
+								rejections: []string{"wanted: perfect flac. got: [Cue FLAC Lossless Log]"},
+							},
+						},
+					},
+					match: false,
+				},
 			},
 			match: true,
 		},


### PR DESCRIPTION
Fix for #2045. Sets `HasLog` to true when `Log` is present in the announced release tags.
Added tests for the release in question.