### PR TITLE
fix(notifications): Test uses redacted credentials

### DIFF
--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -321,6 +321,24 @@ func (s *Service) Send(event domain.NotificationEvent, payload domain.Notificati
 }
 
 func (s *Service) Test(ctx context.Context, notification *domain.Notification) error {
+	if notification.ID > 0 {
+		existing, err := s.repo.FindByID(ctx, notification.ID)
+		if err != nil {
+			s.log.Error().Err(err).Msgf("could not find notification by id: %v", notification.ID)
+			return err
+		}
+
+		if domain.IsRedactedString(notification.Password) {
+			notification.Password = existing.Password
+		}
+		if domain.IsRedactedString(notification.Token) {
+			notification.Token = existing.Token
+		}
+		if domain.IsRedactedString(notification.APIKey) {
+			notification.APIKey = existing.APIKey
+		}
+	}
+
 	var agent domain.NotificationSender
 
 	// send test events


### PR DESCRIPTION
#### What is the relevant ticket/issue

Fixes #2284
Fixes #2289 

#### What's this PR do?

##### Add

* Check for existing notification in the Test method to grab un-redacted credentials

#### Where should the reviewer start?

* internal/notification/service.go

#### How should this be manually tested?

1. Create a new notification with some events, hit save
2. Click Test button
3. It should succeed
