### PR TITLE
fix(macros): parse exec args on windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25
 replace github.com/r3labs/sse/v2 => github.com/autobrr/sse/v2 v2.0.0-20230520125637-530e06346d7d
 
 require (
+	github.com/Hellseher/go-shellquote v0.1.0
 	github.com/KimMachineGun/automemlimit v0.7.4
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/Masterminds/squirrel v1.5.4
@@ -33,7 +34,6 @@ require (
 	github.com/icholy/digest v1.1.0
 	github.com/lib/pq v1.10.9
 	github.com/magiconair/properties v1.8.10
-	github.com/mattn/go-shellwords v1.0.12
 	github.com/mmcdole/gofeed v1.3.0
 	github.com/moistari/rls v0.6.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ crawshaw.io/sqlite v0.3.2/go.mod h1:igAO5JulrQ1DbdZdtVq48mnZUBAPOeFzer7VhDWNtW4=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Hellseher/go-shellquote v0.1.0 h1:T9+VA5gQ25+QAFNyKpCXsxc1zrrUk3vC2utC70DN4qA=
+github.com/Hellseher/go-shellquote v0.1.0/go.mod h1:t4xAP6TrFpgvp/U7szp27rYrXXVu9yn3WhNylBvnfb8=
 github.com/KimMachineGun/automemlimit v0.7.4 h1:UY7QYOIfrr3wjjOAqahFmC3IaQCLWvur9nmfIn6LnWk=
 github.com/KimMachineGun/automemlimit v0.7.4/go.mod h1:QZxpHaGOQoYvFhv/r4u3U0JTC2ZcOwbSr11UZF46UBM=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -254,8 +256,6 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
-github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=

--- a/internal/action/exec.go
+++ b/internal/action/exec.go
@@ -11,7 +11,7 @@ import (
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
 
-	"github.com/mattn/go-shellwords"
+	"github.com/Hellseher/go-shellquote"
 )
 
 func (s *service) execCmd(ctx context.Context, action *domain.Action, release domain.Release) error {
@@ -23,9 +23,7 @@ func (s *service) execCmd(ctx context.Context, action *domain.Action, release do
 		return errors.Wrap(err, "exec failed, could not find program: %s", action.ExecCmd)
 	}
 
-	p := shellwords.NewParser()
-	p.ParseBacktick = true
-	args, err := p.Parse(action.ExecArgs)
+	args, err := shellquote.Split(action.ExecArgs)
 	if err != nil {
 		return errors.Wrap(err, "could not parse exec args: %s", action.ExecArgs)
 	}

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -24,8 +24,8 @@ import (
 	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/autobrr/autobrr/pkg/sharedhttp"
 
+	"github.com/Hellseher/go-shellquote"
 	"github.com/avast/retry-go/v4"
-	"github.com/mattn/go-shellwords"
 	"github.com/rs/zerolog"
 )
 
@@ -876,9 +876,7 @@ func (s *service) execCmd(_ context.Context, external domain.FilterExternal, rel
 	}
 
 	// we need to split on space into a string slice, so we can spread the args into exec
-	p := shellwords.NewParser()
-	p.ParseBacktick = true
-	commandArgs, err := p.Parse(parsedArgs)
+	commandArgs, err := shellquote.Split(parsedArgs)
 	if err != nil {
 		return 0, errors.Wrap(err, "could not parse into shell-words")
 	}


### PR DESCRIPTION
#### What is the relevant ticket/issue

Fixes #1574 and closes #1937 

#### What's this PR do?

Replaces the package that handles external filter and action exec args from string to shell compatible slice of strings. The mattn package did not handle windows backslashes in paths but this new does.

##### Change

* Package for parsing shell args from [mattn/go-shellwords](https://github.com/mattn/go-shellwords) to [Hellseher/go-shellquote](https://github.com/Hellseher/go-shellquote)

#### How should this be manually tested?

* Setup filter with Exec cmd external filter or Exec cmd action **on windows** with a macro like `{{.TorrentPathName}}`

#### Risk involved?

* Low for basic usage and medium if users have more advanced arg setups

#### Does the documentation or dependencies need an update?

* No
