### PR TITLE
chore(indexers): add new EMP domain

### DIFF
--- a/internal/indexer/definitions/emp.yaml
+++ b/internal/indexer/definitions/emp.yaml
@@ -5,6 +5,7 @@ identifier: emp
 description: Empornium (EMP) is a private torrent tracker for XXX
 language: en-us
 urls:
+  - https://emparadise.rs
   - https://www.empornium.sx/
 privacy: private
 protocol: torrent


### PR DESCRIPTION
#### What's this PR do?

This PR adds the new domain for EMP since they
> [...] intend to make Emparadise our main domain and use empornium.sx as our fallback domain
> However, you are free to use whatever domain you prefer.

#### Where should the reviewer start?

* internal/indexer/definitions/emp.yaml

#### How should this be manually tested?

Check if metadata files can be successfully downloaded with the new domain.

#### Risk involved?

None - only indexers that are set up after this change has been released in a stable version will be affected.

#### Note

The new domain will be the default domain when adding EMP as a new indexer in the future.
In case we want to keep the old domain as a default I can reverse the order.
Feel free to express any concerns about the new domain being the default in the future.