### PR TITLE
build: skip GoReleaser publish from forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,6 +346,7 @@ jobs:
 
   release:
     name: Merge and publish distribution binaries
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: prepare
     env:


### PR DESCRIPTION
#### What's this PR do?

##### Change

* Skip GoReleaser Merge and Publish job from forks

#### Where should the reviewer start?

* Single line edit

#### How should this be manually tested?

* Merge change and update a PR from a fork and it should skip the Merge and Publish job

#### Risk involved?

* Low