### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+#### What is the relevant ticket/issue
+
+* [issue #](https://github.com/autobrr/autobrr/issues) or
+* [feature request #](https://github.com/autobrr/autobrr/discussions)
+
+#### What's this PR do?
+
+##### Add
+
+*
+
+##### Change
+
+*
+
+##### Remove
+
+*
+
+#### Where should the reviewer start?
+
+*
+
+#### How should this be manually tested?
+
+*
+
+#### Risk involved?
+
+*
+
+#### Screenshots (if appropriate)
+
+*
+
+#### Does the documentation or dependencies need an update?
+
+*


### PR DESCRIPTION
Why?

Consistency & clarity: every PR contains the same required fields so @zze0s always finds what he needs.

Faster reviews: mandatory “Where should the reviewer start?” and “How should this be tested?” reduce time-to-first-review and eliminate trivial back-and-forth.

Better traceability: consistently linking an issue/ticket enables automatic close-on-merge and simplifies audit/compliance.

Higher quality releases: explicit “Risk involved?”, migration notes and doc-dependency fields surface backwards compatibility and release-note needs early.

Onboarding & contributor enablement: new contributors know exactly what information to provide.

Automation & enforcement: templates can be validated by CI (status checks) so merges are blocked until minimum information is present.

Improved release notes & changelogs: structured PR bodies make it trivial to generate release notes programmatically.