### PR TITLE
fix(indexers): BTN API increase timeout and change Test RPC method

### DIFF
--- a/internal/indexer/api.go
+++ b/internal/indexer/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/autobrr/autobrr/pkg/ops"
 	"github.com/autobrr/autobrr/pkg/red"
 
+	"github.com/dcarbone/zadapters/zstdlog"
 	"github.com/rs/zerolog"
 )
 
@@ -180,7 +181,7 @@ func (s *apiService) getClientForTest(req domain.IndexerTestApiRequest) (apiClie
 		if req.ApiKey == "" {
 			return nil, errors.New("api.Service.AddClient: could not initialize btn client: missing var 'api_key'")
 		}
-		return btn.NewClient(req.ApiKey, btn.WithHTTPClient(proxyHttpClient)), nil
+		return btn.NewClient(req.ApiKey, btn.WithHTTPClient(proxyHttpClient), btn.WithLog(zstdlog.NewStdLoggerWithLevel(s.log.With().Logger(), zerolog.DebugLevel))), nil
 
 	case "ggn":
 		if req.ApiKey == "" {

--- a/internal/proxy/service.go
+++ b/internal/proxy/service.go
@@ -205,7 +205,7 @@ func GetProxiedHTTPClient(p *domain.Proxy) (*http.Client, error) {
 	}
 
 	client := &http.Client{
-		Timeout:   30 * time.Second,
+		Timeout:   60 * time.Second,
 		Transport: transport,
 	}
 

--- a/pkg/btn/btn_test.go
+++ b/pkg/btn/btn_test.go
@@ -40,7 +40,7 @@ func TestAPI(t *testing.T) {
 		//}
 
 		// read json response
-		jsonPayload, _ := os.ReadFile("testdata/btn_get_user_info.json")
+		jsonPayload, _ := os.ReadFile("testdata/btn_torrents_browse.json")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(jsonPayload)
@@ -57,7 +57,7 @@ func TestAPI(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "test_user",
+			name: "test_api",
 			fields: fields{
 				Url:    ts.URL,
 				APIKey: key,

--- a/pkg/btn/client.go
+++ b/pkg/btn/client.go
@@ -40,6 +40,12 @@ func WithHTTPClient(httpClient *http.Client) OptFunc {
 	}
 }
 
+func WithLog(log *log.Logger) OptFunc {
+	return func(c *Client) {
+		c.Log = log
+	}
+}
+
 type Client struct {
 	httpClient  *http.Client
 	rpcClient   jsonrpc.Client
@@ -59,6 +65,7 @@ func NewClient(apiKey string, opts ...OptFunc) *Client {
 			Timeout:   time.Second * 60,
 			Transport: sharedhttp.Transport,
 		},
+		Log: log.New(io.Discard, "", log.LstdFlags),
 	}
 
 	for _, opt := range opts {
@@ -71,10 +78,6 @@ func NewClient(apiKey string, opts ...OptFunc) *Client {
 		},
 		HTTPClient: c.httpClient,
 	})
-
-	if c.Log == nil {
-		c.Log = log.New(io.Discard, "", log.LstdFlags)
-	}
 
 	return c
 }

--- a/pkg/btn/testdata/btn_torrents_browse.json
+++ b/pkg/btn/testdata/btn_torrents_browse.json
@@ -1,0 +1,35 @@
+{
+  "id": 1,
+  "result": {
+    "results": "1555080",
+    "torrents": {
+      "1555073": {
+        "GroupName": "S05E04",
+        "GroupID": "755034",
+        "TorrentID": "1555073",
+        "SeriesID": "70834",
+        "Series": "That Show",
+        "SeriesBanner": "\/\/cdn2.broadcasthe.net\/tvdb\/banners\/graphical\/0000000000000.jpg",
+        "SeriesPoster": "\/\/cdn2.broadcasthe.net\/tvdb\/banners\/posters\/0000000000000\/resized_w300.jpg",
+        "YoutubeTrailer": "",
+        "Category": "Episode",
+        "Snatched": "4",
+        "Seeders": "5",
+        "Leechers": "41",
+        "Source": "WEB-DL",
+        "Container": "MP4",
+        "Codec": "H.264",
+        "Resolution": "1080p",
+        "Origin": "None",
+        "ReleaseName": "That.Show.S05E04.1080p.WEB-DL.H.264-NOGRP",
+        "Size": "3288852849",
+        "Time": "1641153886",
+        "TvdbID": "332747",
+        "TvrageID": "0",
+        "ImdbID": "7252812",
+        "InfoHash": "56CD94119F6BF7FC294A92D7A4099C3D1815C907",
+        "DownloadURL": "https:\/\/broadcasthe.net\/torrents.php?action=download&id=1555073&authkey=REDACTED&torrent_pass=REDACTED"
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Reported on Discord that slow indexer API (BTN) tests did not finish in time.

#### What's this PR do?

##### Change

* Indexer API HTTP timeout to 60s
* Change BTN Test from user profile to torrents browse method because user profile is super slow and torrents browse is likely cached

#### How should this be manually tested?

* Test with BTN