### PR TITLE
build(make): add build/dockerx for cross platform docker builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,14 @@ make build/docker
 
 The image will be tagged as `autobrr:dev`
 
+To build a cross platform Docker image (for instance if you're running on arm64 or Apple ARM):
+
+```shell
+make build/dockerx
+```
+
+[Docker multi-platform docs](https://docs.docker.com/build/building/multi-platform/)
+
 ## Mock indexer
 
 We have a mock indexer you can run locally that features:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ build/web:
 build/docker:
 	docker build -t autobrr:dev -f Dockerfile . --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT)
 
+build/dockerx:
+	docker buildx build -t autobrr:dev -f Dockerfile . --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --platform=linux/amd64,linux/arm64 --pull
+
 clean:
 	$(RM) -rf bin web/dist/*
 


### PR DESCRIPTION
This is needed to build docker images for other platforms (I'm on Apple ARM for instance). This will build the image for both arm64 and amd64. Docker and container registries seamlessly support multiple archs for the same image tag, so if you build both, it will automatically select the correct one to run. Similarly, if you push the image tag, it will push up both and when you pull, it will select the correct arch for the target system.