### PR TITLE
feat(irc): add HTTP proxy support

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -242,10 +242,12 @@ func (h *Handler) Run() (err error) {
 
 			var proxyDialer proxy.Dialer
 
-			if proxyUrl.Scheme == "http" || proxyUrl.Scheme == "https" {
+			switch proxyUrl.Scheme {
+			case "http", "https":
 				h.log.Debug().Msgf("Using HTTP CONNECT proxy: %s for IRC server %s:%d", proxyUrl.Host, h.network.Server, h.network.Port)
-				proxyDialer = newHTTPProxyDialer(proxyUrl, proxy.Direct)
-			} else {
+				proxyDialer = newHTTPProxyDialer(proxyUrl, proxy.Direct, h.network.TLSSkipVerify)
+
+			default:
 				h.log.Debug().Msgf("Using %s proxy: %s", proxyUrl.Scheme, proxyUrl.Host)
 				proxyDialer, err = proxy.FromURL(proxyUrl, proxy.Direct)
 				if err != nil {

--- a/internal/irc/httpproxy.go
+++ b/internal/irc/httpproxy.go
@@ -20,8 +20,9 @@ import (
 
 // httpProxyDialer implements proxy.ContextDialer for HTTP CONNECT proxies
 type httpProxyDialer struct {
-	proxyURL *url.URL
-	forward  proxy.Dialer
+	proxyURL      *url.URL
+	forward       proxy.Dialer
+	tlsSkipVerify bool
 }
 
 // bufferedConn wraps a net.Conn with a buffered reader to preserve any
@@ -36,10 +37,11 @@ func (c *bufferedConn) Read(b []byte) (int, error) {
 }
 
 // newHTTPProxyDialer creates a new HTTP CONNECT proxy dialer
-func newHTTPProxyDialer(proxyURL *url.URL, forward proxy.Dialer) *httpProxyDialer {
+func newHTTPProxyDialer(proxyURL *url.URL, forward proxy.Dialer, tlsSkipVerify bool) *httpProxyDialer {
 	return &httpProxyDialer{
-		proxyURL: proxyURL,
-		forward:  forward,
+		proxyURL:      proxyURL,
+		forward:       forward,
+		tlsSkipVerify: tlsSkipVerify,
 	}
 }
 
@@ -68,7 +70,7 @@ func (d *httpProxyDialer) DialContext(ctx context.Context, network, addr string)
 	if d.proxyURL.Scheme == "https" {
 		tlsConfig := &tls.Config{
 			ServerName:         d.proxyURL.Hostname(),
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: d.tlsSkipVerify,
 		}
 		proxyConn = tls.Client(proxyConn, tlsConfig)
 	}


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Closes #2311

#### What's this PR do?

##### Add

* Add HTTP proxy support for IRC networks

#### Where should the reviewer start?

* `internal/irc/handler.go`

#### How should this be manually tested?

* Setup a HTTP proxy then edit an IRC network to use it. Save and make sure it connects.

#### Risk involved?

* Low

#### Does the documentation or dependencies need an update?

* No
