### PR TITLE
feat(downloadclients): add new host parsing for Transmission

### DIFF
--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/autobrr/autobrr/pkg/errors"
 )
@@ -215,6 +216,9 @@ func (c DownloadClient) BuildLegacyHost() (string, error) {
 	if c.Type == DownloadClientTypeQbittorrent {
 		return c.qbitBuildLegacyHost()
 	}
+	if c.Type == DownloadClientTypeTransmission {
+		return c.transmissionBuildLegacyHost()
+	}
 	return c.Host, nil
 }
 
@@ -253,6 +257,56 @@ func (c DownloadClient) qbitBuildLegacyHost() (string, error) {
 		} else {
 			u.Host = fmt.Sprintf("%v:%v", u.Host, c.Port)
 		}
+	}
+
+	// make into new string and return
+	return u.String(), nil
+}
+
+// transmissionBuildLegacyHost builds the full Transmission RPC URL from host, port, and tls settings
+func (c DownloadClient) transmissionBuildLegacyHost() (string, error) {
+	// parse url
+	u, err := url.Parse(c.Host)
+	if err != nil {
+		return "", err
+	}
+
+	// reset Opaque
+	u.Opaque = ""
+
+	// set scheme
+	scheme := "http"
+	if c.TLS {
+		scheme = "https"
+	}
+	u.Scheme = scheme
+
+	// if host is empty lets use one from settings
+	if u.Host == "" {
+		u.Host = c.Host
+	}
+
+	// reset Path if it's the same as Host (means Host was just a hostname)
+	if u.Host == u.Path {
+		u.Path = ""
+	}
+
+	// handle ports
+	if c.Port > 0 {
+		if c.Port == 80 || c.Port == 443 {
+			// skip for regular http and https
+		} else {
+			u.Host = fmt.Sprintf("%v:%v", u.Host, c.Port)
+		}
+	}
+
+	// Ensure path ends with /rpc
+	if !strings.HasSuffix(u.Path, "/rpc") {
+		path, err := url.JoinPath(u.Path, "/rpc")
+		if err != nil {
+			return "", err
+		}
+		u.Path = path
 	}
 
 	// make into new string and return

--- a/internal/download_client/service.go
+++ b/internal/download_client/service.go
@@ -6,7 +6,6 @@ package download_client
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -322,12 +321,12 @@ func (s *service) GetClient(ctx context.Context, clientId int32) (*domain.Downlo
 		})
 
 	case domain.DownloadClientTypeTransmission:
-		scheme := "http"
-		if client.TLS {
-			scheme = "https"
+		clientHost, err := client.BuildLegacyHost()
+		if err != nil {
+			return nil, errors.Wrap(err, "error building Transmission host url: %v", client.Host)
 		}
 
-		transmissionURL, err := url.Parse(fmt.Sprintf("%s://%s:%d/transmission/rpc", scheme, client.Host, client.Port))
+		transmissionURL, err := url.Parse(clientHost)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not parse transmission url")
 		}

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -304,7 +304,7 @@ function FormFieldsRTorrent() {
 
 function FormFieldsTransmission() {
   const {
-    values: { tls }
+    values: { port, tls }
   } = useFormikContext<InitialValues>();
 
   return (
@@ -313,7 +313,7 @@ function FormFieldsTransmission() {
         required
         name="host"
         label="Host"
-        help="Eg. client.domain.ltd, domain.ltd/client, domain.ltd"
+        help="Eg. http(s)://client.domain.ltd, http(s)://domain.ltd/transmission"
         tooltip={
           <div>
             <p>See guides for how to connect to Transmission for various server types in our docs.</p>
@@ -326,7 +326,13 @@ function FormFieldsTransmission() {
         }
       />
 
-      <NumberFieldWide name="port" label="Port" help="Port for Transmission" />
+      {port > 0 && (
+        <NumberFieldWide
+          name="port"
+          label="Port"
+          help="Port for Transmission"
+        />
+      )}
 
       <SwitchGroupWide name="tls" label="TLS" />
 
@@ -356,12 +362,12 @@ function FormFieldsSabnzbd() {
         help="Eg. http://ip:port or https://url.com/sabnzbd"
         tooltip={
           <div>
-            <p>See our guides on how to connect to qBittorrent for various server types in our docs.</p>
+            <p>See our guides on how to connect to SABnzbd for various server types in our docs.</p>
             <br />
             <p>Dedicated servers:</p>
-            <ExternalLink href="https://autobrr.com/configuration/download-clients/dedicated#qbittorrent" />
+            <ExternalLink href="https://autobrr.com/configuration/download-clients/dedicated#sabnzbd" />
             <p>Shared seedbox providers:</p>
-            <ExternalLink href="https://autobrr.com/configuration/download-clients/shared-seedboxes#qbittorrent" />
+            <ExternalLink href="https://autobrr.com/configuration/download-clients/shared-seedboxes#sabnzbd" />
           </div>
         }
       />
@@ -861,7 +867,7 @@ export function DownloadClientAddForm({ isOpen, toggle }: AddFormProps) {
   );
 }
 
-export function DownloadClientUpdateForm({ isOpen, toggle, data: client}: UpdateFormProps<DownloadClient>) {
+export function DownloadClientUpdateForm({ isOpen, toggle, data: client }: UpdateFormProps<DownloadClient>) {
   const [isTesting, setIsTesting] = useState(false);
   const [isSuccessfulTest, setIsSuccessfulTest] = useState(false);
   const [isErrorTest, setIsErrorTest] = useState(false);


### PR DESCRIPTION
#### What is the relevant ticket/issue

No ticket open, but I noticed that autobrr was unable to communicate if transmission was behind a subpath.

#### What's this PR do?

##### Add

* New parsing method for Transmission host, similar to QBit.

##### Change

* UI to hide Port by default

#### Where should the reviewer start?

* This is a generally small change, but I do wonder if we should completely remove the TLS and port fields in the UI?

#### How should this be manually tested?

* Apply patch on existing and new installation, and test that transmission via a subpath works as expected

#### Risk involved?

* Existing installations will need to update host to point to /transmission

#### Screenshots (if appropriate)

* Later.

#### Does the documentation or dependencies need an update?

* No