### PR TITLE
feat(ui): filters grouping

### DIFF
--- a/web/src/screens/filters/List.tsx
+++ b/web/src/screens/filters/List.tsx
@@ -191,6 +191,8 @@ function filteredData(data: Filter[], status: string) {
 }
 
 // Helper function to find the common prefix of two strings
+const MIN_PREFIX_LENGTH_FOR_GROUPING = 3;
+const MIN_ITEMS_FOR_GROUP = 1;
 function getCommonPrefix(s1: string, s2: string): string {
   let i = 0;
   while (i < s1.length && i < s2.length && s1[i] === s2[i]) {
@@ -206,9 +208,6 @@ interface GroupedItem {
   filters?: Filter[]; // Filters in this group
   filter?: Filter;   // Single filter if not in a group
 }
-
-const MIN_PREFIX_LENGTH_FOR_GROUPING = 3; // Minimum length of a common prefix to be considered for grouping
-const MIN_ITEMS_FOR_GROUP = 2;          // Minimum number of items to form a group
 
 function createGroupedItems(allFilters: Filter[]): GroupedItem[] {
   if (!allFilters || allFilters.length === 0) return [];
@@ -259,7 +258,14 @@ function createGroupedItems(allFilters: Filter[]): GroupedItem[] {
         continue;
       }
     }
-    result.push({ id: `item-${firstFilterInPotentialGroup.id}`, type: 'item', filter: firstFilterInPotentialGroup });
+    // If a multi-item group was not formed, and MIN_ITEMS_FOR_GROUP is 1,
+    // this item becomes a group of its own.
+    result.push({
+      id: `group-single-${firstFilterInPotentialGroup.id}`, // Use filter ID for a unique group ID
+      type: 'group',
+      prefix: firstFilterInPotentialGroup.name, // The prefix for a single-item group is its name
+      filters: [firstFilterInPotentialGroup]
+    });
     i++;
   }
   return result;

--- a/web/src/utils/Context.ts
+++ b/web/src/utils/Context.ts
@@ -13,6 +13,7 @@ interface SettingsType {
   indentLogLines: boolean;
   hideWrappedText: boolean;
   incognitoMode: boolean;
+  groupFiltersInListPage: boolean;
 }
 
 export type FilterListState = {
@@ -44,7 +45,8 @@ const SettingsContextDefaults: SettingsType = {
   scrollOnNewLog: false,
   indentLogLines: false,
   hideWrappedText: false,
-  incognitoMode: false
+  incognitoMode: false,
+  groupFiltersInListPage: false
 };
 
 const FilterListContextDefaults: FilterListState = {


### PR DESCRIPTION
#### What is the relevant ticket?
* Discussed in Discord #dev-general

#### What’s this PR do?
##### Add
* option `groupFiltersInListPage`
* function `getCommonPrefix`
* function `createGroupedItems`
* const `toggleGroupingSetting`
##### Change
* None
##### Remove
* None

#### Where should the reviewer start?
* `web/src/utils/Context.ts`
* `web/src/screens/filters/List.tsx`

#### How should this be manually tested?
* `make build && go run cmd/autobrr/main.go`

#### Risk involved?
* Unsure, needs comprehensive test?

#### Screenshots (if appropriate):
* New grouping option in the console:
![Screenshot from 2025-06-06 10-54-30](https://github.com/user-attachments/assets/cf661253-62f4-4f59-a61a-c5843dbaec70)

* Expanded groups - example:
![Screenshot from 2025-06-06 10-54-48](https://github.com/user-attachments/assets/3d8ee331-d785-47b8-9f27-a0cad8a58bd1)

* Collapsed groups - example:
![Screenshot from 2025-06-06 10-55-09](https://github.com/user-attachments/assets/febaa4bb-4c33-4830-8247-a8111090dd8f)

#### Does the documentation or dependencies need an update?
* No
