### PR TITLE
feat(web): filter releases for Pending status

### DIFF
--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -68,7 +68,7 @@ const (
 	COUNT(DISTINCT CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'start of month')) AS INTEGER) THEN release_id END) as "month_count",
 	COUNT(DISTINCT release_id) as "total_count"
 FROM release_action_status
-WHERE status IN ('PUSH_APPROVED', 'PUSH_PENDING') AND filter_id = ?;`
+WHERE status IN ('PUSH_APPROVED', 'PENDING') AND filter_id = ?;`
 
 	filterDownloadsPG = `SELECT
     COUNT(DISTINCT CASE WHEN timestamp >= date_trunc('hour', CURRENT_TIMESTAMP) THEN release_id END) as "hour_count",
@@ -77,7 +77,7 @@ WHERE status IN ('PUSH_APPROVED', 'PUSH_PENDING') AND filter_id = ?;`
     COUNT(DISTINCT CASE WHEN timestamp >= date_trunc('month', CURRENT_DATE) THEN release_id END) as "month_count",
     COUNT(DISTINCT release_id) as "total_count"
 FROM release_action_status
-WHERE status IN ('PUSH_APPROVED', 'PUSH_PENDING') AND filter_id = $1;`
+WHERE status IN ('PUSH_APPROVED', 'PENDING') AND filter_id = $1;`
 )
 
 func (r *FilterRepo) Find(ctx context.Context, params domain.FilterQueryParams) ([]*domain.Filter, error) {

--- a/web/src/domain/constants.ts
+++ b/web/src/domain/constants.ts
@@ -409,6 +409,10 @@ export const PushStatusOptions: OptionBasic[] = [
     value: "PUSH_APPROVED"
   },
   {
+    label: "Pending",
+    value: "PENDING"
+  },
+  {
     label: "Error",
     value: "PUSH_ERROR"
   }

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -153,7 +153,7 @@ export const ReleasesRoute = createRoute({
     limit: z.number().optional(),
     filter: z.string().optional(),
     q: z.string().optional(),
-    action_status: z.enum(['PUSH_APPROVED', 'PUSH_REJECTED', 'PUSH_ERROR', '']).optional(),
+    action_status: z.enum(['PUSH_APPROVED', 'PUSH_REJECTED', 'PENDING', 'PUSH_ERROR', '']).optional(),
     // filters: z.array().catch(''),
     // sort: z.enum(['newest', 'oldest', 'price']).catch('newest'),
   }).parse(search),

--- a/web/src/screens/settings/Releases.tsx
+++ b/web/src/screens/settings/Releases.tsx
@@ -207,6 +207,7 @@ function DeleteReleases() {
   const releaseStatusOptions = [
     { label: "Approved", value: "PUSH_APPROVED" },
     { label: "Rejected", value: "PUSH_REJECTED" },
+    { label: "Pending", value: "PENDING" },
     { label: "Errored", value: "PUSH_ERROR" }
   ];
 


### PR DESCRIPTION
#### What's this PR do?

##### Add

* Add release filtering for action push status `Pending`
* Add release action status `Pending` for deleting releases

##### Change

* Download count check from `PUSH_PENDING` to `PENDING` - this might have been a long standing bug leading to more grabs than set filter limits

#### How should this be manually tested?

* Releases search in webui, click **Push Status** and select `Pending`
* In Settings -> Releases the **Release statuses** dropdown now include Pending

#### Risk involved?

* Low

#### Screenshots (if appropriate)

* <img width="895" height="628" alt="image" src="https://github.com/user-attachments/assets/d41b106c-be02-43f7-aebe-03a1d9578240" />
* <img width="327" height="280" alt="image" src="https://github.com/user-attachments/assets/fefe2972-d815-475f-b5b7-3c63739dc739" />

#### Does the documentation or dependencies need an update?

* No
