### PR TITLE
fix(indexers): CapybaraBR tmdb id parsing

### DIFF
--- a/internal/indexer/definitions/capybarabr.yaml
+++ b/internal/indexer/definitions/capybarabr.yaml
@@ -120,7 +120,18 @@ irc:
               torrentId: "15094"
               torrentSize: 15.81 MiB
               tags: ""
-        pattern: '\[(.+?)\] \[(.+?)\] (?:\[(.+?)\] )?\[(.+?)\] \[(https?:\/\/[^\/]+\/).+?(\d+)\] \[(.+?)\](?: \[tmdb-(\d+)\])?'
+          - line: "[Filmes] [WEB-DL] [1080p] [Black Book 2006 1080p AMZN WEB-DL DDP2.0 H.264 DUAL-FLY] [https://capybarabr.com/torrents/30671] [9.04 GiB] [tmdb=9075]"
+            expect:
+              category: Filmes
+              releaseTags: WEB-DL
+              resolution: "1080p"
+              torrentName: "Black Book 2006 1080p AMZN WEB-DL DDP2.0 H.264 DUAL-FLY"
+              baseUrl: https://capybarabr.com/
+              torrentId: "30671"
+              torrentSize: 9.04 GiB
+              tags: "9075"
+
+        pattern: '\[(.+?)\] \[(.+?)\] (?:\[(.+?)\] )?\[(.+?)\] \[(https?:\/\/[^\/]+\/).+?(\d+)\] \[(.+?)\](?: \[[a-z]+[-=](\d+)\])?'
         vars:
           - category
           - releaseTags


### PR DESCRIPTION
I found an issue with parsing of `capybarabr`, where the `tags` variable is not being correctly parsed.
I use the tags for some webhooks, so I would like to fix it.

This is just to fix parsing.

Here are some excerpts of the IRC channel:
```
[Series] [WEB-DL] [1080p] [Georgie and Mandys First Marriage S01E20 1080p AMZN WEB-DL DDP5.1 H.264 DUAL-BiOMA] [https://capybarabr.com/torrents/30653] [1.2 GiB] [tmdb=243875]

[Filmes] [WEB-DL] [1080p] [Happy Mondays 2025 1080p NF WEB-DL DDP5.1 H.264-BiOMA] [https://capybarabr.com/torrents/30654] [5.03 GiB] [tmdb=1289088]

[Series] [WEB-DL] [1080p] [The Cleaning Lady S04 1080p AMZN WEB-DL DDP5.1 H.264 DUAL-BiOMA] [https://capybarabr.com/torrents/30656] [2.04 GiB] [tmdb=125282]

[Series] [WEB-DL] [1080p] [Conan OBrien Must Go S02E03 1080p AMZN WEB-DL DDP5.1 H.264-BiOMA] [https://capybarabr.com/torrents/30657] [2.86 GiB] [tmdb=226698]

[Series] [WEB-DL] [1080p] [Sirens S01 1080p NF WEB-DL DDP5.1 Atmos H.264 DUAL-BiOMA] [https://capybarabr.com/torrents/30658] [12.26 GiB] [tmdb=246992]
```

Regex101 parsing fixed:
![image](https://github.com/user-attachments/assets/ba6ec132-bc86-4918-953d-279788bd2064)
