### PR TITLE
fix(releases): keep releases if PUSH_APPROVED is not in the delete list for cleanup

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -854,6 +854,24 @@ func (repo *ReleaseRepo) Delete(ctx context.Context, req *domain.DeleteReleaseRe
 			return errors.Wrap(err, "error building subquery")
 		}
 		qb = qb.Where("id IN ("+subQueryText+")", subQueryArgs...)
+
+		// If PUSH_APPROVED is not in the delete list, exclude releases that have
+		// any approved action - a release pushed to at least one client must be kept.
+		approvedInList := false
+		for _, s := range req.ReleaseStatuses {
+			if s == string(domain.ReleasePushStatusApproved) {
+				approvedInList = true
+				break
+			}
+		}
+		if !approvedInList {
+			excludeSubQuery := sq.Select("release_id").From("release_action_status").Where(sq.Eq{"status": string(domain.ReleasePushStatusApproved)})
+			excludeText, excludeArgs, err := excludeSubQuery.ToSql()
+			if err != nil {
+				return errors.Wrap(err, "error building approved-exclusion subquery")
+			}
+			qb = qb.Where("id NOT IN ("+excludeText+")", excludeArgs...)
+		}
 	}
 
 	query, args, err := qb.ToSql()


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Closes #2391

#### What's this PR do?

##### Add

* Add a check to exclude releases if they have PUSH_APPROVED  and another status

#### Where should the reviewer start?

* First file

#### How should this be manually tested?

* Setup a cleanup filter with Rejected,Pending,Error and make sure you have releases with Approved and Rejected and it should keep the ones with Approved

#### Risk involved?

* Medium

#### Does the documentation or dependencies need an update?

* No
