### PR TITLE
(Fix): multiple external webhooks processing return on first error

### DIFF
--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -254,6 +254,7 @@ func (r *FilterRepo) FindByID(ctx context.Context, filterID int) (*domain.Filter
 			"f.min_leechers",
 			"f.max_leechers",
 			"f.release_profile_duplicate_id",
+			"f.webhook_continue_on_error",
 			"f.created_at",
 			"f.updated_at",
 		).
@@ -351,6 +352,7 @@ func (r *FilterRepo) FindByID(ctx context.Context, filterID int) (*domain.Filter
 		&f.MinLeechers,
 		&f.MaxLeechers,
 		&releaseProfileDuplicateId,
+		&f.WebhookContinueOnError,
 		&f.CreatedAt,
 		&f.UpdatedAt,
 	)
@@ -484,6 +486,7 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, indexer string
 			"f.created_at",
 			"f.updated_at",
 			"f.release_profile_duplicate_id",
+			"f.webhook_continue_on_error",
 			"rdp.id",
 			"rdp.name",
 			"rdp.release_name",
@@ -636,6 +639,7 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, indexer string
 			&rdpRepack,
 			&rdpEdition,
 			&rdpLanguage,
+			&f.WebhookContinueOnError,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "error scanning row")
@@ -876,6 +880,7 @@ func (r *FilterRepo) Store(ctx context.Context, filter *domain.Filter) error {
 			"min_leechers",
 			"max_leechers",
 			"release_profile_duplicate_id",
+			"webhook_continue_on_error",
 		).
 		Values(
 			filter.Name,
@@ -945,6 +950,7 @@ func (r *FilterRepo) Store(ctx context.Context, filter *domain.Filter) error {
 			filter.MinLeechers,
 			filter.MaxLeechers,
 			toNullInt64(filter.ReleaseProfileDuplicateID),
+			filter.WebhookContinueOnError,
 		).
 		Suffix("RETURNING id").RunWith(r.db.handler)
 
@@ -1032,6 +1038,7 @@ func (r *FilterRepo) Update(ctx context.Context, filter *domain.Filter) error {
 		Set("min_leechers", filter.MinLeechers).
 		Set("max_leechers", filter.MaxLeechers).
 		Set("release_profile_duplicate_id", toNullInt64(filter.ReleaseProfileDuplicateID)).
+		Set("webhook_continue_on_error", filter.WebhookContinueOnError).
 		Set("updated_at", time.Now().Format(time.RFC3339)).
 		Where(sq.Eq{"id": filter.ID})
 
@@ -1259,6 +1266,9 @@ func (r *FilterRepo) UpdatePartial(ctx context.Context, filter domain.FilterUpda
 	}
 	if filter.ReleaseProfileDuplicateID != nil {
 		q = q.Set("release_profile_duplicate_id", filter.ReleaseProfileDuplicateID)
+	}
+	if filter.WebhookContinueOnError != nil {
+		q = q.Set("webhook_continue_on_error", filter.WebhookContinueOnError)
 	}
 
 	q = q.Where(sq.Eq{"id": filter.ID})

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -194,6 +194,7 @@ CREATE TABLE filter
     min_leechers                   INTEGER DEFAULT 0,
     max_leechers                   INTEGER DEFAULT 0,
     release_profile_duplicate_id   INTEGER,
+    webhook_continue_on_error      BOOLEAN DEFAULT FALSE,
     FOREIGN KEY (release_profile_duplicate_id) REFERENCES release_profile_duplicate(id) ON DELETE SET NULL
 );
 
@@ -1351,5 +1352,8 @@ CREATE INDEX release_hybrid_index
 	`UPDATE filter
 	SET announce_types = '{"NEW"}'
 	WHERE announce_types = '{}';
+`,
+	`ALTER TABLE filter
+	ADD COLUMN webhook_continue_on_error BOOLEAN DEFAULT false;
 `,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -194,6 +194,7 @@ CREATE TABLE filter
     min_leechers                   INTEGER DEFAULT 0,
     max_leechers                   INTEGER DEFAULT 0,
     release_profile_duplicate_id   INTEGER,
+    webhook_continue_on_error      BOOLEAN DEFAULT FALSE,
     FOREIGN KEY (release_profile_duplicate_id) REFERENCES release_profile_duplicate(id) ON DELETE SET NULL
 );
 
@@ -1996,5 +1997,8 @@ CREATE INDEX release_hybrid_index
 	`UPDATE filter
 	SET announce_types = '{"NEW"}'
 	WHERE announce_types = '{}';
+`,
+	`ALTER TABLE filter
+	ADD COLUMN webhook_continue_on_error BOOLEAN DEFAULT false;
 `,
 }

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -175,6 +175,7 @@ type Filter struct {
 	Downloads                 *FilterDownloads         `json:"downloads,omitempty"`
 	Rejections                []string                 `json:"-"`
 	RejectReasons             *RejectionReasons        `json:"-"`
+	WebhookContinueOnError    bool                     `json:"webhook_continue_on_error"`
 }
 
 type FilterExternal struct {
@@ -296,6 +297,7 @@ type FilterUpdate struct {
 	Actions                   []*Action               `json:"actions,omitempty"`
 	External                  []FilterExternal        `json:"external,omitempty"`
 	Indexers                  []Indexer               `json:"indexers,omitempty"`
+	WebhookContinueOnError    *bool                   `json:"webhook_continue_on_error"`
 }
 
 func (f *Filter) Validate() error {

--- a/web/src/screens/filters/Details.tsx
+++ b/web/src/screens/filters/Details.tsx
@@ -457,6 +457,7 @@ export const FilterDetails = () => {
               actions: filter.actions || [],
               external: filter.external || [],
               release_profile_duplicate_id: filter.release_profile_duplicate_id,
+              webhook_continue_on_error: filter.webhook_continue_on_error
             } as Filter}
             onSubmit={handleSubmit}
             enableReinitialize={true}

--- a/web/src/screens/filters/sections/General.tsx
+++ b/web/src/screens/filters/sections/General.tsx
@@ -154,6 +154,20 @@ export const General = () => {
           />
         </FilterLayout>
       </FilterSection>
+
+      <FilterSection
+        title="External Filter Settings"
+        subtitle="Configure webhook filter behavior"
+      >
+        <FilterLayout>
+          <SwitchGroup
+            name="webhook_continue_on_error"
+            label="Continue webhook processing on error"
+            description="Continue processing other webhooks even if one fails."
+            className="pb-2 col-span-12 sm:col-span-6"
+          />
+        </FilterLayout>
+      </FilterSection>
     </FilterPage>
   );
 };

--- a/web/src/types/Filter.d.ts
+++ b/web/src/types/Filter.d.ts
@@ -84,6 +84,7 @@ interface Filter {
   external: ExternalFilter[];
   downloads?: FilterDownloads;
   release_profile_duplicate_id?: number;
+  webhook_continue_on_error: Boolean
 }
 
 interface Action {


### PR DESCRIPTION
- Add a new field `webhook_continue_on_error` in the filter general settings to take care of this

- include migrations