### PR TITLE
build: goreleaser snapshot during pr builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: "~> v2"
-          args: release --clean --skip=validate,publish --parallelism 5
+          args: release --clean --skip=validate,publish --parallelism 5 --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
Build goreleaser as snapshot during PRs to allow forks to build with GoReleaser Pro.