### PR TITLE
fix(feeds): Test errors after save

### DIFF
--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -271,6 +271,21 @@ func (s *service) test(ctx context.Context, feed *domain.Feed) error {
 		}
 	}
 
+	if feed.ID > 0 {
+		existingFeed, err := s.repo.FindOne(ctx, domain.FindOneParams{FeedID: feed.ID})
+		if err != nil {
+			s.log.Error().Err(err).Msg("could not find feed")
+			return err
+		}
+
+		if domain.IsRedactedString(feed.ApiKey) {
+			feed.ApiKey = existingFeed.ApiKey
+		}
+		if domain.IsRedactedString(feed.Cookie) {
+			feed.Cookie = existingFeed.Cookie
+		}
+	}
+
 	// test feeds
 	switch feed.Type {
 	case string(domain.FeedTypeTorznab):


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Reported on Discord

#### What's this PR do?

After a Feed has been saved and a user clicks Test it uses the literal `<redacted>` value as API key.

##### Add

* Check for existing ID, then check if it's a redacted value, if yes set api key and cookie

#### Where should the reviewer start?

* First file

#### How should this be manually tested?

* Create a Feed, click Test it should work, then open with edit and click test button again and it should work

#### Risk involved?

* Low

#### Does the documentation or dependencies need an update?

* No
