### PR TITLE
fix(database): add missing rows.Close calls

### DIFF
--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -802,6 +802,7 @@ func (r *FilterRepo) FindExternalFiltersByID(ctx context.Context, filterId int) 
 		}
 		return nil, errors.Wrap(err, "error executing query")
 	}
+	defer rows.Close()
 
 	var externalFilters []domain.FilterExternal
 

--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -1209,6 +1209,7 @@ func (repo *ReleaseRepo) CheckIsDuplicateRelease(ctx context.Context, profile *d
 	if err != nil {
 		return false, err
 	}
+	defer rows.Close()
 
 	if err := rows.Err(); err != nil {
 		return false, errors.Wrap(err, "error rows CheckIsDuplicateRelease")

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -138,6 +138,7 @@ func (db *DB) databaseConsistencyCheckSQLite() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to query integrity check")
 	}
+	defer rows.Close()
 
 	var results []string
 	for rows.Next() {


### PR DESCRIPTION
#### What's this PR do?

##### Add

* Add missing calls to rows.Close() for db.Query/QueryContext calls

#### Risk involved?

* Low

#### Does the documentation or dependencies need an update?

* No
