### PR TITLE
fix(database): use stable timestamp for release tests

### DIFF
--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -954,7 +954,7 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockReleaseActionStatus.ActionID = int64(mockAction.ID)
 			mockReleaseActionStatus.FilterID = int64(mockFilter.ID)
 			mockReleaseActionStatus.ReleaseID = mockRelease.ID
-			mockReleaseActionStatus.Timestamp = mockReleaseActionStatus.Timestamp.AddDate(0, -1, 0)
+			mockReleaseActionStatus.Timestamp = mockReleaseActionStatus.Timestamp.Add(-35 * 24 * time.Hour) // use Add instead of AddDate(0, -1, 0) to not cause issues where previous month is shorter than current month.
 
 			err = releaseRepo.StoreReleaseActionStatus(t.Context(), mockReleaseActionStatus)
 			assert.NoError(t, err)
@@ -963,7 +963,7 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockReleaseActionStatus2.ActionID = int64(mockAction2.ID)
 			mockReleaseActionStatus2.FilterID = int64(mockFilter.ID)
 			mockReleaseActionStatus2.ReleaseID = mockRelease.ID
-			mockReleaseActionStatus2.Timestamp = mockReleaseActionStatus2.Timestamp.AddDate(0, -1, 0)
+			mockReleaseActionStatus2.Timestamp = mockReleaseActionStatus2.Timestamp.Add(-35 * 24 * time.Hour) // use Add instead of AddDate(0, -1, 0) to not cause issues where previous month is shorter than current month.
 
 			err = releaseRepo.StoreReleaseActionStatus(t.Context(), mockReleaseActionStatus2)
 			assert.NoError(t, err)


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Found during tests of #2401

#### What's this PR do?

##### Change

* Use stable timestamp (fixed value at 35 days, longer than a month) to not run into issues with `.AddDate` where -1 month behaves weird when the previous month has less days than the current one, like -1 (February) during March 29-31 etc.

#### Where should the reviewer start?

* `internal/database/filter_test.go`

#### How should this be manually tested?

* Automated tests

#### Risk involved?

* None
