### PR TITLE
fix(sessions): database store initialization

### DIFF
--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -118,8 +118,10 @@ func main() {
 
 	// session manager
 	sessionManager := scs.New()
-	sessionManager.Store = sqlite3store.New(db)
-	if db.Driver == "postgres" {
+	switch db.Driver {
+	case database.DriverSQLite:
+		sessionManager.Store = sqlite3store.New(db)
+	case database.DriverPostgres:
 		sessionManager.Store = postgresstore.New(db.Handler)
 	}
 


### PR DESCRIPTION
Fix the init of database store for the session manager.

By running this below with first init of the sqlite store the New method stars the background cleanup job automatically. And that should not run when Postgres is used.

```go
// session manager
sessionManager := scs.New()
sessionManager.Store = sqlite3store.New(db)
if db.Driver == "postgres" {
	sessionManager.Store = postgresstore.New(db.Handler)
}
```

Reported by @bakerboy448