### PR TITLE
docs: update Linux start service command

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ WantedBy=multi-user.target
 Start the service. Enable will make it startup on reboot.
 
 ```bash
-systemctl enable --now autobrr@USERNAME.service
+systemctl enable --now autobrr@$USER.service
 ```
 
 By default, the configuration is set to listen on `127.0.0.1`. While autobrr works fine as is exposed to the internet,


### PR DESCRIPTION
The service is created as a system service but the start command attempts to start it as a user service. This will not work and the command should be replaced. This change is also what is already present in the official documentation.

#### What is the relevant ticket/issue

* [issue #](https://github.com/autobrr/autobrr/issues) or
* [feature request #](https://github.com/autobrr/autobrr/discussions)

#### What's this PR do?

Fix a bad Linux system service start command.

##### Change

The existing Linux system service start command.

#### Where should the reviewer start?

N/A

#### How should this be manually tested?

N/A

#### Risk involved?

Little/None. The current command does not work.

#### Screenshots (if appropriate)

N/A

#### Does the documentation or dependencies need an update?

This is part of the documentation.
