### PR TITLE
feat(releasedownload): clean up old temp files

### DIFF
--- a/internal/releasedownload/download_service.go
+++ b/internal/releasedownload/download_service.go
@@ -14,6 +14,7 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -146,6 +147,16 @@ func (s *DownloadService) downloadTorrentFile(ctx context.Context, indexer *doma
 
 	tmpFilePattern := "autobrr-"
 	tmpDir := os.TempDir()
+
+	// Clean up old tmp files
+	files, err := os.ReadDir(tmpDir)
+	if err == nil {
+		for _, file := range files {
+			if strings.HasPrefix(file.Name(), tmpFilePattern) {
+				os.Remove(filepath.Join(tmpDir, file.Name()))
+			}
+		}
+	}
 
 	// Create tmp file
 	// TODO check if tmp file is wanted


### PR DESCRIPTION
resolves #2103 

This PR adds code to remove old temporary files with the prefix `autobrr-`

There already is some code for this flying around in the codebase but 
i couldn't make sense on when it gets called and my debugging skills weren't enough to figure it out.

https://github.com/autobrr/autobrr/blob/6073480bc42bf77383638507c647cd66d9abc606/internal/domain/release.go#L940-L947
https://github.com/autobrr/autobrr/blob/46f6fbe5cc4d95b8d299eb4bbc222c3e12a2e566/internal/release/service.go#L206

This PR has likely a lot of room for improvement so feel free to suggest changes!
