### PR TITLE
fix(logs): sanitize torrentData from actions and webhooks

### DIFF
--- a/internal/logger/sanitize.go
+++ b/internal/logger/sanitize.go
@@ -23,6 +23,10 @@ var (
 			repl:    "${1}REDACTED${3}",
 		},
 		{
+			pattern: regexp.MustCompile(`(\\"torrentData\\":\s?\\")(.+?)(\\"|")`),
+			repl:    "${1}REDACTED${3}",
+		},
+		{
 			pattern: regexp.MustCompile(`(torrent_pass|passkey|authkey|auth|secret_key|api|apikey)=([a-zA-Z0-9]+)`),
 			repl:    "${1}=REDACTED",
 		},
@@ -98,9 +102,9 @@ func SanitizeLogFile(filePath string, output io.Writer) error {
 			strings.Contains(line, `"module":"action"`)
 
 		for i := 0; i < len(regexReplacements); i++ {
-			// Apply the first three patterns only if the line contains "module":"feed",
+			// Apply the first patterns only if the line contains "module":"feed",
 			// "module":"filter", "repo":"release", or "module":"action"
-			if i < 4 {
+			if i < 5 {
 				if bFilter {
 					line = regexReplacements[i].pattern.ReplaceAllString(line, regexReplacements[i].repl)
 				}

--- a/internal/logger/sanitize_test.go
+++ b/internal/logger/sanitize_test.go
@@ -150,6 +150,11 @@ func TestSanitizeLogFile(t *testing.T) {
 			expected: "\"module\":\"action\" ExternalWebhookHost:REDACTED ExternalWebhookData:",
 		},
 		{
+			name:     "torrentData_json_escaped",
+			input:    "\"module\":\"action\" data: {\\n  \\\"torrentData\\\": \\\"m1lL2Nzpjb21tZW50NzY6vdG9ycmMzU3NWE0NmU3ODU3NzJmNjZmZjBkYzQ4MWVmOTQ3NWFhYmE3NWUzZTQyZWE0NjNkODllYj5+/ny\\\"}",
+			expected: "\"module\":\"action\" data: {\\n  \\\"torrentData\\\": \\\"REDACTED\\\"}",
+		},
+		{
 			input:    "\"module\":\"filter\" \\\"id\\\": 3855,\\n  \\\"apikey\\\": \\\"ad789a9s8d.asdpoiasdpojads09sad809\\\",\\n  \\\"minratio\\\": 10.0\\n",
 			expected: "\"module\":\"filter\" \\\"id\\\": 3855,\\n  \\\"apikey\\\": \\\"REDACTED\\\",\\n  \\\"minratio\\\": 10.0\\n",
 		},


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Reported on Discord

#### What's this PR do?

##### Add

* Add patterns to detect torrentData in http payloads for actions and webhooks

#### Where should the reviewer start?

* `internal/logger/sanitize.go`

#### How should this be manually tested?

1. Setup action or external filter with json payload that contains `torrentData`
2. Let it run
3. Download logs from logs page
4. `torrentData` should now show `REDACTED`

#### Risk involved?

* Low
