### PR TITLE
fix(indexers): HDB parse announce with Internal and Exclusive correctly

### DIFF
--- a/internal/indexer/definitions/hdb.yaml
+++ b/internal/indexer/definitions/hdb.yaml
@@ -74,8 +74,8 @@ irc:
             torrentName: 'PilotsEYE tv: QUITO 2014 1080p Blu-ray AVC DD 2.0'
             category: Documentary
             releaseTags: H.264, Blu-ray/HD DVD
-            tags: ""
             origin: ""
+            tags: ""
             uploader: Anonymous
             torrentSize: 23.14 GiB
             baseUrl: https://hdbits.org/
@@ -85,8 +85,8 @@ irc:
             torrentName: Xiao Q 2019 720p BluRay DD-EX 5.1 x264-Anonymous
             category: Movie
             releaseTags: H.264, Encode
-            tags: ""
             origin: Internal
+            tags: ""
             uploader: Anonymous
             torrentSize: 4.54 GiB
             baseUrl: https://hdbits.org/
@@ -96,8 +96,8 @@ irc:
             torrentName: The Gentlemen 2019 UHD Blu-ray English TrueHD 7.1
             category: Audio Track
             releaseTags: ""
-            tags: ""
             origin: ""
+            tags: ""
             uploader: Anonymous
             torrentSize: 3.19 GiB
             baseUrl: https://hdbits.org/
@@ -107,20 +107,31 @@ irc:
             torrentName: That Movie 1983 1080p GBR Blu-ray AVC DTS-HD MA 1.0-GROUP
             category: Movie
             releaseTags: H.264, Blu-ray/HD DVD
-            tags: Exclusive
             origin: ""
+            tags: Exclusive
+            uploader: anon
+            torrentSize: 29.55 GiB
+            baseUrl: https://hdbits.org/
+            torrentId: "000000"
+        - line: 'New Torrent: That Movie 1983 1080p GBR Blu-ray AVC DTS-HD MA 1.0-GROUP - Type: Movie (H.264, Blu-ray/HD DVD) Internal! Exclusive! - Uploaded by: anon - Size: 29.55 GiB - https://hdbits.org/details.php?id=000000&hit=1'
+          expect:
+            torrentName: That Movie 1983 1080p GBR Blu-ray AVC DTS-HD MA 1.0-GROUP
+            category: Movie
+            releaseTags: H.264, Blu-ray/HD DVD
+            origin: "Internal"
+            tags: Exclusive
             uploader: anon
             torrentSize: 29.55 GiB
             baseUrl: https://hdbits.org/
             torrentId: "000000"
 
-        pattern: 'New Torrent: (.+) - Type: (.+?) (?:\((.+)\))?\s?(?:(Exclusive)?(Internal)?!)?\s?- Uploaded by: (.+) - Size: (.+) - (https:\/\/.+?\/).+id=(\d+)'
+        pattern: 'New Torrent: (.+?) - Type: (.+?) (?:\((.+?)\))?\s*(Internal)?!?\s*(Exclusive)?!?\s*- Uploaded by: (.+?) - Size: (.+?) - (https:\/\/.+?\/).+id=(\d+)'
         vars:
           - torrentName
           - category
           - releaseTags
-          - tags
           - origin
+          - tags
           - uploader
           - torrentSize
           - baseUrl


### PR DESCRIPTION
#### What is the relevant ticket/issue

* [Reported on Discord](https://discord.com/channels/881212911849209957/881967548143403058/1420817396741963887)

#### What's this PR do?

Fix the HDB announce regex to capture both Internal and Exclusive.

https://regex101.com/r/6iVKmC/1

##### Change

* HDB indexer definition regex