### PR TITLE
feat(macros): add CurrentTimeUnixMS

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -40,6 +40,7 @@ type Macro struct {
 	CurrentMonth              int
 	CurrentSecond             int
 	CurrentYear               int
+	CurrenTimeUnixMS          int64
 	Description               string
 	DownloadUrl               string
 	Episode                   int
@@ -118,6 +119,7 @@ func NewMacro(release Release) Macro {
 		CurrentMonth:              int(currentTime.Month()),
 		CurrentSecond:             currentTime.Second(),
 		CurrentYear:               currentTime.Year(),
+		CurrenTimeUnixMS:          currentTime.UnixMilli(),
 		Description:               release.Description,
 		DownloadUrl:               release.DownloadURL,
 		Episode:                   release.Episode,


### PR DESCRIPTION
Add new macro CurrentTimeUnixMS to get unix epoch time in milliseconds.