### PR TITLE
build(make): fix build/dockerx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build/docker:
 	docker build -t autobrr:dev -f Dockerfile . --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT)
 
 build/dockerx:
-	docker buildx build -t autobrr:dev -f Dockerfile . --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --platform=linux/amd64,linux/arm64 --pull
+	docker buildx build -t autobrr:dev -f Dockerfile . --build-arg GIT_TAG=$(GIT_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --platform=linux/amd64,linux/arm64 --pull --load
 
 clean:
 	$(RM) -rf bin web/dist/*


### PR DESCRIPTION
I forgot buildx is weird and I needed to add the `--load`. Without it, the images only stay in the build cache and aren't actually loaded into local docker so that they're usable.