### PR TITLE
feat(feeds): Torznab use Enclosure link if available

### DIFF
--- a/internal/feed/torznab.go
+++ b/internal/feed/torznab.go
@@ -146,6 +146,12 @@ func (j *TorznabJob) processItems(items []torznab.FeedItem) ([]*domain.Release, 
 			rls.DownloadURL = ""
 		}
 
+		if item.Enclosure != nil {
+			if item.Enclosure.Type == "application/x-bittorrent" {
+				rls.DownloadURL = item.Enclosure.URL
+			}
+		}
+
 		rls.ParseString(item.Title)
 		rls.Size = uint64(item.Size)
 		rls.Seeders = item.Seeders

--- a/pkg/torznab/feed.go
+++ b/pkg/torznab/feed.go
@@ -43,16 +43,29 @@ type ProwlarrIndexer struct {
 	ID   string `xml:"id,attr"`
 }
 
+type JackettIndexer struct {
+	Text string `xml:",chardata"`
+	ID   string `xml:"id,attr"`
+}
+
 type Attributes []ItemAttr
+
+type Enclosure struct {
+	URL    string `xml:"url,attr"`
+	Length string `xml:"length,attr"`
+	Type   string `xml:"type,attr"`
+}
 
 type FeedItem struct {
 	Title           string           `xml:"title,omitempty"`
 	GUID            string           `xml:"guid,omitempty"`
 	PubDate         Time             `xml:"pubDate,omitempty"`
-	Prowlarrindexer *ProwlarrIndexer `xml:"prowlarrindexer,omitempty"` // TODO handle jackett variant
+	ProwlarrIndexer *ProwlarrIndexer `xml:"prowlarrindexer,omitempty"`
+	JackettIndexer  *JackettIndexer  `xml:"jackettindexer,omitempty"`
 	Comments        string           `xml:"comments"`
 	Size            int64            `xml:"size"`
 	Link            string           `xml:"link"`
+	Enclosure       *Enclosure       `xml:"enclosure,omitempty"`
 	Category        []int            `xml:"category,omitempty"`
 	Categories      Categories
 	Files           int


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Closes https://github.com/autobrr/autobrr/discussions/2373

#### What's this PR do?

##### Change

* Check if Enclosure exists on Torznab result and use that as download url


#### Where should the reviewer start?

* `pkg/torznab/feed.go`

#### How should this be manually tested?

* Setup a Torznab feed and have it fetch items

#### Risk involved?

* Low

#### Does the documentation or dependencies need an update?

* No
