### PR TITLE
fix(releases): add missing valid status for Delete

### DIFF
--- a/internal/http/release.go
+++ b/internal/http/release.go
@@ -236,6 +236,7 @@ func (h releaseHandler) deleteReleases(w http.ResponseWriter, r *http.Request) {
 		"PUSH_APPROVED": true,
 		"PUSH_REJECTED": true,
 		"PUSH_ERROR":    true,
+		"PENDING":       true,
 	}
 	var filteredStatuses []string
 	for _, status := range releaseStatuses {


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Reported on Discord

#### What's this PR do?

##### Add

* `PENDING` as valid status for deleting releases

#### How should this be manually tested?

* Settings -> Releases -> Delete, select all or pending and run it