### PR TITLE
feat(webb): use URL for filtering on Releases page

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -240,7 +240,7 @@ func (repo *ReleaseRepo) findReleases(ctx context.Context, tx *Tx, params domain
 	}
 
 	if params.Filters.Indexers != nil {
-		filter := sq.And{}
+		filter := sq.Or{}
 		for _, v := range params.Filters.Indexers {
 			filter = append(filter, sq.Eq{"r.indexer": v})
 		}

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -472,13 +472,13 @@ export const APIClient = {
         if (!filter.value)
           return;
 
-        if (filter.id == "indexer.identifier") {
+        if (filter.id == "indexer.identifier" || filter.id == "indexer_identifier") {
           if (typeof filter.value === "string") {
             params["indexer"].push(filter.value);
-          }
-        } else if (filter.id == "indexer_identifier") {
-          if (typeof filter.value === "string") {
-            params["indexer"].push(filter.value);
+          } else if (Array.isArray(filter.value)) {
+            for (const v of filter.value) {
+              if (typeof v === "string") params["indexer"].push(v);
+            }
           }
         } else if (filter.id === "action_status") {
           if (typeof filter.value === "string") {

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -149,13 +149,11 @@ export const ReleasesRoute = createRoute({
   path: 'releases',
   component: Releases,
   validateSearch: (search) => z.object({
-    offset: z.number().optional(),
-    limit: z.number().optional(),
-    filter: z.string().optional(),
+    page: z.number().optional(),
+    pageSize: z.number().optional(),
     q: z.string().optional(),
     action_status: z.enum(['PUSH_APPROVED', 'PUSH_REJECTED', 'PENDING', 'PUSH_ERROR', '']).optional(),
-    // filters: z.array().catch(''),
-    // sort: z.enum(['newest', 'oldest', 'price']).catch('newest'),
+    indexer: z.string().optional(),
   }).parse(search),
 });
 

--- a/web/src/screens/releases/ReleaseFilters.tsx
+++ b/web/src/screens/releases/ReleaseFilters.tsx
@@ -66,21 +66,63 @@ const ListboxFilter = ({
 export const IndexerSelectColumnFilter = ({ column }: { column: Column<Release, unknown> }) => {
   const { data, isSuccess } = useQuery(ReleasesIndexersQueryOptions());
 
-  // Assign indexer name based on the filterValue (indexer.identifier)
-  const currentIndexerName = data?.find(indexer => indexer.identifier === column.getFilterValue())?.name ?? "Indexer";
+  const selectedValues = (column.getFilterValue() as string[] | undefined) ?? [];
+
+  let label = "Indexer";
+  if (selectedValues.length === 1) {
+    label = data?.find(i => i.identifier === selectedValues[0])?.name ?? selectedValues[0];
+  } else if (selectedValues.length > 1) {
+    label = `${selectedValues.length} indexers`;
+  }
 
   return (
-    <ListboxFilter
-      id={column.id}
-      key={column.id}
-      label={currentIndexerName}
-      currentValue={column.getFilterValue() as string || ""}
-      onChange={newValue => column.setFilterValue(newValue || undefined)}
-    >
-      {isSuccess && data && data?.map((indexer, idx) => (
-        <FilterOption key={idx} label={indexer.name} value={indexer.identifier} />
-      ))}
-    </ListboxFilter>
+    <div className="w-48">
+      <Listbox
+        value={selectedValues}
+        onChange={(newValues: string[]) => {
+          column.setFilterValue(newValues.length > 0 ? newValues : undefined);
+        }}
+        multiple
+      >
+        <div className="relative mt-1">
+          <ListboxButton className="relative w-full py-2 pl-3 pr-10 text-left bg-white dark:bg-gray-800 rounded-lg shadow-md cursor-pointer dark:text-gray-400 sm:text-sm">
+            <span className="block truncate">{label}</span>
+            <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+              <ChevronDownIcon
+                className="w-5 h-5 ml-2 -mr-1 text-gray-600 hover:text-gray-600"
+                aria-hidden="true"
+              />
+            </span>
+          </ListboxButton>
+          <Transition
+            as={React.Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <ListboxOptions
+              className="absolute z-10 w-full mt-1 overflow-auto text-base bg-white dark:bg-gray-800 rounded-md shadow-lg max-h-60 border border-black/5 dark:border-gray-700/40 focus:outline-hidden sm:text-sm"
+            >
+              {selectedValues.length > 0 && (
+                <button
+                  type="button"
+                  className="w-full cursor-pointer select-none relative py-2 pl-10 pr-4 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-900 text-left text-sm"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    column.setFilterValue(undefined);
+                  }}
+                >
+                  Clear selection
+                </button>
+              )}
+              {isSuccess && data?.map((indexer, idx) => (
+                <FilterOption key={idx} label={indexer.name} value={indexer.identifier} />
+              ))}
+            </ListboxOptions>
+          </Transition>
+        </div>
+      </Listbox>
+    </div>
   );
 };
 


### PR DESCRIPTION
#### What is the relevant ticket/issue

* https://github.com/autobrr/autobrr/discussions/2279

#### What's this PR do?

##### Add

* Use URL params to store filter state on the Releases page
* Multi select for Indexer filter

#### Where should the reviewer start?

* `web/src/routes.tsx`

#### How should this be manually tested?

* Go to the Releases page, select a filter and watch the URL update
* Copy url from before and refresh page or open a new tab and same filter should persist

#### Risk involved?

* Low

#### Screenshots (if appropriate)

<img width="1279" height="1186" alt="image" src="https://github.com/user-attachments/assets/08be8cee-283f-4728-b215-7684e18b2990" />

#### Does the documentation or dependencies need an update?

* No
