### PR TITLE
feat(macros): add Cookie

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -33,6 +33,7 @@ type Macro struct {
 	Category                  string
 	Codec                     []string
 	Container                 string
+	Cookie                    string
 	CurrentDay                int
 	CurrentHour               int
 	CurrentMinute             int
@@ -110,6 +111,7 @@ func NewMacro(release Release) Macro {
 		Category:                  release.Category,
 		Codec:                     release.Codec,
 		Container:                 release.Container,
+		Cookie:                    release.RawCookie,
 		CurrentDay:                currentTime.Day(),
 		CurrentHour:               currentTime.Hour(),
 		CurrentMinute:             currentTime.Minute(),


### PR DESCRIPTION
Add Cookie to Macros for the few indexers that use it. Can be used for upcoming cross-seed features.