### PR TITLE
fix(web): omit router and query devtools in production builds

### DIFF
--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -365,8 +365,8 @@ export const RootComponent = () => {
       <Outlet />
       {settings.debug ? (
         <>
-          <TanStackRouterDevtools />
-          <ReactQueryDevtools initialIsOpen={false} />
+          {process.env.NODE_ENV === 'development' && <TanStackRouterDevtools />}
+          {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
         </>
       ) : null}
     </div>


### PR DESCRIPTION
If you enable WebUI debug mode in the settings it will currently show the router devtools in the production build.
This also increases the build size for the frontend without any value - it's rather a slowdown.

This PR uses conditional rendering to only load the devtools in development builds.