### PR TITLE
fix(http): keep session cookie SameSite=Lax

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -93,13 +93,11 @@ func (h *authHandler) login(w http.ResponseWriter, r *http.Request) {
 	h.sessionManager.Cookie.SameSite = http.SameSiteLaxMode
 	h.sessionManager.Cookie.Path = h.config.BaseURL
 
-	// autobrr does not support serving on TLS / https, so this is only available behind reverse proxy
-	// if forwarded protocol is https then set cookie secure
-	// SameSite Strict can only be set with a secure cookie. So we overwrite it here if possible.
-	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+	// autobrr does not support serving on TLS / https, so this is only available behind reverse proxy.
+	// When forwarded protocol is https we mark the cookie as Secure, but keep SameSite=Lax so OIDC
+	// callbacks returning from a different domain still include the session cookie.
 	if r.Header.Get("X-Forwarded-Proto") == "https" {
 		h.sessionManager.Cookie.Secure = true
-		h.sessionManager.Cookie.SameSite = http.SameSiteStrictMode
 	}
 
 	if err := h.sessionManager.RenewToken(ctx); err != nil {

--- a/internal/http/oidc.go
+++ b/internal/http/oidc.go
@@ -307,10 +307,10 @@ func (h *OIDCHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	h.sessionManager.Cookie.SameSite = http.SameSiteLaxMode
 	h.sessionManager.Cookie.Path = h.config.BaseURL
 
-	// If forwarded protocol is https then set cookie secure
+	// If forwarded protocol is https then set cookie secure. We keep SameSite=Lax to allow the
+	// session cookie to accompany OIDC callbacks originating from another domain.
 	if r.Header.Get("X-Forwarded-Proto") == "https" {
 		h.sessionManager.Cookie.Secure = true
-		h.sessionManager.Cookie.SameSite = http.SameSiteStrictMode
 	}
 
 	// Set session values using sessionManager


### PR DESCRIPTION
#### What is the relevant ticket/issue

* #2258 

#### What's this PR do?

##### Change

* Removes `SameSiteStrictMode`, we already set cookie to secure over https anyway

#### Risk involved?

* Shouldn't be any. We do the same in qui https://github.com/autobrr/qui/blob/main/internal/api/handlers/oidc.go#L347-L349
