### PR TITLE
fix(web): sanitize URL from basic auth credentials

### DIFF
--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -78,6 +78,19 @@ function encodeRFC3986URIComponent(str: string): string {
 }
 
 /**
+ * Sanitizes URL by stripping any embedded basic auth credentials from the URL
+ * @param url URL to sanitize
+ * @returns The sanitized URL without basic auth credentials
+ */
+
+function sanitizeURL(url: string): string {
+  const urlObj = new URL(url, window.location.origin);
+  urlObj.username = '';
+  urlObj.password = '';
+  return urlObj.toString();
+}
+
+/**
  * Makes a request on the network and returns a promise.
  *
  * This function serves as both a request builder and a response interceptor.
@@ -156,7 +169,7 @@ export async function HttpClient<T = unknown>(
     }
   }
 
-  const response = await window.fetch(`${baseUrl()}${endpoint}`, init);
+  const response = await window.fetch(sanitizeURL(`${baseUrl()}${endpoint}`), init);
 
   const isJson = response.headers.get("Content-Type")?.includes("application/json");
 


### PR DESCRIPTION
This PR introduces a new function in `APIClient.tsx` called `sanitizeURL`.
This function will parse a given URL and if there are basic auth credentials present,
it strip it of username and password and return the URL without it and the characters for it's syntax.

Otherwise, if the credentials aren't stripped by a third party the JavaScript `fetch` API will throw an recoverable error.
(See corresponding issue.)

fixes #2102 

