### PR TITLE
fix(web): dropdown causes crash

### DIFF
--- a/web/src/components/inputs/constants.tsx
+++ b/web/src/components/inputs/constants.tsx
@@ -1,0 +1,14 @@
+export const SMColSpanClasses: Record<number, string> = {
+  1: 'sm:col-span-1',
+  2: 'sm:col-span-2',
+  3: 'sm:col-span-3',
+  4: 'sm:col-span-4',
+  5: 'sm:col-span-5',
+  6: 'sm:col-span-6',
+  7: 'sm:col-span-7',
+  8: 'sm:col-span-8',
+  9: 'sm:col-span-9',
+  10: 'sm:col-span-10',
+  11: 'sm:col-span-11',
+  12: 'sm:col-span-12'
+};

--- a/web/src/components/inputs/index.ts
+++ b/web/src/components/inputs/index.ts
@@ -9,4 +9,5 @@ export * from "./input_wide";
 export * from "./radio";
 export * from "./select";
 export * from "./switch";
+export { SMColSpanClasses } from "./constants";
 

--- a/web/src/components/inputs/select.tsx
+++ b/web/src/components/inputs/select.tsx
@@ -11,6 +11,7 @@ import { MultiSelect as RMSC } from "react-multi-select-component";
 
 import { classNames, COL_WIDTHS } from "@utils";
 import { DocsTooltip } from "@components/tooltips/DocsTooltip";
+import { SMColSpanClasses } from "./constants";
 
 export interface MultiSelectOption {
   value: string | number;
@@ -44,11 +45,13 @@ export const MultiSelect = ({
     key: value
   });
 
+  const smColClass = columns ? SMColSpanClasses[columns] : "";
+
   return (
     <div
       className={classNames(
         "col-span-12",
-        columns ? `sm:col-span-${columns}` : ""
+        smColClass
       )}
     >
       <label
@@ -99,47 +102,50 @@ export const IndexerMultiSelect = ({
   label,
   options,
   columns
-}: MultiSelectProps) => (
-  <div
-    className={classNames(
-      "col-span-12",
-      columns ? `sm:col-span-${columns}` : ""
-    )}
-  >
-    <label
-      className="block ml-px mb-1 text-xs font-bold tracking-wide text-gray-700 uppercase dark:text-gray-200"
-      htmlFor={label}
-    >
-      {label}
-    </label>
-
-    <Field name={name} type="select" multiple={true}>
-      {({
-        field,
-        meta,
-        form: { setFieldValue }
-      }: FieldProps) => (
-        <>
-          <RMSC
-            {...field}
-            options={options}
-            labelledBy={name}
-            value={field.value && field.value.map((item: IndexerMultiSelectOption) => ({
-              value: item.id, label: item.name
-            }))}
-            onChange={(values: MultiSelectOption[]) => {
-              const item = values && values.map((i) => ({ id: i.value, name: i.label }));
-              setFieldValue(field.name, item);
-            }}
-          />
-          {meta.touched && meta.error && (
-            <p className="error text-sm text-red-600 mt-1">* {meta.error}</p>
-          )}
-        </>
+}: MultiSelectProps) => {
+  const smColClass = columns ? SMColSpanClasses[columns] : "";
+  return (
+    <div
+      className={classNames(
+        "col-span-12",
+        smColClass
       )}
-    </Field>
-  </div>
-);
+    >
+      <label
+        className="block ml-px mb-1 text-xs font-bold tracking-wide text-gray-700 uppercase dark:text-gray-200"
+        htmlFor={label}
+      >
+        {label}
+      </label>
+
+      <Field name={name} type="select" multiple={true}>
+        {({
+            field,
+            meta,
+            form: { setFieldValue }
+          }: FieldProps) => (
+          <>
+            <RMSC
+              {...field}
+              options={options}
+              labelledBy={name}
+              value={field.value && field.value.map((item: IndexerMultiSelectOption) => ({
+                value: item.id, label: item.name
+              }))}
+              onChange={(values: MultiSelectOption[]) => {
+                const item = values && values.map((i) => ({ id: i.value, name: i.label }));
+                setFieldValue(field.name, item);
+              }}
+            />
+            {meta.touched && meta.error && (
+              <p className="error text-sm text-red-600 mt-1">* {meta.error}</p>
+            )}
+          </>
+        )}
+      </Field>
+    </div>
+  );
+}
 
 interface DownloadClientSelectProps {
   name: string;
@@ -273,11 +279,12 @@ export const Select = ({
   columns = 6,
   className
 }: SelectFieldProps) => {
+  const smColClass = SMColSpanClasses[columns] || "sm:col-span-6";
   return (
     <div
       className={classNames(
         className ?? "col-span-12",
-        columns ? `sm:col-span-${columns}` : ""
+        smColClass,
       )}
     >
       <Field name={name} type="select">
@@ -502,8 +509,10 @@ export const AgeSelect = ({
     { value: '0', label: 'Delete everything' }
   ];
 
+  const smColClass = SMColSpanClasses[columns] || 'sm:col-span-6';
+
   return (
-    <div className={`col-span-12 ${columns ? `sm:col-span-${columns}` : ""}`}>
+    <div className={`col-span-12 ${smColClass}`}>
       <Listbox value={duration} onChange={(value) => {
         const parsedValue = parseInt(value, 10);
         setParsedDuration(parsedValue);


### PR DESCRIPTION
#### What is the relevant ticket/issue

Fixes #1984 

#### What's this PR do?

##### Change

* Moves dynamic sm:col classes to const values due to Tailwind jit not supporting dynamic class interpolation potentially leading to missing classes and crashes on certain resolutions

#### How should this be manually tested?

* TBD, not too easy to reproduce