### PR TITLE
fix(irc): connect via HTTP proxy

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -258,7 +258,7 @@ func (h *Handler) Run() (err error) {
 
 			proxyContextDialer, ok := proxyDialer.(proxy.ContextDialer)
 			if !ok {
-				return errors.Wrap(err, "proxy dialer does not expose DialContext(): %v", proxyDialer)
+				return errors.New("proxy dialer does not expose DialContext(): %v", proxyDialer)
 			}
 
 			client.DialContext = proxyContextDialer.DialContext

--- a/internal/irc/httpproxy.go
+++ b/internal/irc/httpproxy.go
@@ -78,9 +78,6 @@ func (d *httpProxyDialer) DialContext(ctx context.Context, network, addr string)
 	// Send CONNECT request with additional headers for better compatibility
 	connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\n", addr)
 	connectReq += fmt.Sprintf("Host: %s\r\n", addr)
-	connectReq += "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36\r\n"
-	connectReq += "Proxy-Connection: Keep-Alive\r\n"
-	connectReq += "Connection: Keep-Alive\r\n"
 
 	// Add proxy authentication if provided
 	if d.proxyURL.User != nil {


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Closes #2331

#### What's this PR do?

##### Change

* Remove extra headers from irc http proxy connect

#### Where should the reviewer start?

* httpproxy.go

#### How should this be manually tested?

* Setup a HTTP proxy and select it in an IRC network, connect and it should work

#### Risk involved?

* Low

#### Does the documentation or dependencies need an update?

* No
