### PR TITLE
feat(indexers): new IRC auth mechanism for RocketHD

### DIFF
--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -1357,4 +1357,21 @@ CREATE INDEX release_hybrid_index
 	ALTER TABLE list
 		ADD COLUMN skip_clean_sanitize BOOLEAN DEFAULT FALSE;
 `,
+	`UPDATE irc_network 
+	SET 
+    	auth_mechanism = 'NONE',
+    	auth_account = '',
+    	auth_password = ''
+	WHERE server = 'irc.rocket-hd.cc' 
+    	AND auth_mechanism != 'NONE';
+
+	UPDATE irc_channel 
+	SET password = NULL
+	WHERE password IS NOT NULL
+    	AND network_id IN (
+        	SELECT id 
+        	FROM irc_network 
+        	WHERE server = 'irc.rocket-hd.cc'
+    	);
+`,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -2002,4 +2002,20 @@ CREATE INDEX release_hybrid_index
 	ALTER TABLE list
 		ADD COLUMN skip_clean_sanitize BOOLEAN DEFAULT FALSE;
 `,
+	`UPDATE irc_network 
+	SET 
+    	auth_mechanism = 'NONE',
+    	auth_account = '',
+    	auth_password = ''
+	WHERE server = 'irc.rocket-hd.cc' 
+    	AND auth_mechanism != 'NONE';
+`,
+	`UPDATE irc_channel 
+	SET password = NULL
+	WHERE network_id IN (
+    	SELECT id 
+    	FROM irc_network 
+    	WHERE server = 'irc.rocket-hd.cc'
+);
+`,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -2009,8 +2009,8 @@ CREATE INDEX release_hybrid_index
     	auth_password = ''
 	WHERE server = 'irc.rocket-hd.cc' 
     	AND auth_mechanism != 'NONE';
-`,
-	`UPDATE irc_channel 
+
+	UPDATE irc_channel 
 	SET password = NULL
 	WHERE password IS NOT NULL
     	AND network_id IN (

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -2012,10 +2012,11 @@ CREATE INDEX release_hybrid_index
 `,
 	`UPDATE irc_channel 
 	SET password = NULL
-	WHERE network_id IN (
-    	SELECT id 
-    	FROM irc_network 
-    	WHERE server = 'irc.rocket-hd.cc'
-);
+	WHERE password IS NOT NULL
+    	AND network_id IN (
+        	SELECT id 
+        	FROM irc_network 
+        	WHERE server = 'irc.rocket-hd.cc'
+    	);
 `,
 }

--- a/internal/indexer/definitions/rocket-hd.yaml
+++ b/internal/indexer/definitions/rocket-hd.yaml
@@ -53,7 +53,6 @@ irc:
       label: NickServ Password
       help: NickServ password
 
-
   parse:
     type: single
     lines:

--- a/internal/indexer/definitions/rocket-hd.yaml
+++ b/internal/indexer/definitions/rocket-hd.yaml
@@ -41,18 +41,6 @@ irc:
       label: Network password
       help: Your profile > Settings > IRC Key
 
-    - name: auth.account
-      type: text
-      required: false
-      label: NickServ Account
-      help: NickServ account. Make sure to group your user and bot.
-
-    - name: auth.password
-      type: secret
-      required: false
-      label: NickServ Password
-      help: NickServ password
-
   parse:
     type: single
     lines:

--- a/internal/indexer/definitions/rocket-hd.yaml
+++ b/internal/indexer/definitions/rocket-hd.yaml
@@ -17,7 +17,7 @@ settings:
     type: secret
     required: true
     label: RSS key (RID)
-    help: "Go to My Settings > RSS Key, and copy your RSS Key"
+    help: "Your profile > Settings > RSS Key"
 
 irc:
   network: RocketNET
@@ -35,23 +35,24 @@ irc:
       label: Nick
       help: Bot nick. Eg. user-bot
 
+    - name: pass
+      type: secret
+      required: true
+      label: Network password
+      help: Your profile > Settings > IRC Key
+
     - name: auth.account
       type: text
-      required: true
+      required: false
       label: NickServ Account
       help: NickServ account. Make sure to group your user and bot.
 
     - name: auth.password
       type: secret
-      required: true
+      required: false
       label: NickServ Password
       help: NickServ password
 
-    - name: channels.password
-      type: secret
-      required: true
-      label: Channel Password
-      help: Channel password
 
   parse:
     type: single


### PR DESCRIPTION
RocketHD will make a change to their IRC server and its announce channel this weekend. 
After this change, the IRC server requires authentication with a network/server password. 
Users will be able to obtain an IRC key on site which needs to be used as their IRC server password. 
A channel password or NickServ auth will no longer be required. 

