### PR TITLE
fix(web): ensure release table auto-update

### DIFF
--- a/web/src/screens/dashboard/ActivityTable.tsx
+++ b/web/src/screens/dashboard/ActivityTable.tsx
@@ -117,7 +117,7 @@ export const ActivityTable = () => {
     }
   ], []);
 
-  const { isLoading, data } = useSuspenseQuery(ReleasesLatestQueryOptions());
+  const { isLoading, data, dataUpdatedAt } = useSuspenseQuery(ReleasesLatestQueryOptions());
 
   const [modifiedData, setModifiedData] = useState<Release[]>([]);
   const [settings, setSettings] = SettingsContext.use();
@@ -143,7 +143,7 @@ export const ActivityTable = () => {
     } else {
       setModifiedData([]);
     }
-  }, [settings.incognitoMode, data?.data]);
+  }, [settings.incognitoMode, data?.data, dataUpdatedAt]);
 
   if (isLoading) {
     return (
@@ -162,7 +162,7 @@ export const ActivityTable = () => {
     setSettings(prev => ({ ...prev, incognitoMode: !prev.incognitoMode }));
   };
 
-  const displayData = settings.incognitoMode ? modifiedData : (data?.data ?? []);
+  const displayData = settings.incognitoMode ? modifiedData : [...(data?.data ?? [])];
 
   return (
     <div className="flex flex-col mt-12 relative">

--- a/web/src/screens/releases/ReleaseTable.tsx
+++ b/web/src/screens/releases/ReleaseTable.tsx
@@ -145,6 +145,7 @@ export const ReleaseTable = () => {
     isLoading,
     error,
     data,
+    dataUpdatedAt,
   } = useQuery(ReleasesListQueryOptions(pagination.pageIndex * pagination.pageSize, pagination.pageSize, columnFilters));
 
   const [modifiedData, setModifiedData] = useState<Release[]>([]);
@@ -177,14 +178,14 @@ export const ReleaseTable = () => {
     } else {
       setModifiedData([]);
     }
-  }, [settings.incognitoMode, data?.data]);
+  }, [settings.incognitoMode, data?.data, dataUpdatedAt]);
 
   const toggleReleaseNames = () => {
     setSettings(prev => ({ ...prev, incognitoMode: !prev.incognitoMode }));
   };
 
   const defaultData = React.useMemo(() => [], [])
-  const displayData = settings.incognitoMode ? modifiedData : (data?.data ?? defaultData);
+  const displayData = settings.incognitoMode ? modifiedData : [...(data?.data ?? defaultData)];
 
   const tableInstance = useReactTable({
     columns,


### PR DESCRIPTION
Fixes an issue where the Activity and Release tables would not auto-update with new data unless the page was manually refreshed. The regression was introduced in commit 24648e45. The root cause is related to how the table detects data changes and how `useEffect` dependencies were structured after the incognito mode feature was added.
