### PR TITLE
feat(downloadclients): Sonarr and Radarr send indexer flags

### DIFF
--- a/internal/action/radarr.go
+++ b/internal/action/radarr.go
@@ -27,9 +27,12 @@ func (s *service) radarr(ctx context.Context, action *domain.Action, release dom
 		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)
 	}
 
-	arr := client.Client.(*radarr.Client)
+	arr, ok := client.Client.(*radarr.Client)
+	if !ok {
+		return nil, errors.New("invalid client type")
+	}
 
-	r := radarr.Release{
+	r := radarr.ReleasePushRequest{
 		Title:            release.TorrentName,
 		InfoUrl:          release.InfoURL,
 		DownloadUrl:      release.DownloadURL,
@@ -50,6 +53,12 @@ func (s *service) radarr(ctx context.Context, action *domain.Action, release dom
 	if action.ExternalDownloadClient != "" {
 		r.DownloadClient = action.ExternalDownloadClient
 	}
+
+	indexerFlags := radarr.BuildIndexerFlags(radarr.ReleaseMeta{
+		FreeleechPercent: release.FreeleechPercent,
+		Origin:           release.Origin,
+	})
+	r.IndexerFlags = int(indexerFlags)
 
 	rejections, err := arr.Push(ctx, r)
 	if err != nil {

--- a/pkg/arr/radarr/radarr.go
+++ b/pkg/arr/radarr/radarr.go
@@ -35,7 +35,7 @@ type Config struct {
 
 type ClientInterface interface {
 	Test(ctx context.Context) (*SystemStatusResponse, error)
-	Push(ctx context.Context, release Release) ([]string, error)
+	Push(ctx context.Context, release ReleasePushRequest) ([]string, error)
 }
 
 type Client struct {
@@ -89,7 +89,7 @@ func (c *Client) Test(ctx context.Context) (*SystemStatusResponse, error) {
 	return &response, nil
 }
 
-func (c *Client) Push(ctx context.Context, release Release) ([]string, error) {
+func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string, error) {
 	status, res, err := c.postBody(ctx, "release/push", release)
 	if err != nil {
 		return nil, errors.Wrap(err, "error push release")
@@ -111,7 +111,7 @@ func (c *Client) Push(ctx context.Context, release Release) ([]string, error) {
 		return rejections, nil
 	}
 
-	pushResponse := make([]PushResponse, 0)
+	pushResponse := make([]ReleasePushResponse, 0)
 	if err = json.Unmarshal(res, &pushResponse); err != nil {
 		return nil, errors.Wrap(err, "could not unmarshal data")
 	}

--- a/pkg/arr/radarr/radarr_test.go
+++ b/pkg/arr/radarr/radarr_test.go
@@ -64,7 +64,7 @@ func Test_client_Push(t *testing.T) {
 		config Config
 	}
 	type args struct {
-		release Release
+		release ReleasePushRequest
 	}
 	tests := []struct {
 		name       string
@@ -85,7 +85,7 @@ func Test_client_Push(t *testing.T) {
 					Password:  "",
 				},
 			},
-			args: args{release: Release{
+			args: args{release: ReleasePushRequest{
 				Title:            "Some.Old.Movie.1996.Remastered.1080p.BluRay.REMUX.AVC.MULTI.TrueHD.Atmos.7.1-NOGROUP",
 				DownloadUrl:      "https://www.test.org/rss/download/0000001/00000000000000000000/Some.Old.Movie.1996.Remastered.1080p.BluRay.REMUX.AVC.MULTI.TrueHD.Atmos.7.1-NOGROUP.torrent",
 				Size:             0,
@@ -107,7 +107,7 @@ func Test_client_Push(t *testing.T) {
 					Password:  "",
 				},
 			},
-			args: args{release: Release{
+			args: args{release: ReleasePushRequest{
 				Title:            "Some.Old.Movie.1996.Remastered.1080p.BluRay.REMUX.AVC.MULTI.TrueHD.Atmos.7.1-NOGROUP",
 				DownloadUrl:      "https://www.test.org/rss/download/0000001/00000000000000000000/Some.Old.Movie.1996.Remastered.1080p.BluRay.REMUX.AVC.MULTI.TrueHD.Atmos.7.1-NOGROUP.torrent",
 				Size:             0,
@@ -129,7 +129,7 @@ func Test_client_Push(t *testing.T) {
 					Password:  "",
 				},
 			},
-			args: args{release: Release{
+			args: args{release: ReleasePushRequest{
 				Title:            "Minx 1 epi 9 2160p",
 				DownloadUrl:      "https://www.test.org/rss/download/0000001/00000000000000000000/Minx.1.epi.9.2160p.torrent",
 				Size:             0,

--- a/pkg/arr/sonarr/sonarr.go
+++ b/pkg/arr/sonarr/sonarr.go
@@ -36,7 +36,7 @@ type Config struct {
 
 type ClientInterface interface {
 	Test(ctx context.Context) (*SystemStatusResponse, error)
-	Push(ctx context.Context, release Release) ([]string, error)
+	Push(ctx context.Context, release ReleasePushRequest) ([]string, error)
 }
 
 type Client struct {
@@ -91,7 +91,7 @@ func (c *Client) Test(ctx context.Context) (*SystemStatusResponse, error) {
 	return &response, nil
 }
 
-func (c *Client) Push(ctx context.Context, release Release) ([]string, error) {
+func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string, error) {
 	status, res, err := c.postBody(ctx, "release/push", release)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not push release to sonarr")
@@ -114,7 +114,7 @@ func (c *Client) Push(ctx context.Context, release Release) ([]string, error) {
 		return rejections, nil
 	}
 
-	pushResponse := make([]PushResponse, 0)
+	pushResponse := make([]ReleasePushResponse, 0)
 	if err = json.Unmarshal(res, &pushResponse); err != nil {
 		return nil, errors.Wrap(err, "could not unmarshal data")
 	}

--- a/pkg/arr/sonarr/sonarr_test.go
+++ b/pkg/arr/sonarr/sonarr_test.go
@@ -51,7 +51,7 @@ func Test_client_Push(t *testing.T) {
 		config Config
 	}
 	type args struct {
-		release Release
+		release ReleasePushRequest
 	}
 	tests := []struct {
 		name       string
@@ -72,7 +72,7 @@ func Test_client_Push(t *testing.T) {
 					Password:  "",
 				},
 			},
-			args: args{release: Release{
+			args: args{release: ReleasePushRequest{
 				Title:            "That Show S01 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-NOGROUP",
 				DownloadUrl:      "https://www.test.org/rss/download/0000001/00000000000000000000/That Show S01 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-NOGROUP.torrent",
 				Size:             0,
@@ -96,7 +96,7 @@ func Test_client_Push(t *testing.T) {
 					Password:  "",
 				},
 			},
-			args: args{release: Release{
+			args: args{release: ReleasePushRequest{
 				Title:            "That Show S01 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-NOGROUP",
 				DownloadUrl:      "https://www.test.org/rss/download/0000001/00000000000000000000/That Show S01 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-NOGROUP.torrent",
 				Size:             0,


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Reported on [Discord](https://discord.com/channels/881212911849209957/1468470500627058850) 

#### What's this PR do?

##### Add

* Set indexerFlags based on freeleech percent and origin for sonarr and radarr

#### Where should the reviewer start?

* `pkg/arr/radarr/types.go`

#### How should this be manually tested?

* Set indexer in arr to require an indexer flag such as Freeleech and setup filters to push releases with and without

#### Risk involved?

* Low

#### Does the documentation or dependencies need an update?

* No
