### PR TITLE
fix(actions): Deluge always set `AddPaused` to override client

### DIFF
--- a/internal/action/deluge.go
+++ b/internal/action/deluge.go
@@ -328,9 +328,9 @@ func (s *service) prepareDelugeOptions(action *domain.Action) (deluge.Options, e
 	// set options
 	options := deluge.Options{}
 
-	if action.Paused {
-		options.AddPaused = &action.Paused
-	}
+	// always set; to override client default
+	options.AddPaused = &action.Paused
+
 	if action.SavePath != "" {
 		options.DownloadLocation = &action.SavePath
 	}


### PR DESCRIPTION
Leaving AddPaused unset when we want the torrent to not be paused just falls back to the default client settings; which might be to add it as paused

#### What is the relevant ticket/issue

* [issue #2309](https://github.com/autobrr/autobrr/issues/2309)

#### What's this PR do?

##### Change

* Specify the deluge option AddPaused=false when action.Paused=false.

#### Where should the reviewer start?

* It's a very small change.

#### How should this be manually tested?

* Replication steps in the linked issue.

#### Risk involved?

* Very low; unless `action.Paused` isn't always a bool.
* There is minor risk that this would be insufficient to fix the issue; I can try to test.

#### Does the documentation or dependencies need an update?

* No
