### PR TITLE
fix(indexers): SeedPool internal announces

### DIFF
--- a/internal/indexer/definitions/seedpool.yaml
+++ b/internal/indexer/definitions/seedpool.yaml
@@ -70,7 +70,7 @@ irc:
             torrentSize: 17.85 GiB
             origin: ""
             freeleech: "★"
-        pattern: '^【 (.+?) 】 (.*?) ჻ (.*?)@(https:\/\/.*?\/)torrents/(\d+) ჻ ([^჻]+)(?: ჻ (iNTERNAL))?(?: ჻ (★))?$'
+        pattern: '^【 (.+?) 】 (.*?) ჻ (.*?)@(https:\/\/.*?\/)torrents/(\d+) ჻ ([^჻]+)(?: ჻ (iNTERNAL))?(?: ჻ (★))?\s*$'
         vars:
           - category
           - torrentName


### PR DESCRIPTION
### Summary
This PR updates the seedpool regex pattern to allow optional trailing whitespace due to inconsistencies with announce bots, specifically with the seedpool internal release announces.

### Motivation
Strings like:
`【 Movie 】 ... ჻ iNTERNAL `
previously failed to match due to the trailing space. This change fixes that.

### Changes
- Added `\s*` at the end of the regex pattern in internal/indexer/definitions/seedpool.yaml
