### PR TITLE
feat(irc): add support for `/sleep` in connect commands

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -910,6 +911,21 @@ func (h *Handler) sendConnectCommands(msg string) error {
 
 		// if there's an extra , (comma) the command will be empty so lets skip that
 		if cmd == "" {
+			continue
+		}
+
+		if strings.HasPrefix(cmd, "/sleep") {
+			parts := strings.SplitN(cmd, " ", 2)
+			if len(parts) < 2 {
+				h.log.Warn().Msgf("sleep command missing duration: %s", cmd)
+				continue
+			}
+			secs, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+			if err != nil {
+				h.log.Error().Err(err).Msgf("error parsing sleep command: %s", cmd)
+				continue
+			}
+			time.Sleep(time.Duration(secs) * time.Second)
 			continue
 		}
 

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -925,6 +925,7 @@ func (h *Handler) sendConnectCommands(msg string) error {
 				h.log.Error().Err(err).Msgf("error parsing sleep command: %s", cmd)
 				continue
 			}
+			h.log.Debug().Msgf("sleeping for %d seconds: %s", secs, cmd)
 			time.Sleep(time.Duration(secs) * time.Second)
 			continue
 		}


### PR DESCRIPTION
#### What is the relevant ticket/issue

* [Feature req on Discord](https://discord.com/channels/881212911849209957/1490691846194593985)

#### What's this PR do?

##### Add

* Support for `/sleep` connect command that takes a number of seconds.

#### Where should the reviewer start?

* First file

#### How should this be manually tested?

* Add a connect command `/sleep 10` and look for a log message `sleeping for 10 seconds: /sleep 10`

#### Risk involved?

* Low

#### Does the documentation or dependencies need an update?

* Yes
