### PR TITLE
fix(indexers): Test API sends key as redacted if saved

### DIFF
--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -769,6 +769,15 @@ func (s *service) TestApi(ctx context.Context, req domain.IndexerTestApiRequest)
 		return err
 	}
 
+	if domain.IsRedactedString(req.ApiKey) {
+		apikey, ok := indexer.Settings["api_key"]
+		if !ok {
+			return errors.New("could not find apikey in indexer settings")
+		}
+
+		req.ApiKey = apikey
+	}
+
 	def := s.getMappedDefinitionByName(indexer.Identifier)
 	if def == nil {
 		return errors.New("could not find definition: %s", indexer.Identifier)


### PR DESCRIPTION
The Test API button for indexers would send and use the `<redacted>` value if form was saved before clicking the button.