### PR TITLE
feat(list): include year for mdblist

### DIFF
--- a/internal/database/list.go
+++ b/internal/database/list.go
@@ -45,6 +45,7 @@ func (r *ListRepo) List(ctx context.Context) ([]*domain.List, error) {
 		"include_unmonitored",
 		"include_alternate_titles",
 		"skip_clean_sanitize",
+		"include_year",
 		"last_refresh_time",
 		"last_refresh_status",
 		"last_refresh_data",
@@ -73,8 +74,7 @@ func (r *ListRepo) List(ctx context.Context) ([]*domain.List, error) {
 		var url, apiKey, lastRefreshStatus, lastRefreshData sql.Null[string]
 		var lastRefreshTime sql.Null[time.Time]
 		var clientID sql.Null[int]
-
-		err = rows.Scan(&list.ID, &list.Name, &list.Enabled, &list.Type, &clientID, &url, pq.Array(&list.Headers), &list.APIKey, &list.MatchRelease, pq.Array(&list.TagsInclude), pq.Array(&list.TagsExclude), &list.IncludeUnmonitored, &list.IncludeAlternateTitles, &list.SkipCleanSanitize, &lastRefreshTime, &lastRefreshStatus, &lastRefreshData, &list.CreatedAt, &list.UpdatedAt)
+		err = rows.Scan(&list.ID, &list.Name, &list.Enabled, &list.Type, &clientID, &url, pq.Array(&list.Headers), &list.APIKey, &list.MatchRelease, pq.Array(&list.TagsInclude), pq.Array(&list.TagsExclude), &list.IncludeUnmonitored, &list.IncludeAlternateTitles, &list.SkipCleanSanitize, &list.IncludeYear, &lastRefreshTime, &lastRefreshStatus, &lastRefreshData, &list.CreatedAt, &list.UpdatedAt)
 		if err != nil {
 			return nil, err
 		}
@@ -109,6 +109,7 @@ func (r *ListRepo) FindByID(ctx context.Context, listID int64) (*domain.List, er
 		"include_unmonitored",
 		"include_alternate_titles",
 		"skip_clean_sanitize",
+		"include_year",
 		"last_refresh_time",
 		"last_refresh_status",
 		"last_refresh_data",
@@ -137,7 +138,7 @@ func (r *ListRepo) FindByID(ctx context.Context, listID int64) (*domain.List, er
 	var url, apiKey sql.Null[string]
 	var clientID sql.Null[int]
 
-	err = row.Scan(&list.ID, &list.Name, &list.Enabled, &list.Type, &clientID, &url, pq.Array(&list.Headers), &list.APIKey, &list.MatchRelease, pq.Array(&list.TagsInclude), pq.Array(&list.TagsExclude), &list.IncludeUnmonitored, &list.IncludeAlternateTitles, &list.SkipCleanSanitize, &list.LastRefreshTime, &list.LastRefreshStatus, &list.LastRefreshData, &list.CreatedAt, &list.UpdatedAt)
+	err = row.Scan(&list.ID, &list.Name, &list.Enabled, &list.Type, &clientID, &url, pq.Array(&list.Headers), &list.APIKey, &list.MatchRelease, pq.Array(&list.TagsInclude), pq.Array(&list.TagsExclude), &list.IncludeUnmonitored, &list.IncludeAlternateTitles, &list.SkipCleanSanitize, &list.IncludeYear, &list.LastRefreshTime, &list.LastRefreshStatus, &list.LastRefreshData, &list.CreatedAt, &list.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -172,6 +173,7 @@ func (r *ListRepo) Store(ctx context.Context, list *domain.List) error {
 			"include_unmonitored",
 			"include_alternate_titles",
 			"skip_clean_sanitize",
+			"include_year",
 		).
 		Values(
 			list.Name,
@@ -187,6 +189,7 @@ func (r *ListRepo) Store(ctx context.Context, list *domain.List) error {
 			list.IncludeUnmonitored,
 			list.IncludeAlternateTitles,
 			list.SkipCleanSanitize,
+			list.IncludeYear,
 		).Suffix("RETURNING id").RunWith(tx)
 
 	//query, args, err := qb.ToSql()
@@ -231,6 +234,7 @@ func (r *ListRepo) Update(ctx context.Context, list *domain.List) error {
 		Set("include_unmonitored", list.IncludeUnmonitored).
 		Set("include_alternate_titles", list.IncludeAlternateTitles).
 		Set("skip_clean_sanitize", list.SkipCleanSanitize).
+		Set("include_year", list.IncludeYear).
 		Set("updated_at", sq.Expr("CURRENT_TIMESTAMP")).
 		Where(sq.Eq{"id": list.ID})
 

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -549,6 +549,7 @@ CREATE TABLE list
     tags_excluded            TEXT [] DEFAULT '{}' NOT NULL,
     include_unmonitored      BOOLEAN,
     include_alternate_titles BOOLEAN,
+    include_year             BOOLEAN DEFAULT FALSE,
     skip_clean_sanitize      BOOLEAN DEFAULT FALSE,
     last_refresh_time        TIMESTAMP,
     last_refresh_status      TEXT,
@@ -1391,6 +1392,7 @@ CREATE INDEX release_hybrid_index
 CREATE INDEX sessions_expiry_idx ON sessions (expiry);
 `,
 	`
-	ALTER TABLE list ADD COLUMN include_year BOOLEAN DEFAULT FALSE;
+	ALTER TABLE list
+		ADD COLUMN include_year BOOLEAN DEFAULT FALSE;
 `,
 }

--- a/internal/database/postgres_migrate.go
+++ b/internal/database/postgres_migrate.go
@@ -1365,20 +1365,20 @@ CREATE INDEX release_hybrid_index
 	ALTER TABLE list
 		ADD COLUMN skip_clean_sanitize BOOLEAN DEFAULT FALSE;
 `,
-	`UPDATE irc_network 
-	SET 
+	`UPDATE irc_network
+	SET
     	auth_mechanism = 'NONE',
     	auth_account = '',
     	auth_password = ''
-	WHERE server = 'irc.rocket-hd.cc' 
+	WHERE server = 'irc.rocket-hd.cc'
     	AND auth_mechanism != 'NONE';
 
-	UPDATE irc_channel 
+	UPDATE irc_channel
 	SET password = NULL
 	WHERE password IS NOT NULL
     	AND network_id IN (
-        	SELECT id 
-        	FROM irc_network 
+        	SELECT id
+        	FROM irc_network
         	WHERE server = 'irc.rocket-hd.cc'
     	);
 `,
@@ -1389,5 +1389,8 @@ CREATE INDEX release_hybrid_index
 );
 
 CREATE INDEX sessions_expiry_idx ON sessions (expiry);
+`,
+	`
+	ALTER TABLE list ADD COLUMN include_year BOOLEAN DEFAULT FALSE;
 `,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -550,6 +550,7 @@ CREATE TABLE list
     tags_excluded            TEXT [] DEFAULT '{}' NOT NULL,
     include_unmonitored      BOOLEAN,
     include_alternate_titles BOOLEAN,
+    include_year             BOOLEAN DEFAULT FALSE,
     skip_clean_sanitize      BOOLEAN DEFAULT FALSE,
     last_refresh_time        TIMESTAMP,
     last_refresh_status      TEXT,
@@ -2036,6 +2037,7 @@ CREATE INDEX release_hybrid_index
 CREATE INDEX sessions_expiry_idx ON sessions(expiry);
 `,
 	`
-	ALTER TABLE list ADD COLUMN include_year BOOLEAN DEFAULT FALSE;
+	ALTER TABLE list
+		ADD COLUMN include_year BOOLEAN DEFAULT FALSE;
 `,
 }

--- a/internal/database/sqlite_migrate.go
+++ b/internal/database/sqlite_migrate.go
@@ -2010,20 +2010,20 @@ CREATE INDEX release_hybrid_index
 	ALTER TABLE list
 		ADD COLUMN skip_clean_sanitize BOOLEAN DEFAULT FALSE;
 `,
-	`UPDATE irc_network 
-	SET 
+	`UPDATE irc_network
+	SET
     	auth_mechanism = 'NONE',
     	auth_account = '',
     	auth_password = ''
-	WHERE server = 'irc.rocket-hd.cc' 
+	WHERE server = 'irc.rocket-hd.cc'
     	AND auth_mechanism != 'NONE';
 
-	UPDATE irc_channel 
+	UPDATE irc_channel
 	SET password = NULL
 	WHERE password IS NOT NULL
     	AND network_id IN (
-        	SELECT id 
-        	FROM irc_network 
+        	SELECT id
+        	FROM irc_network
         	WHERE server = 'irc.rocket-hd.cc'
     	);
 `,
@@ -2034,5 +2034,8 @@ CREATE INDEX release_hybrid_index
 );
 
 CREATE INDEX sessions_expiry_idx ON sessions(expiry);
+`,
+	`
+	ALTER TABLE list ADD COLUMN include_year BOOLEAN DEFAULT FALSE;
 `,
 }

--- a/internal/domain/list.go
+++ b/internal/domain/list.go
@@ -67,6 +67,7 @@ type List struct {
 	LastRefreshStatus      ListRefreshStatus `json:"last_refresh_status"`
 	CreatedAt              time.Time         `json:"created_at"`
 	UpdatedAt              time.Time         `json:"updated_at"`
+	IncludeYear            bool              `json:"include_year"`
 	SkipCleanSanitize      bool              `json:"skip_clean_sanitize"`
 }
 

--- a/web/src/forms/settings/ListForms.tsx
+++ b/web/src/forms/settings/ListForms.tsx
@@ -143,6 +143,7 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
                     include_unmonitored: false,
                     include_alternate_titles: false,
                     skip_clean_sanitize: false,
+                    include_year: false,
                   }}
                   onSubmit={onSubmit}
                   validate={validate}
@@ -375,6 +376,7 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
                     include_unmonitored: data.include_unmonitored,
                     include_alternate_titles: data.include_alternate_titles,
                     skip_clean_sanitize: data.skip_clean_sanitize,
+                    include_year: data.include_year,
                   }}
                   onSubmit={onSubmit}
                   // validate={validate}
@@ -606,6 +608,13 @@ const FilterOptionCheckBoxes = (props: ListTypeFormProps) => {
           <SwitchGroupWide name="skip_clean_sanitize" label="Bypass the cleanup and sanitization and use the list as-is" description="By default, titles are automatically sanitized and checked for unusual characters." />
         </fieldset>
       );
+    case "MDBLIST":
+      return (
+        <fieldset>
+          <legend className="sr-only">Settings</legend>
+          <SwitchGroupWide name="include_year" label="Include release year for each title" description="Release year information can be added for each title." />
+        </fieldset>
+      );
   }
 }
 
@@ -688,6 +697,7 @@ function ListTypeTrakt() {
         <fieldset>
           <legend className="sr-only">Settings</legend>
           <SwitchGroupWide name="match_release" label="Match Release" description="Use Match Releases field. Uses Movies/Shows field by default." />
+          <SwitchGroupWide name="include_year" label="Include Year" description="Include the release year in the filter. Example: Movie?Title*2024*" />
         </fieldset>
       </div>
     </div>
@@ -761,6 +771,12 @@ function ListTypePlainText() {
         <fieldset>
           <legend className="sr-only">Settings</legend>
           <SwitchGroupWide name="skip_clean_sanitize" label="Bypass the cleanup and sanitization and use the list as-is" description="By default, titles are automatically sanitized and checked for unusual characters." />
+        </fieldset>
+      </div>
+      <div className="space-y-1">
+        <fieldset>
+          <legend className="sr-only">Settings</legend>
+          <SwitchGroupWide name="include_year" label="Include release year for each title" description="Release year information can be added for each title." />
         </fieldset>
       </div>
     </div>

--- a/web/src/types/List.d.ts
+++ b/web/src/types/List.d.ts
@@ -19,6 +19,7 @@ interface List {
   include_unmonitored: boolean;
   include_alternate_titles: boolean;
   skip_clean_sanitize: boolean;
+  include_year: boolean;
 }
 
 interface ListFilter {
@@ -41,6 +42,7 @@ interface ListCreate {
   include_unmonitored: boolean;
   include_alternate_titles: boolean;
   skip_clean_sanitize: boolean;
+  include_year: boolean;
 }
 
 type ListType =


### PR DESCRIPTION
#### What is the relevant ticket/issue

Problem statement: When you use MDBList to populate **MOVIES / SHOWS** or **MATCH RELEASES**, it only contains title at the moment. It leads to undesirable results, when e.g. movie(s) with the same title were released on different years. The MDBList json does contain the `release_year` already, so we can use that to make the matching more precise. See the schema of MDBList item:

```json
  {
    "id": 1061474,
    "rank": 2,
    "adult": 0,
    "title": "Superman",
    "tvdbid": null,
    "imdb_id": "tt5950044",
    "mediatype": "movie",
    "release_year": 2025
  }
```

#### What's this PR do?

##### Add

* New toggle option "Include year", that will turn the above example to `Superman*2025*`, instead of just `Superman`

#### Where should the reviewer start?

* `internal/database/list.go`
* `internal/database/postgres_migrate.go`
* `internal/database/sqlite_migrate.go`
* `internal/domain/list.go`
* `internal/list/process_list_mdblist.go`
* `web/src/forms/settings/ListForms.tsx`
* `web/src/types/List.d.ts`

#### How should this be manually tested?

* `go run cmd/autobrr/main.go` & `pnpm dev` - go to `http://<AUTOBRR>/settings/lists` and add a new MDBList, enable the Include Year option + Match Release and look at the results.

#### Risk involved?

* Yes, if the Match Release is not ticked, this will not work. 

#### Screenshots (if appropriate)

* TBA

#### Does the documentation or dependencies need an update?

* Yes