### PR TITLE
feat(downloadclients): qBittorrent add API key support

### DIFF
--- a/internal/download_client/connection.go
+++ b/internal/download_client/connection.go
@@ -16,8 +16,8 @@ import (
 	"github.com/autobrr/autobrr/pkg/arr/readarr"
 	"github.com/autobrr/autobrr/pkg/arr/sonarr"
 	"github.com/autobrr/autobrr/pkg/errors"
-	"github.com/autobrr/autobrr/pkg/porla"
 	"github.com/autobrr/autobrr/pkg/nzbget"
+	"github.com/autobrr/autobrr/pkg/porla"
 	"github.com/autobrr/autobrr/pkg/sabnzbd"
 	"github.com/autobrr/autobrr/pkg/transmission"
 	"github.com/autobrr/autobrr/pkg/whisparr"
@@ -84,6 +84,7 @@ func (s *service) testQbittorrentConnection(ctx context.Context, client domain.D
 		TLSSkipVerify: client.TLSSkipVerify,
 		Username:      client.Username,
 		Password:      client.Password,
+		APIKey:        client.Settings.APIKey,
 		Log:           s.subLogger,
 	}
 

--- a/internal/download_client/service.go
+++ b/internal/download_client/service.go
@@ -19,8 +19,8 @@ import (
 	"github.com/autobrr/autobrr/pkg/arr/readarr"
 	"github.com/autobrr/autobrr/pkg/arr/sonarr"
 	"github.com/autobrr/autobrr/pkg/errors"
-	"github.com/autobrr/autobrr/pkg/porla"
 	"github.com/autobrr/autobrr/pkg/nzbget"
+	"github.com/autobrr/autobrr/pkg/porla"
 	"github.com/autobrr/autobrr/pkg/sabnzbd"
 	"github.com/autobrr/autobrr/pkg/transmission"
 	"github.com/autobrr/autobrr/pkg/whisparr"
@@ -105,7 +105,7 @@ func (s *service) GetArrTags(ctx context.Context, id int32) ([]*domain.ArrTag, e
 	}
 
 	switch client.Type {
-	case "RADARR":
+	case domain.DownloadClientTypeRadarr:
 		arrClient := client.Client.(*radarr.Client)
 		tags, err := arrClient.GetTags(ctx)
 		if err != nil {
@@ -123,7 +123,7 @@ func (s *service) GetArrTags(ctx context.Context, id int32) ([]*domain.ArrTag, e
 
 		return data, nil
 
-	case "SONARR":
+	case domain.DownloadClientTypeSonarr:
 		arrClient := client.Client.(*sonarr.Client)
 		tags, err := arrClient.GetTags(ctx)
 		if err != nil {
@@ -285,6 +285,7 @@ func (s *service) GetClient(ctx context.Context, clientId int32) (*domain.Downlo
 			Host:          clientHost,
 			Username:      client.Username,
 			Password:      client.Password,
+			APIKey:        client.Settings.APIKey,
 			TLSSkipVerify: client.TLSSkipVerify,
 			Log:           zstdlog.NewStdLoggerWithLevel(s.log.With().Str("type", "qBittorrent").Str("client", client.Name).Logger(), zerolog.TraceLevel),
 			BasicUser:     client.Settings.Auth.Username,

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -205,7 +205,7 @@ function FormFieldsQbit() {
       <TextFieldWide name="username" label={t("forms.downloadClient.username")} />
       <PasswordFieldWide name="password" label={t("forms.downloadClient.password")} />
 
-      <PasswordFieldWide required name="settings.apikey" label={t("forms.downloadClient.apiKey")} />
+      <PasswordFieldWide name="settings.apikey" label={t("forms.downloadClient.apiKey")} />
 
       <SwitchGroupWide name="settings.basic.auth" label={t("forms.downloadClient.basicAuth")} />
 

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -205,6 +205,8 @@ function FormFieldsQbit() {
       <TextFieldWide name="username" label={t("forms.downloadClient.username")} />
       <PasswordFieldWide name="password" label={t("forms.downloadClient.password")} />
 
+      <PasswordFieldWide required name="settings.apikey" label={t("forms.downloadClient.apiKey")} />
+
       <SwitchGroupWide name="settings.basic.auth" label={t("forms.downloadClient.basicAuth")} />
 
       {settings.basic?.auth === true && (


### PR DESCRIPTION
#### What is the relevant ticket/issue

* none

#### What's this PR do?

##### Add

* Add API key auth support for qBittorrent

#### Where should the reviewer start?

* `connection.go`

#### How should this be manually tested?

* Setup a qBittorrent client in settings and test it with API key

#### Risk involved?

* Low

#### Does the documentation or dependencies need an update?

* Later
