### PR TITLE
fix(database): duplicate `skip_clean_sanitize` column

### DIFF
--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -550,6 +550,7 @@ CREATE TABLE list
     tags_excluded            TEXT [] DEFAULT '{}' NOT NULL,
     include_unmonitored      BOOLEAN,
     include_alternate_titles BOOLEAN,
+    skip_clean_sanitize      BOOLEAN DEFAULT FALSE,
     last_refresh_time        TIMESTAMP,
     last_refresh_status      TEXT,
     last_refresh_data        TEXT,

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -1815,7 +1815,6 @@ UPDATE irc_network
     tags_excluded            TEXT [] DEFAULT '{}' NOT NULL,
     include_unmonitored      BOOLEAN,
     include_alternate_titles BOOLEAN,
-    skip_clean_sanitize      BOOLEAN DEFAULT FALSE,
     last_refresh_time        TIMESTAMP,
     last_refresh_status      TEXT,
     last_refresh_data        TEXT,


### PR DESCRIPTION
There is an error in the `sqlite_migrate.go` file for the `list` table where we create the 
`skip_clean_sanitize` column at line 1818 and then we alter the table later 
at line 2003 adding the `skip_clean_sanitize` column again which result in an error.

The proposed fix is to not create the `skip_clean_sanitize` column in the initial creation of the table
and add the `skip_clean_sanitize` column later on.

`postgres_migrate.go` does not create the `skip_clean_sanitize` in the first place 
and adds the `skip_clean_sanitize` column later on, like proposed in the SQLite fix.
So the PostgreSQL migrations do not need to be fixed.

Migrations from 1.53.1 to develop have been tested with SQLite and PostgreSQL and are working.

fixes #2095 

Note: 
Issue says he upgraded from v1.52.1 but we don't have that version.
Given the schema version it has to be v1.53.1.