### PR TITLE
fix(web): indexer proxy button overflow

### DIFF
--- a/web/src/screens/settings/Indexer.tsx
+++ b/web/src/screens/settings/Indexer.tsx
@@ -143,15 +143,15 @@ const ListItem = ({ indexer }: ListItemProps) => {
         <div className="col-span-2 sm:col-span-1 flex pl-1 sm:pl-5 items-center">
           <Checkbox value={indexer.enabled ?? false} setValue={onToggleMutation} />
         </div>
-        <div className="col-span-7 pl-12 sm:pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">
+        <div className="col-span-7 pl-6 sm:pl-12 sm:pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">
           {indexer.name}
         </div>
         <div className="hidden md:block col-span-2 pr-6 py-3 text-left items-center whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 truncate">
           {ImplementationBadges[indexer.implementation]}
         </div>
-        <div className="col-span-2 flex first-letter:px-6 py-3 whitespace-nowrap justify-end text-sm font-medium">
+        <div className="col-span-3 sm:col-span-2 flex first-letter:px-6 py-3 whitespace-nowrap justify-end text-sm font-medium">
           <span
-            className="col-span-2 px-6 text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
+            className="col-span-3 sm:col-span-2 px-6 text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
             onClick={toggleUpdate}
           >
             {t("listScreens.common.edit")}
@@ -212,7 +212,7 @@ function IndexerSettings() {
                 {t("listScreens.common.enabled")} <span className="sort-indicator">{sortedIndexers.getSortIndicator("enabled")}</span>
               </div>
               <div
-                className="col-span-7 pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-250 transition-colors uppercase tracking-wider cursor-pointer"
+                className="col-span-7 pl-6 sm:pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-250 transition-colors uppercase tracking-wider cursor-pointer"
                 onClick={() => sortedIndexers.requestSort("name")}
               >
                 {t("listScreens.common.name")} <span className="sort-indicator">{sortedIndexers.getSortIndicator("name")}</span>

--- a/web/src/screens/settings/Indexer.tsx
+++ b/web/src/screens/settings/Indexer.tsx
@@ -143,15 +143,15 @@ const ListItem = ({ indexer }: ListItemProps) => {
         <div className="col-span-2 sm:col-span-1 flex pl-1 sm:pl-5 items-center">
           <Checkbox value={indexer.enabled ?? false} setValue={onToggleMutation} />
         </div>
-        <div className="col-span-7 sm:col-span-8 pl-12 sm:pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">
+        <div className="col-span-7 pl-12 sm:pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">
           {indexer.name}
         </div>
         <div className="hidden md:block col-span-2 pr-6 py-3 text-left items-center whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 truncate">
           {ImplementationBadges[indexer.implementation]}
         </div>
-        <div className="col-span-1 flex first-letter:px-6 py-3 whitespace-nowrap text-right text-sm font-medium">
+        <div className="col-span-2 flex first-letter:px-6 py-3 whitespace-nowrap justify-end text-sm font-medium">
           <span
-            className="col-span-1 px-6 text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
+            className="col-span-2 px-6 text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
             onClick={toggleUpdate}
           >
             {t("listScreens.common.edit")}
@@ -212,7 +212,7 @@ function IndexerSettings() {
                 {t("listScreens.common.enabled")} <span className="sort-indicator">{sortedIndexers.getSortIndicator("enabled")}</span>
               </div>
               <div
-                className="col-span-7 sm:col-span-8 pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-250 transition-colors uppercase tracking-wider cursor-pointer"
+                className="col-span-7 pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-250 transition-colors uppercase tracking-wider cursor-pointer"
                 onClick={() => sortedIndexers.requestSort("name")}
               >
                 {t("listScreens.common.name")} <span className="sort-indicator">{sortedIndexers.getSortIndicator("name")}</span>

--- a/web/src/screens/settings/Proxy.tsx
+++ b/web/src/screens/settings/Proxy.tsx
@@ -66,15 +66,15 @@ function ListItem({ proxy }: ListItemProps) {
         <div className="col-span-2 sm:col-span-1 flex pl-1 sm:pl-5 items-center">
           <Checkbox value={proxy.enabled ?? false} setValue={onToggleMutation} />
         </div>
-        <div className="col-span-7 pl-12 sm:pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">
+        <div className="col-span-7 pl-6 sm:pl-12 sm:pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">
           {proxy.name}
         </div>
         <div className="hidden md:block col-span-2 pr-6 py-3 text-left items-center whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 truncate">
           {proxy.type}
         </div>
-        <div className="col-span-2 flex first-letter:px-6 py-3 whitespace-nowrap justify-end text-sm font-medium">
+        <div className="col-span-3 sm:col-span-2 flex first-letter:px-6 py-3 whitespace-nowrap justify-end text-sm font-medium">
           <span
-            className="col-span-2 px-6 text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
+            className="col-span-3 sm:col-span-2 px-6 text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
             onClick={toggleUpdate}
           >
             {t("listScreens.common.edit")}
@@ -121,7 +121,7 @@ function ProxySettings() {
                 {/*<span className="sort-indicator">{sortedIndexers.getSortIndicator("enabled")}</span>*/}
               </div>
               <div
-                className="col-span-7 pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-250 transition-colors uppercase tracking-wider cursor-pointer"
+                className="col-span-7 pl-6 sm:pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-250 transition-colors uppercase tracking-wider cursor-pointer"
                 // onClick={() => sortedIndexers.requestSort("name")}
               >
                 {t("listScreens.common.name")}

--- a/web/src/screens/settings/Proxy.tsx
+++ b/web/src/screens/settings/Proxy.tsx
@@ -66,15 +66,15 @@ function ListItem({ proxy }: ListItemProps) {
         <div className="col-span-2 sm:col-span-1 flex pl-1 sm:pl-5 items-center">
           <Checkbox value={proxy.enabled ?? false} setValue={onToggleMutation} />
         </div>
-        <div className="col-span-7 sm:col-span-8 pl-12 sm:pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">
+        <div className="col-span-7 pl-12 sm:pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate">
           {proxy.name}
         </div>
         <div className="hidden md:block col-span-2 pr-6 py-3 text-left items-center whitespace-nowrap text-sm text-gray-500 dark:text-gray-400 truncate">
           {proxy.type}
         </div>
-        <div className="col-span-1 flex first-letter:px-6 py-3 whitespace-nowrap text-right text-sm font-medium">
+        <div className="col-span-2 flex first-letter:px-6 py-3 whitespace-nowrap justify-end text-sm font-medium">
           <span
-            className="col-span-1 px-6 text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
+            className="col-span-2 px-6 text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
             onClick={toggleUpdate}
           >
             {t("listScreens.common.edit")}
@@ -121,7 +121,7 @@ function ProxySettings() {
                 {/*<span className="sort-indicator">{sortedIndexers.getSortIndicator("enabled")}</span>*/}
               </div>
               <div
-                className="col-span-7 sm:col-span-8 pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-250 transition-colors uppercase tracking-wider cursor-pointer"
+                className="col-span-7 pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-250 transition-colors uppercase tracking-wider cursor-pointer"
                 // onClick={() => sortedIndexers.requestSort("name")}
               >
                 {t("listScreens.common.name")}


### PR DESCRIPTION
### Fix after merging #2410 

#### What's this PR do?

##### Change

This PR adapts the column spans for the headings and rows of the grid for the indexer and proxy settings in:
* web/src/screens/settings/Indexer.tsx
* web/src/screens/settings/Proxy.tsx

`text-right` seemed to be the incorrect property here so it has been switched with `justity-end`  
to align the `Edit` button to the right side.

#### Where should the reviewer start?

Settings > Indexers / Proxy layout

#### How should this be manually tested?

Check overflows and/or collisions on indexer and proxy settings pages for desktop and mobile views.

#### Risk involved?

Possible collisions of components in mobile view for long names.

#### Screenshots (if appropriate)

##### Desktop
Old
<img width="1183" height="71" alt="image" src="https://github.com/user-attachments/assets/1aea6794-fa46-4e0f-8dba-d606b052a375" />
New
<img width="1183" height="71" alt="image" src="https://github.com/user-attachments/assets/afb3ed44-2ca5-4614-8f84-8b46031d2a6d" />

##### Mobile
Old
<img width="462" height="408" alt="image" src="https://github.com/user-attachments/assets/b991df36-9316-4b4b-9498-5b247ae620f7" />
New
<img width="462" height="408" alt="image" src="https://github.com/user-attachments/assets/c41456bf-02e2-409a-9ddf-0850a049e2fa" />


#### Does the documentation or dependencies need an update?

No

