### PR TITLE
build(ci): use web package manager for pnpm setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,10 +56,12 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
 
-    - name: Set up corepack
-      run: npm install -g corepack@latest && corepack enable
+    - name: Set up pnpm
+      uses: pnpm/action-setup@v6.0.5
+      with:
+        package_json_file: web/package.json
 
-      # It can not be done before enable corepack
+      # It can not be done before installing pnpm
     - name: Set up cache
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -32,10 +32,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Set up corepack
-        run: npm install -g corepack@latest && corepack enable
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6.0.5
+        with:
+          package_json_file: web/package.json
 
-      # It can not be done before enable corepack
+      # It can not be done before installing pnpm
       - name: Set up cache
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Set up corepack
-        run: npm install -g corepack@latest && corepack enable
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6.0.5
+        with:
+          package_json_file: web/package.json
 
-      # It can not be done before enable corepack
+      # It can not be done before installing pnpm
       - name: Set up cache
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
#### What is the relevant ticket/issue

* N/A

#### What's this PR do?

##### Change

* Uses `pnpm/action-setup` with `package_json_file: web/package.json` in the web dependency workflows.

This is necessary because the workflows were resolving pnpm from the root/Corepack default before installing dependencies in `web/`, which let CI pick a newer pnpm store path than the version pinned by `web/package.json`; using the web package manifest keeps pnpm setup and cache behavior on the same version.

#### Where should the reviewer start?

* `.github/workflows/eslint.yml`
* `.github/workflows/codeql.yml`
* `.github/workflows/release.yml`

#### How should this be manually tested?

* Re-run the affected GitHub Actions workflows.

#### Risk involved?

* Low; workflow-only change that aligns pnpm setup with the existing web package manager declaration.

#### Screenshots (if appropriate)

* N/A

#### Does the documentation or dependencies need an update?

* No
