### PR TITLE
fix(proxy): test connection with non-redacted creds

### DIFF
--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -159,6 +159,8 @@ func (s *service) Test(ctx context.Context, proxy *domain.Proxy) error {
 		return errors.Wrap(err, "could not connect to proxy server: %s", proxy.Addr)
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return errors.New("got unexpected status code: %d", resp.StatusCode)
 	}


### PR DESCRIPTION
#### What is the relevant ticket/issue

Closes #2219 

#### What's this PR do?

##### Change

* fix proxy test to grab existing creds if it receives `<redacted>` from the request.

#### How should this be manually tested?

* Setup a proxy, hit save, refresh, hit Test button