### PR TITLE
build: remove early web dist publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,13 +72,6 @@ jobs:
           name: web-dist
           path: web/dist
 
-      - name: Upload web-dist to release assets
-        uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            dist/web-dist.tar.gz
-
   test:
     name: Test ubuntu-latest
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What's this PR do?

##### Remove

* Remove recently added early web-dist publish because it created a release and GoReleaser didn't update it properly
