### PR TITLE
feat(indexers): add Ultrabits

### DIFF
--- a/internal/indexer/definitions/ultrabits.yaml
+++ b/internal/indexer/definitions/ultrabits.yaml
@@ -68,7 +68,7 @@ irc:
               leechTypeEnum: 1
               torrentId: cmpa4sh22000f01mdh5jb0x4k
               originEnum: 0
-              torrentName: The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR
+              torrentName: Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE
               torrentSize: 4.32 GiB
               uploader: uploader
           - line: 'NEW Movie-WEB|0|cmpa4sh22000f01mdh5jb0x4k|1|Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE|4.32 GiB|uploader'
@@ -77,7 +77,7 @@ irc:
               leechTypeEnum: 0
               torrentId: cmpa4sh22000f01mdh5jb0x4k
               originEnum: 1
-              torrentName: The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR
+              torrentName: Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE
               torrentSize: 4.32 GiB
               uploader: uploader
           - line: 'ARCHIVE Movie-WEB|0|cmpa4sh22000f01mdh5jb0x4k|1|Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE|4.32 GiB|uploader'
@@ -86,7 +86,7 @@ irc:
               leechTypeEnum: 0
               torrentId: cmpa4sh22000f01mdh5jb0x4k
               originEnum: 1
-              torrentName: The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR
+              torrentName: Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE
               torrentSize: 4.32 GiB
               uploader: uploader
         pattern: '^(.+)\|(\d)\|([a-zA-Z0-9]+)\|(\d)\|(.+)\|(.+)\|(.+)$'

--- a/internal/indexer/definitions/ultrabits.yaml
+++ b/internal/indexer/definitions/ultrabits.yaml
@@ -1,0 +1,113 @@
+---
+# id: ultrabits
+name: UltraBits
+identifier: ultrabits
+description: UltraBits - Swedish/Nordic private tracker (movies, tv, music, games, general)
+language: en-us,sv-se
+urls:
+  - https://ultrabits.org/
+privacy: private
+protocol: torrent
+supports:
+  - irc
+  - rss
+settings:
+  - name: passkey
+    type: secret
+    required: true
+    label: Passkey
+    help: |
+      Personal account credential. Find it under
+      Profile - Settings - Security on ultrabits.org. Treat it like
+      a password - anyone with this passkey can download as you.
+
+irc:
+  network: UltraBits
+  server: irc.ultrabits.org
+  port: 6697
+  tls: true
+  channels:
+    - "#announce"
+  announcers:
+    - ub-announce
+  settings:
+    - name: nick
+      type: text
+      required: true
+      label: Bot nick
+      help: |
+        The nickname autobrr connects as. Pick something unique to
+        your client — autobrr's own bot, separate from anything you
+        chat with manually.
+
+    - name: auth.account
+      type: text
+      required: true
+      label: Tracker username
+      help: |
+        Your UltraBits username. The IRC server SASLs you in as this
+        account, regardless of what nick autobrr connects with.
+
+    - name: auth.password
+      type: secret
+      required: true
+      label: IRC key (ub_…)
+      help: |
+        A dedicated IRC key for autobrr. Generate at
+        Profile → Settings → IRC keys. Per-client, individually
+        revocable — if this autobrr instance is compromised you can
+        revoke this one key without breaking irssi / HexChat / etc.
+
+parse:
+  type: single
+  lines:
+    - tests:
+        - line: '[NEW] [movie] [Movie-x264] [FL] The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR [78.4 GiB] by Trinity | https://ultrabits.org/torrents/the-matrix-1999-uhd-bluray-2160p'
+          expect:
+            tags: NEW
+            mediaType: movie
+            category: Movie-x264
+            freeleech: FL
+            torrentName: The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR
+            torrentSize: 78.4 GiB
+            uploader: Trinity
+            slug: the-matrix-1999-uhd-bluray-2160p
+        - line: '[P2P] [tv] [TV-Nordic] [FL] [aud:sv] [sub:sv,en] Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE [703.7 MiB] by Anonymous | https://ultrabits.org/torrents/dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine'
+          expect:
+            tags: P2P
+            mediaType: tv
+            category: TV-Nordic
+            freeleech: FL
+            audioLangs: sv
+            subLangs: sv,en
+            torrentName: Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE
+            torrentSize: 703.7 MiB
+            uploader: Anonymous
+            slug: dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine
+        - line: '[ARCHIVE] [music] [FLAC] Pink.Floyd-The.Dark.Side.of.the.Moon-1973-LP-FLAC [413.2 MiB] by SoundGoblin | https://ultrabits.org/torrents/pink-floyd-dark-side-1973-flac'
+          expect:
+            tags: ARCHIVE
+            mediaType: music
+            category: FLAC
+            torrentName: Pink.Floyd-The.Dark.Side.of.the.Moon-1973-LP-FLAC
+            torrentSize: 413.2 MiB
+            uploader: SoundGoblin
+            slug: pink-floyd-dark-side-1973-flac
+      pattern: '^\[(\w+)\] \[(\w+)\] \[([\w-]+)\](?: \[(FL)\])?(?: \[(2X)\])?(?: \[(INT)\])?(?: \[aud:([\w,]+)\])?(?: \[sub:([\w,]+)\])? (.+?) \[([\d.]+ [KMGTP]i?B)\] by (\S+) \| https?://[^/]+/torrents/(\S+)$'
+      vars:
+        - tags
+        - mediaType
+        - category
+        - freeleech
+        - doubleUp
+        - internal
+        - audioLangs
+        - subLangs
+        - torrentName
+        - torrentSize
+        - uploader
+        - slug
+
+  match:
+    infourl: "/torrents/{{ .slug }}"
+    torrenturl: "/rss/dl/{{ .passkey }}/{{ .slug }}.torrent"

--- a/internal/indexer/definitions/ultrabits.yaml
+++ b/internal/indexer/definitions/ultrabits.yaml
@@ -2,7 +2,7 @@
 # id: ultrabits
 name: UltraBits
 identifier: ultrabits
-description: UltraBits - Swedish/Nordic private tracker (movies, tv, music, games, general)
+description: UltraBits is a Swedish/Nordic private tracker for MOVIES, TV, MUSIC, GAMES, GENERAL
 language: en-us,sv-se
 urls:
   - https://ultrabits.org/
@@ -62,52 +62,64 @@ irc:
     type: single
     lines:
       - tests:
-          - line: '[NEW] [movie] [Movie-x264] [FL] The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR [78.4 GiB] by Trinity | https://ultrabits.org/torrents/the-matrix-1999-uhd-bluray-2160p'
+          - line: 'P2P Movie-WEB|1|cmpa4sh22000f01mdh5jb0x4k|0|Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE|4.32 GiB|uploader'
             expect:
-              tags: NEW
-              mediaType: movie
-              category: Movie-x264
-              freeleech: FL
+              category: P2P Movie-x264
+              leechTypeEnum: 1
+              torrentId: cmpa4sh22000f01mdh5jb0x4k
+              originEnum: 0
               torrentName: The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR
-              torrentSize: 78.4 GiB
-              uploader: Trinity
-              slug: the-matrix-1999-uhd-bluray-2160p
-          - line: '[P2P] [tv] [TV-Nordic] [FL] [aud:sv] [sub:sv,en] Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE [703.7 MiB] by Anonymous | https://ultrabits.org/torrents/dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine'
+              torrentSize: 4.32 GiB
+              uploader: uploader
+          - line: 'NEW Movie-WEB|0|cmpa4sh22000f01mdh5jb0x4k|1|Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE|4.32 GiB|uploader'
             expect:
-              tags: P2P
-              mediaType: tv
-              category: TV-Nordic
-              freeleech: FL
-              audioLangs: sv
-              subLangs: sv,en
-              torrentName: Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE
-              torrentSize: 703.7 MiB
-              uploader: Anonymous
-              slug: dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine
-          - line: '[ARCHIVE] [music] [FLAC] Pink.Floyd-The.Dark.Side.of.the.Moon-1973-LP-FLAC [413.2 MiB] by SoundGoblin | https://ultrabits.org/torrents/pink-floyd-dark-side-1973-flac'
+              category: NEW Movie-x264
+              leechTypeEnum: 0
+              torrentId: cmpa4sh22000f01mdh5jb0x4k
+              originEnum: 1
+              torrentName: The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR
+              torrentSize: 4.32 GiB
+              uploader: uploader
+          - line: 'ARCHIVE Movie-WEB|0|cmpa4sh22000f01mdh5jb0x4k|1|Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE|4.32 GiB|uploader'
             expect:
-              tags: ARCHIVE
-              mediaType: music
-              category: FLAC
-              torrentName: Pink.Floyd-The.Dark.Side.of.the.Moon-1973-LP-FLAC
-              torrentSize: 413.2 MiB
-              uploader: SoundGoblin
-              slug: pink-floyd-dark-side-1973-flac
-        pattern: '^\[(\w+)\] \[(\w+)\] \[([\w-]+)\](?: \[(FL)\])?(?: \[(2X)\])?(?: \[(INT)\])?(?: \[aud:([\w,]+)\])?(?: \[sub:([\w,]+)\])? (.+?) \[([\d.]+ [KMGTP]i?B)\] by (\S+) \| https?://[^/]+/torrents/(\S+)$'
+              category: ARCHIVE Movie-x264
+              leechTypeEnum: 0
+              torrentId: cmpa4sh22000f01mdh5jb0x4k
+              originEnum: 1
+              torrentName: The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR
+              torrentSize: 4.32 GiB
+              uploader: uploader
+        pattern: '^(.+)\|(\d)\|([a-zA-Z0-9]+)\|(\d)\|(.+)\|(.+)\|(.+)$'
         vars:
-          - tags
-          - mediaType
           - category
-          - freeleech
-          - doubleUp
-          - internal
-          - audioLangs
-          - subLangs
+          - leechTypeEnum
+          - torrentId
+          - originEnum
           - torrentName
           - torrentSize
           - uploader
-          - slug
+
+    mappings:
+      originEnum:
+        "0":
+          origin: ""
+        "1":
+          origin: "INTERNAL"
+
+      leechTypeEnum:
+        "0": # Normal
+          downloadVolumeFactor: 1
+          uploadVolumeFactor: 1
+        "1": # 100% FL
+          downloadVolumeFactor: 0
+          uploadVolumeFactor: 1
+        "2": # Normal leech with Double up
+          downloadVolumeFactor: 1
+          uploadVolumeFactor: 2
+        "3": # 100% FL with Double up
+          downloadVolumeFactor: 0
+          uploadVolumeFactor: 2
 
     match:
-      infourl: "/torrents/{{ .slug }}"
-      torrenturl: "/rss/dl/{{ .passkey }}/{{ .slug }}.torrent"
+      infourl: "/torrents/{{ .torrentId }}"
+      torrenturl: "/rss/dl/{{ .passkey }}/{{ .torrentId }}.torrent"

--- a/internal/indexer/definitions/ultrabits.yaml
+++ b/internal/indexer/definitions/ultrabits.yaml
@@ -12,14 +12,12 @@ supports:
   - irc
   - rss
 settings:
-  - name: passkey
+  - name: apikey
     type: secret
     required: true
-    label: Passkey
+    label: API key
     help: |
-      Personal account credential. Find it under
-      Profile - Settings - Security on ultrabits.org. Treat it like
-      a password - anyone with this passkey can download as you.
+      Find it under Profile - Settings - API Keys. https://ultrabits.org/profile/settings/api-keys
 
 irc:
   network: UltraBits
@@ -36,9 +34,7 @@ irc:
       required: true
       label: Bot nick
       help: |
-        The nickname autobrr connects as. Pick something unique to
-        your client — autobrr's own bot, separate from anything you
-        chat with manually.
+        The nickname autobrr connects as. Eg. username_bot
 
     - name: auth.account
       type: text
@@ -51,12 +47,10 @@ irc:
     - name: auth.password
       type: secret
       required: true
-      label: IRC key (ub_…)
+      label: IRC key (ub_xxx)
       help: |
         A dedicated IRC key for autobrr. Generate at
-        Profile → Settings → IRC keys. Per-client, individually
-        revocable — if this autobrr instance is compromised you can
-        revoke this one key without breaking irssi / HexChat / etc.
+        Profile → Settings → IRC keys. https://ultrabits.org/profile/settings/irc-keys
 
   parse:
     type: single
@@ -113,13 +107,13 @@ irc:
         "1": # 100% FL
           downloadVolumeFactor: 0
           uploadVolumeFactor: 1
-        "2": # Normal leech with Double up
-          downloadVolumeFactor: 1
-          uploadVolumeFactor: 2
-        "3": # 100% FL with Double up
+        "2": # 100% FL with Double up
           downloadVolumeFactor: 0
+          uploadVolumeFactor: 2
+        "3": # Normal leech with Double up
+          downloadVolumeFactor: 1
           uploadVolumeFactor: 2
 
     match:
       infourl: "/torrents/{{ .torrentId }}"
-      torrenturl: "/rss/dl/{{ .passkey }}/{{ .torrentId }}.torrent"
+      torrenturl: "/rss/dl/{{ .apikey }}/{{ .torrentId }}.torrent"

--- a/internal/indexer/definitions/ultrabits.yaml
+++ b/internal/indexer/definitions/ultrabits.yaml
@@ -58,56 +58,56 @@ irc:
         revocable — if this autobrr instance is compromised you can
         revoke this one key without breaking irssi / HexChat / etc.
 
-parse:
-  type: single
-  lines:
-    - tests:
-        - line: '[NEW] [movie] [Movie-x264] [FL] The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR [78.4 GiB] by Trinity | https://ultrabits.org/torrents/the-matrix-1999-uhd-bluray-2160p'
-          expect:
-            tags: NEW
-            mediaType: movie
-            category: Movie-x264
-            freeleech: FL
-            torrentName: The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR
-            torrentSize: 78.4 GiB
-            uploader: Trinity
-            slug: the-matrix-1999-uhd-bluray-2160p
-        - line: '[P2P] [tv] [TV-Nordic] [FL] [aud:sv] [sub:sv,en] Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE [703.7 MiB] by Anonymous | https://ultrabits.org/torrents/dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine'
-          expect:
-            tags: P2P
-            mediaType: tv
-            category: TV-Nordic
-            freeleech: FL
-            audioLangs: sv
-            subLangs: sv,en
-            torrentName: Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE
-            torrentSize: 703.7 MiB
-            uploader: Anonymous
-            slug: dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine
-        - line: '[ARCHIVE] [music] [FLAC] Pink.Floyd-The.Dark.Side.of.the.Moon-1973-LP-FLAC [413.2 MiB] by SoundGoblin | https://ultrabits.org/torrents/pink-floyd-dark-side-1973-flac'
-          expect:
-            tags: ARCHIVE
-            mediaType: music
-            category: FLAC
-            torrentName: Pink.Floyd-The.Dark.Side.of.the.Moon-1973-LP-FLAC
-            torrentSize: 413.2 MiB
-            uploader: SoundGoblin
-            slug: pink-floyd-dark-side-1973-flac
-      pattern: '^\[(\w+)\] \[(\w+)\] \[([\w-]+)\](?: \[(FL)\])?(?: \[(2X)\])?(?: \[(INT)\])?(?: \[aud:([\w,]+)\])?(?: \[sub:([\w,]+)\])? (.+?) \[([\d.]+ [KMGTP]i?B)\] by (\S+) \| https?://[^/]+/torrents/(\S+)$'
-      vars:
-        - tags
-        - mediaType
-        - category
-        - freeleech
-        - doubleUp
-        - internal
-        - audioLangs
-        - subLangs
-        - torrentName
-        - torrentSize
-        - uploader
-        - slug
+  parse:
+    type: single
+    lines:
+      - tests:
+          - line: '[NEW] [movie] [Movie-x264] [FL] The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR [78.4 GiB] by Trinity | https://ultrabits.org/torrents/the-matrix-1999-uhd-bluray-2160p'
+            expect:
+              tags: NEW
+              mediaType: movie
+              category: Movie-x264
+              freeleech: FL
+              torrentName: The.Matrix.1999.UHD.BluRay.2160p.HEVC.TrueHD.7.1-FraMeSToR
+              torrentSize: 78.4 GiB
+              uploader: Trinity
+              slug: the-matrix-1999-uhd-bluray-2160p
+          - line: '[P2P] [tv] [TV-Nordic] [FL] [aud:sv] [sub:sv,en] Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE [703.7 MiB] by Anonymous | https://ultrabits.org/torrents/dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine'
+            expect:
+              tags: P2P
+              mediaType: tv
+              category: TV-Nordic
+              freeleech: FL
+              audioLangs: sv
+              subLangs: sv,en
+              torrentName: Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE
+              torrentSize: 703.7 MiB
+              uploader: Anonymous
+              slug: dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine
+          - line: '[ARCHIVE] [music] [FLAC] Pink.Floyd-The.Dark.Side.of.the.Moon-1973-LP-FLAC [413.2 MiB] by SoundGoblin | https://ultrabits.org/torrents/pink-floyd-dark-side-1973-flac'
+            expect:
+              tags: ARCHIVE
+              mediaType: music
+              category: FLAC
+              torrentName: Pink.Floyd-The.Dark.Side.of.the.Moon-1973-LP-FLAC
+              torrentSize: 413.2 MiB
+              uploader: SoundGoblin
+              slug: pink-floyd-dark-side-1973-flac
+        pattern: '^\[(\w+)\] \[(\w+)\] \[([\w-]+)\](?: \[(FL)\])?(?: \[(2X)\])?(?: \[(INT)\])?(?: \[aud:([\w,]+)\])?(?: \[sub:([\w,]+)\])? (.+?) \[([\d.]+ [KMGTP]i?B)\] by (\S+) \| https?://[^/]+/torrents/(\S+)$'
+        vars:
+          - tags
+          - mediaType
+          - category
+          - freeleech
+          - doubleUp
+          - internal
+          - audioLangs
+          - subLangs
+          - torrentName
+          - torrentSize
+          - uploader
+          - slug
 
-  match:
-    infourl: "/torrents/{{ .slug }}"
-    torrenturl: "/rss/dl/{{ .passkey }}/{{ .slug }}.torrent"
+    match:
+      infourl: "/torrents/{{ .slug }}"
+      torrenturl: "/rss/dl/{{ .passkey }}/{{ .slug }}.torrent"

--- a/internal/indexer/definitions/ultrabits.yaml
+++ b/internal/indexer/definitions/ultrabits.yaml
@@ -64,7 +64,7 @@ irc:
       - tests:
           - line: 'P2P Movie-WEB|1|cmpa4sh22000f01mdh5jb0x4k|0|Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE|4.32 GiB|uploader'
             expect:
-              category: P2P Movie-x264
+              category: P2P Movie-WEB
               leechTypeEnum: 1
               torrentId: cmpa4sh22000f01mdh5jb0x4k
               originEnum: 0
@@ -73,7 +73,7 @@ irc:
               uploader: uploader
           - line: 'NEW Movie-WEB|0|cmpa4sh22000f01mdh5jb0x4k|1|Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE|4.32 GiB|uploader'
             expect:
-              category: NEW Movie-x264
+              category: NEW Movie-WEB
               leechTypeEnum: 0
               torrentId: cmpa4sh22000f01mdh5jb0x4k
               originEnum: 1
@@ -82,7 +82,7 @@ irc:
               uploader: uploader
           - line: 'ARCHIVE Movie-WEB|0|cmpa4sh22000f01mdh5jb0x4k|1|Eva.and.Adam.Fyra.Fodelsedagar.and.Ett.Fiasko.2001.1080p.NF.WEB-DL.DDP5.1.x264-OzONE|4.32 GiB|uploader'
             expect:
-              category: ARCHIVE Movie-x264
+              category: ARCHIVE Movie-WEB
               leechTypeEnum: 0
               torrentId: cmpa4sh22000f01mdh5jb0x4k
               originEnum: 1


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Added [Ultrabits](https://ultrabits.org) definition. Originally created as custom definition by the tracker staff, but I made some improvements and got confirmation it can be added upstream for official support.

#### Details of the indexer

IRC:
network: `UltraBits`
server: `irc.ultrabits.org`
port: `6697`
tls: `true`
channel: `#announce`

Announce example: `[P2P] [tv] [TV-Nordic] [FL] [aud:sv] [sub:sv,en] Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE [703.7 MiB] by Anonymous | https://ultrabits.org/torrents/dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine`

Match information example:
Match 1 0–208 `[P2P] [tv] [TV-Nordic] [FL] [aud:sv] [sub:sv,en] Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE [703.7 MiB] by Anonymous | https://ultrabits.org/torrents/dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine`
Group 1–4 `P2P` - `tags`
Group 7–9 `tv` - `mediaType`
Group 12–21 `TV-Nordic` - `category`
Group 24–26 `FL` - `freeleech`
Group 33–35 `sv` - `audioLangs`
Group 42–47 `sv,en` - `subLangs`
Group 49–99 `Dips.S03E04.SWEDiSH.1080p.SVT.WEB-DL.H.265-NORViNE` - `torrentName`
Group 101–110 `703.7 MiB` - `torrentSize`
Group 115–124 `Anonymous` - `uploader`
Group 158–208 `dips-s03e04-swedish-1080p-svt-web-dl-h-265-norvine` - `slug`

##### Add

* Ultrabits

##### Change

* None

##### Remove

* None

#### Where should the reviewer start?

* `internal/indexer/definitions/ultrabits.yaml`

#### How should this be manually tested?

* It was already tested

#### Risk involved?

* No

#### Screenshots (if appropriate)

* No

#### Does the documentation or dependencies need an update?

* Yes - add to the freeleech table
