### PR TITLE
feat(indexers): add CZTeam

### DIFF
--- a/internal/indexer/definitions/czteam.yaml
+++ b/internal/indexer/definitions/czteam.yaml
@@ -1,0 +1,81 @@
+---
+# id: czteam
+name: CZTeam
+identifier: czteam
+description: CZTeam (CZT) is a ROMANIAN private torrent tracker for MOVIES / TV / GENERAL
+language: ro
+urls:
+  - https://czteam.me
+privacy: private
+protocol: torrent
+supports:
+  - irc
+  - rss
+# source: custom
+settings:
+  - name: passkey
+    type: secret
+    required: true
+    label: Passkey
+    help: "Go to My Settings -> Passkey and copy your Passkey"
+
+irc:
+  network: P2P-Network
+  server: irc.p2p-network.net
+  port: 6697
+  tls: true
+  channels:
+    - "#czteam"
+  announcers:
+    - Tabacila
+  settings:
+    - name: nick
+      type: text
+      required: true
+      label: Nick
+      help: Bot nick. Eg. user_autobrr
+
+    - name: auth.account
+      type: text
+      required: false
+      label: NickServ Account
+      help: NickServ account. Make sure to group your user and bot.
+
+    - name: auth.password
+      type: secret
+      required: false
+      label: NickServ Password
+      help: NickServ password
+
+  parse:
+    type: single
+    lines:
+      - tests:
+          - line: "New Torrent: Nuremberg.2025.2160p.iT.WEB-DL.DTS-HD.MA.5.1.DV.HDR10P.H.265-BTBN -- [Movies/HDTV-RO] [28,59 GB] -- https://czteam.me/details.php?id=218411"
+            expect:
+              torrentName: Nuremberg.2025.2160p.iT.WEB-DL.DTS-HD.MA.5.1.DV.HDR10P.H.265-BTBN
+              freeleech: ""
+              category: Movies/HDTV-RO
+              torrentSize: "28,59 GB"
+              baseUrl: https://czteam.me/
+              torrentId: "218411"
+          - line: "New Torrent: For.All.Mankind.S05E02.The.Hard.Six.1080p.ATVP.WEB-DL.DDP5.1.Atmos.H.264-FLUX -- [FreeLeech!] -- [TvEps/HD] [4,12 GB] -- https://czteam.me/details.php?id=218406"
+            expect:
+              torrentName: For.All.Mankind.S05E02.The.Hard.Six.1080p.ATVP.WEB-DL.DDP5.1.Atmos.H.264-FLUX
+              freeleech: FreeLeech!
+              category: TvEps/HD
+              torrentSize: "4,12 GB"
+              baseUrl: https://czteam.me/
+              torrentId: "218406"
+        pattern: 'New Torrent:\s+(.+?)\s+--\s+(?:\[(FreeLeech!)\]\s+--\s+)?\[([^\]]+)\]\s+\[([^\]]+)\]\s+--\s+(https?:\/\/[^\/]+\/)details\.php\?id=(\d+)'
+        vars:
+          - torrentName
+          - freeleech
+          - category
+          - torrentSize
+          - baseUrl
+          - torrentId
+
+    match:
+      infourl: "/details.php?id={{ .torrentId }}"
+      torrenturl: "/download.php?torrent={{ .torrentId }}&passkey={{ .passkey }}"


### PR DESCRIPTION
Adds support for **CZTeam** (CZT) — a Romanian private torrent tracker (formerly Czone), recently reopened.

**IRC**

- Network: P2P-Network (`irc.p2p-network.net:6697`, TLS)
- Channel: `#czteam`
- Announcer: `Tabacila`

**Announce format**

```
New Torrent: <release-name> -- [FreeLeech!] -- [<category>] [<size>] -- https://czteam.me/details.php?id=<id>
```

The `[FreeLeech!] --` segment is optional. Both shapes are covered by the YAML's `tests:` block.

**Captured vars**: `torrentName`, `freeleech`, `category`, `torrentSize`, `baseUrl`, `torrentId`.

**Auth**: per-user 16-hex passkey, used in the torrent-download URL (`/download.php?torrent={{ .torrentId }}&passkey={{ .passkey }}`). Members get the value from `https://czteam.me/my.php`.

The same definition has been distributed to early users via `https://czteam.me/integrations/autobrr-czteam.yaml` and confirmed working end-to-end against a live autobrr instance (irc connection, announce parsing, .torrent download).