### PR TITLE
feat(docs): support more freeleech mappings in update-indexers

### DIFF
--- a/scripts/update-indexers.py
+++ b/scripts/update-indexers.py
@@ -31,13 +31,19 @@ def parse_yaml_file(file_path: str) -> Dict:
         # 1. In vars section
         has_freeleech = bool(re.search(r'vars:.*?-\s*freeleech\s*$', content, re.MULTILINE | re.DOTALL))
         has_freeleech_percent = bool(re.search(r'vars:.*?-\s*freeleechPercent\s*$', content, re.MULTILINE | re.DOTALL))
-        
+
         # 2. In mappings section - check what the fields map to
         mappings_freeleech = bool(re.search(r'mappings:.*?(?:freeleech|freeleechPercent):\s*(?!.*?percent|.*?\d+%)', content, re.MULTILINE | re.DOTALL))
         mappings_freeleech_percent = bool(re.search(r'mappings:.*?(?:freeleech|freeleechPercent):\s*(?:.*?percent|.*?\d+%)', content, re.MULTILINE | re.DOTALL))
-        
+
         has_freeleech = has_freeleech or mappings_freeleech
         has_freeleech_percent = has_freeleech_percent or mappings_freeleech_percent
+
+        # 3. If mappings section contains downloadVolumeFactor, treat as supporting both
+        mappings_section = re.search(r'mappings:.*', content, re.DOTALL)
+        if mappings_section and 'downloadVolumeFactor' in mappings_section.group(0):
+            has_freeleech = True
+            has_freeleech_percent = True
         
         result = {
             'name': name_match.group(1).strip() if name_match else '',


### PR DESCRIPTION
#### What is the relevant ticket/issue

* None

#### What's this PR do?

##### Add

* Support checking for `downloadVolumeFactor` in mappings for the update-indexers.py script that automatically builds a list of indexers with freeleech and freeleech percent support

#### Where should the reviewer start?

* `scripts/update-indexers.py`

#### How should this be manually tested?

* Run PR and test

#### Risk involved?

* Low