### PR TITLE
fix(web): adjust layout for new languages

### DIFF
--- a/web/src/screens/settings/Application.tsx
+++ b/web/src/screens/settings/Application.tsx
@@ -163,7 +163,7 @@ function ApplicationSettings() {
               ...prevState,
               theme: e.target.value as Theme
             }))}
-            className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 cursor-pointer text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="rounded-md min-w-32 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 cursor-pointer text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <option value="light">{t("common:theme.light")}</option>
             <option value="dark">{t("common:theme.dark")}</option>
@@ -187,7 +187,7 @@ function ApplicationSettings() {
               ...prevState,
               language: e.target.value as Language
             }))}
-            className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 cursor-pointer text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="rounded-md min-w-56 border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 cursor-pointer text-sm text-gray-900 dark:text-gray-100 px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <option value="en">{t("common:language.english")}</option>
             <option value="de">{t("common:language.german")}</option>

--- a/web/src/screens/settings/DownloadClient.tsx
+++ b/web/src/screens/settings/DownloadClient.tsx
@@ -130,12 +130,12 @@ function ListItem({ client }: DLSettingsItemProps) {
             setValue={onToggleMutation}
           />
         </div>
-        <div className="col-span-8 sm:col-span-4 lg:col-span-4 pl-10 sm:pl-12 pr-6 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate" title={client.name}>{client.name}</div>
-        <div className="hidden sm:block col-span-4 pr-6 py-3 text-left items-center whitespace-nowrap text-sm text-gray-600 dark:text-gray-400 truncate" title={client.host}>{client.host}</div>
-        <div className="hidden sm:block col-span-2 py-3 text-left items-center text-sm text-gray-600 dark:text-gray-400">
+        <div className="col-span-8 sm:col-span-3 lg:col-span-3 pl-10 sm:pl-12 pr-4 py-3 block flex-col text-sm font-medium text-gray-900 dark:text-white truncate" title={client.name}>{client.name}</div>
+        <div className="hidden sm:block col-span-6 lg:col-span-4 pr-12 lg:pr-4 py-3 text-left items-center whitespace-nowrap text-sm text-gray-600 dark:text-gray-400 truncate" title={client.host}>{client.host}</div>
+        <div className="hidden lg:block col-span-2 py-3 text-left items-center text-sm text-gray-600 dark:text-gray-400 ">
           {actionTypeNameMap[client.type]}
         </div>
-        <div className="col-span-1 pl-0.5 whitespace-nowrap text-center text-sm font-medium">
+        <div className="col-span-2 px-6 whitespace-nowrap flex justify-end text-sm font-medium">
           <span className="text-blue-600 dark:text-gray-300 hover:text-blue-900 cursor-pointer" onClick={toggleUpdateClient}>
             {t("settings:listScreens.common.edit")}
           </span>
@@ -179,7 +179,7 @@ function DownloadClientSettings() {
                 {t("listScreens.common.enabled")} <span className="sort-indicator">{sortedClients.getSortIndicator("enabled")}</span>
               </div>
               <div
-                className="col-span-6 sm:col-span-4 lg:col-span-4 pl-10 sm:pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer"
+                className="col-span-6 sm:col-span-3 lg:col-span-3 pl-10 sm:pl-12 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer"
                 onClick={() => sortedClients.requestSort("name")}
               >
                 {t("listScreens.common.name")} <span className="sort-indicator">{sortedClients.getSortIndicator("name")}</span>
@@ -190,7 +190,7 @@ function DownloadClientSettings() {
               >
                 {t("listScreens.downloadClients.host")} <span className="sort-indicator">{sortedClients.getSortIndicator("host")}</span>
               </div>
-              <div className="hidden sm:flex col-span-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer"
+              <div className="hidden lg:flex col-span-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer"
                 onClick={() => sortedClients.requestSort("type")}
               >
                 {t("listScreens.common.type")} <span className="sort-indicator">{sortedClients.getSortIndicator("type")}</span>

--- a/web/src/screens/settings/Notifications.tsx
+++ b/web/src/screens/settings/Notifications.tsx
@@ -69,12 +69,12 @@ function NotificationSettings() {
         <ul className="min-w-full">
           <li className="grid grid-cols-12 border-b border-gray-200 dark:border-gray-700">
             <div className="col-span-2 sm:col-span-1 pl-1 sm:pl-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t("listScreens.common.enabled")}</div>
-            <div className="col-span-9 md:col-span-5 pl-10 sm:pl-12 pr-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t("listScreens.common.name")}</div>
-            <div className="hidden md:flex col-span-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t("listScreens.common.type")}</div>
-            <div className="hidden md:flex col-span-1 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            <div className="col-span-9 lg:col-span-6 xl:col-span-5 pl-10 sm:pl-12 pr-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t("listScreens.common.name")}</div>
+            <div className="hidden lg:flex justify-self-center col-span-2 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">{t("listScreens.common.type")}</div>
+            <div className="hidden xl:flex justify-self-center col-span-1 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
               <span className="mr-1">{t("listScreens.notifications.events")}</span>
             </div>
-            <div className="hidden md:flex col-span-1 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            <div className="hidden xl:flex justify-self-center -col-span-1 px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
               <span className="mr-1">{t("listScreens.notifications.filters")}</span>
             </div>
           </li>
@@ -153,13 +153,13 @@ function ListItem({ notification }: ListItemProps) {
             setValue={onToggleMutation}
           />
         </div>
-        <div className="col-span-9 md:col-span-5 pl-10 sm:pl-12 pr-2 sm:pr-6 truncate block items-center text-sm font-medium text-gray-900 dark:text-white" title={notification.name}>
+        <div className="col-span-8 lg:col-span-6 xl:col-span-5 pl-10 sm:pl-12 pr-2 sm:pr-6 truncate block items-center text-sm font-medium text-gray-900 dark:text-white" title={notification.name}>
           {notification.name}
         </div>
-        <div className="hidden md:flex col-span-2 items-center">
+        <div className="hidden lg:flex justify-self-center col-span-2 items-center">
           {iconComponentMap[notification.type]}
         </div>
-        <div className="hidden md:flex col-span-1 px-6 items-center sm:px-6">
+        <div className="hidden xl:flex justify-self-center col-span-1 px-6 items-center sm:px-6">
           <span
             className="mr-2 inline-flex items-center px-2.5 py-1 rounded-md text-sm font-medium bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-400"
             title={notification.events.join(", ")}
@@ -167,7 +167,7 @@ function ListItem({ notification }: ListItemProps) {
             {notification.events.length}
           </span>
         </div>
-        <div className="hidden md:flex col-span-2 px-6 items-center sm:px-6">
+        <div className="hidden xl:flex justify-self-center col-span-1 px-6 items-center sm:px-6">
           <span
             className="mr-2 inline-flex items-center px-2.5 py-1 rounded-md text-sm font-medium bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-400"
             title={notification.used_by_filters?.join(", ")}
@@ -175,9 +175,9 @@ function ListItem({ notification }: ListItemProps) {
             {notification.used_by_filters?.length || 0}
           </span>
         </div>
-        <div className="col-span-1 flex first-letter:px-6 whitespace-nowrap text-right text-sm font-medium">
+        <div className="col-span-3 xl:col-span-2 flex justify-end px-6 whitespace-nowrap text-right text-sm font-medium">
           <span
-            className="col-span-1 px-0 sm:px-6 text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
+            className="text-blue-600 dark:text-gray-300 hover:text-blue-900 dark:hover:text-blue-500 cursor-pointer"
             onClick={toggleUpdateForm}
           >
             {t("listScreens.common.edit")}


### PR DESCRIPTION
This PR fixes another couple of colllsions and overflows in the settings with the new languages.
Russian seems to have a pretty long word for `Edit` so it's adapted to this word.