### PR TITLE
feat(actions): support multiple comma separated labels for Transmission

### DIFF
--- a/internal/action/transmission.go
+++ b/internal/action/transmission.go
@@ -70,9 +70,14 @@ func (s *service) transmission(ctx context.Context, action *domain.Action, relea
 			}
 
 			if action.Label != "" {
-				labels := strings.TrimSuffix(action.Label, ",")
-				labels = strings.TrimPrefix(labels, ",")
-				p.Labels = strings.Split(labels, ",")
+				var labels []string
+				for label := range strings.SplitSeq(action.Label, ",") {
+					label = strings.TrimSpace(label)
+					if label != "" {
+						labels = append(labels, label)
+					}
+				}
+				p.Labels = labels
 			}
 
 			if action.LimitUploadSpeed > 0 {
@@ -133,9 +138,14 @@ func (s *service) transmission(ctx context.Context, action *domain.Action, relea
 		}
 
 		if action.Label != "" {
-			labels := strings.TrimSuffix(action.Label, ",")
-			labels = strings.TrimPrefix(labels, ",")
-			p.Labels = strings.Split(labels, ",")
+			var labels []string
+			for label := range strings.SplitSeq(action.Label, ",") {
+				label = strings.TrimSpace(label)
+				if label != "" {
+					labels = append(labels, label)
+				}
+			}
+			p.Labels = labels
 		}
 
 		if action.LimitUploadSpeed > 0 {

--- a/internal/action/transmission.go
+++ b/internal/action/transmission.go
@@ -70,7 +70,9 @@ func (s *service) transmission(ctx context.Context, action *domain.Action, relea
 			}
 
 			if action.Label != "" {
-				p.Labels = []string{action.Label}
+				labels := strings.TrimSuffix(action.Label, ",")
+				labels = strings.TrimPrefix(labels, ",")
+				p.Labels = strings.Split(labels, ",")
 			}
 
 			if action.LimitUploadSpeed > 0 {
@@ -131,7 +133,9 @@ func (s *service) transmission(ctx context.Context, action *domain.Action, relea
 		}
 
 		if action.Label != "" {
-			p.Labels = []string{action.Label}
+			labels := strings.TrimSuffix(action.Label, ",")
+			labels = strings.TrimPrefix(labels, ",")
+			p.Labels = strings.Split(labels, ",")
 		}
 
 		if action.LimitUploadSpeed > 0 {

--- a/web/src/i18n/locales/de/filters.json
+++ b/web/src/i18n/locales/de/filters.json
@@ -527,8 +527,8 @@
       "skipHashCheckTooltip": "Dies funktioniert nur mit Deluge v2."
     },
     "transmission": {
-      "label": "Torrentlabel",
-      "labelPlaceholder": "z.B. label1"
+      "label": "Torrentlabel (mme)",
+      "labelPlaceholder": "z.B. label1,label2"
     },
     "rtorrent": {
       "label": "Label",

--- a/web/src/i18n/locales/en/filters.json
+++ b/web/src/i18n/locales/en/filters.json
@@ -527,8 +527,8 @@
       "skipHashCheckTooltip": "This will only work on Deluge v2."
     },
     "transmission": {
-      "label": "Torrent Label",
-      "labelPlaceholder": "eg. label1"
+      "label": "Torrent Label(s)",
+      "labelPlaceholder": "eg. label1,label2"
     },
     "rtorrent": {
       "label": "Label",

--- a/web/src/i18n/locales/es/filters.json
+++ b/web/src/i18n/locales/es/filters.json
@@ -527,8 +527,8 @@
       "skipHashCheckTooltip": "Esto solo funcionará en Deluge v2."
     },
     "transmission": {
-      "label": "Etiqueta del torrent",
-      "labelPlaceholder": "ej. etiqueta1"
+      "label": "Etiquetas del torrent",
+      "labelPlaceholder": "ej. etiqueta1,etiqueta2"
     },
     "rtorrent": {
       "label": "Etiqueta",

--- a/web/src/i18n/locales/fr/filters.json
+++ b/web/src/i18n/locales/fr/filters.json
@@ -527,8 +527,8 @@
       "skipHashCheckTooltip": "Cela ne fonctionnera qu'avec Deluge v2."
     },
     "transmission": {
-      "label": "Label du torrent",
-      "labelPlaceholder": "ex. label1"
+      "label": "Labels du torrent",
+      "labelPlaceholder": "ex. label1,label2"
     },
     "rtorrent": {
       "label": "Label",

--- a/web/src/i18n/locales/no/filters.json
+++ b/web/src/i18n/locales/no/filters.json
@@ -527,8 +527,8 @@
       "skipHashCheckTooltip": "Dette vil kun fungere på Deluge v2."
     },
     "transmission": {
-      "label": "Torrentetikett",
-      "labelPlaceholder": "f.eks. etikett1"
+      "label": "Torrentetiketter",
+      "labelPlaceholder": "f.eks. etikett1,etikett2"
     },
     "rtorrent": {
       "label": "Etikett",

--- a/web/src/i18n/locales/ru/filters.json
+++ b/web/src/i18n/locales/ru/filters.json
@@ -527,8 +527,8 @@
       "skipHashCheckTooltip": "Это работает только в Deluge v2."
     },
     "transmission": {
-      "label": "Метка торрента",
-      "labelPlaceholder": "например, label1"
+      "label": "Метки торрента",
+      "labelPlaceholder": "например, label1,label2"
     },
     "rtorrent": {
       "label": "Метка",

--- a/web/src/i18n/locales/zh-CN/filters.json
+++ b/web/src/i18n/locales/zh-CN/filters.json
@@ -528,7 +528,7 @@
     },
     "transmission": {
       "label": "种子标签",
-      "labelPlaceholder": "例如：label1"
+      "labelPlaceholder": "例如：label1,label2"
     },
     "rtorrent": {
       "label": "标签",


### PR DESCRIPTION
#### What is the relevant ticket/issue
None Identified

#### What's this PR do?
This enables the transmission client to receive multiple comma separated labels.

##### Change

* `autobrr/internal/action/transmission.go`
* `autobrr/web/src/i18n/locales/en/filters.json`


#### How should this be manually tested?
I tested manually with a transmission 4.0.5 instance for the following scenarios:
- Empty label field
- single label - `label1`
- multiple label `label1,label2`
- leading `,` - `,label1`
- trailing `,` - `label1,`
- double middle `,` - `label1,,label2`
- Whole thing `,` - `,label1,,label2,`

#### Does the documentation or dependencies need an update?
* Yes, the other translations should be updated as well
