### PR TITLE
feat(filters): clarify mode for RegEx fields

### DIFF
--- a/web/src/screens/filters/sections/Advanced.tsx
+++ b/web/src/screens/filters/sections/Advanced.tsx
@@ -61,6 +61,8 @@ const Releases = () => {
                 <br />
                 <br />
                 <p>Remember to tick <b>Use Regex</b> if using more than <code>*</code> and <code>?</code>.</p>
+                <br />
+                <p>Mode: <code>(?i)</code> <b>case-insensitive</b></p>
               </div>
             }
           />
@@ -80,6 +82,8 @@ const Releases = () => {
                 <br />
                 <br />
                 <p>Remember to tick <b>Use Regex</b> if using more than <code>*</code> and <code>?</code>.</p>
+                <br />
+                <p>Mode: <code>(?i)</code> <b>case-insensitive</b></p>
               </div>
             }
           />
@@ -446,6 +450,8 @@ const FeedSpecific = () => {
             <br />
             <br />
             <p>Remember to tick <b>Use Regex</b> if using more than <code>*</code> and <code>?</code>.</p>
+            <br />
+            <p>Mode: <code>(?i)</code> <b>case-insensitive</b></p>
           </div>
         }
       />
@@ -462,6 +468,8 @@ const FeedSpecific = () => {
             <br />
             <br />
             <p>Remember to tick <b>Use Regex</b> if using more than <code>*</code> and <code>?</code>.</p>
+            <br />
+            <p>Mode: <code>(?i)</code> <b>case-insensitive</b></p>
           </div>
         }
       />
@@ -547,6 +555,17 @@ const RawReleaseTags = () => {
         useRegex={values.use_regex_release_tags}
         columns={6}
         placeholder="eg. *mkv*,*foreign*"
+        tooltip={
+          <div>
+            <p>This field has full regex support (Golang flavour).</p>
+            <DocsLink href="https://autobrr.com/filters#advanced" />
+            <br />
+            <br />
+            <p>Remember to tick <b>Use Regex</b> if using more than <code>*</code> and <code>?</code>.</p>
+            <br />
+            <p>Mode: <code>(?i)</code> <b>case-insensitive</b></p>
+          </div>
+        }
       />
       <RegexField
         name="except_release_tags"
@@ -554,6 +573,17 @@ const RawReleaseTags = () => {
         useRegex={values.use_regex_release_tags}
         columns={6}
         placeholder="eg. *mkv*,*foreign*"
+        tooltip={
+          <div>
+            <p>This field has full regex support (Golang flavour).</p>
+            <DocsLink href="https://autobrr.com/filters#advanced" />
+            <br />
+            <br />
+            <p>Remember to tick <b>Use Regex</b> if using more than <code>*</code> and <code>?</code>.</p>
+            <br />
+            <p>Mode: <code>(?i)</code> <b>case-insensitive</b></p>
+          </div>
+        }
       />
     </CollapsibleSection>
   );


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Closes #2162 

#### What's this PR do?

##### Add

* Explanation about Mode to RegEx fields

#### Risk involved?

* None

#### Screenshots (if appropriate)

* <img width="596" height="143" alt="image" src="https://github.com/user-attachments/assets/99a3696f-ab3d-4e1e-aa47-8f22123dcba1" />


#### Does the documentation or dependencies need an update?

* Yes
