### PR TITLE
feat(indexers): add VietMediaF

### DIFF
--- a/internal/indexer/definitions/vietmediaf.yaml
+++ b/internal/indexer/definitions/vietmediaf.yaml
@@ -77,7 +77,7 @@ irc:
             uploader: Bitcy
             baseUrl: "https://tracker.vietmediaf.store/"
             torrentId: "456"
-        pattern: 'Category \[(.+)\] Type \[(.+)\] Name \[(.+?)\] ?(?:Resolution \[(.*)\] )?Freeleech \[(.+)\] Internal \[(.+)\] Double Upload \[(.+)\] Size \[(.+)\] Uploader \[(.+)\] Url \[(https?\:\/\/.+\/).+\/(.+)\]'
+        pattern: 'Category \[(.+)\] Type \[(.+)\] Name \[(.+?)\] ?(?:Resolution \[(.*)\] )?Freeleech \[(.+)\] Internal \[(.+)\] Double Upload \[(.+)\] Size \[(.+)\] Uploader \[(.+)\] Url \[(https?\:\/\/.+\/).+\/download\/(.+)\]'
         vars:
           - category
           - releaseTags


### PR DESCRIPTION
#### What is the relevant ticket/issue

N/A - New indexer definition contribution

#### What's this PR do?

##### Add

Add indexer definition for VietMediaF, a Vietnamese private tracker powered by UNIT3D.

IRC announce parsing on Libera.Chat (#vietmediaf channel)
RSS support via RSS key (RID)
Two parse test cases included (Movie and Music categories)
Supports fields: category, releaseTags, torrentName, resolution, freeleechPercent, internal, tags (double upload), torrentSize, uploader

##### Change

*

##### Remove

*

#### Where should the reviewer start?

internal/indexer/definitions/vietmediaf.yaml
 — this is the only file in this PR.

#### How should this be manually tested?

Add VietMediaF as an indexer in autobrr settings
Configure the RSS key and IRC credentials
Verify IRC announce parsing matches the expected pattern with the included test cases
Verify torrent download URL is correctly constructed as /torrent/download/{torrentId}.{rsskey}

#### Risk involved?

Minimal — this is a new indexer definition file only. No existing code is modified.

#### Screenshots (if appropriate)

*

#### Does the documentation or dependencies need an update?

No
