### PR TITLE
feat(indexers): add ShareIsland

### DIFF
--- a/internal/indexer/definitions/shareisland.yaml
+++ b/internal/indexer/definitions/shareisland.yaml
@@ -1,0 +1,107 @@
+---
+# source: UNIT3D
+name: ShareIsland
+identifier: shareisland
+description: ShareIsland (SHRI) is an Italian private torrent tracker for Movies, TV and general.
+language: it-IT
+urls:
+  - https://shareisland.org
+privacy: private
+protocol: torrent
+supports:
+  - irc
+  - rss
+settings:
+  - name: rsskey
+    type: secret
+    required: true
+    label: RSS key
+    help: "Go to your profile tab, Settings > RSS Key, copy RSS Key"
+
+irc:
+  network: ShareIsland
+  server: irc.shareisland.org
+  port: 6697
+  tls: true
+  channels:
+    - "#announce"
+  announcers:
+    - ShareBot
+  settings:
+    - name: nick
+      type: text
+      required: true
+      label: Nick
+      help: Bot nick. Site username_BOT or username
+
+    - name: auth.account
+      type: text
+      required: true
+      label: Account
+      help: Site username
+
+    - name: auth.password
+      type: secret
+      required: true
+      label: IRC Key
+      help: "Go to your profile tab, Settings > IRC Key, copy IRC Key"
+
+  parse:
+    type: single
+    lines:
+      - tests:
+          - line: "[New]-[Movie]-[WEB-DL]-[Marty Supreme 2025 ITA - ENG 1080p AMZN WEB-DL DD+ 5.1 H.264-cinepth]-[Internal: Yes]-[FL: 0%]-[DU: No]-[Size: 11.14 GiB]-[Uploader: Ovebello]-[URL: https://shareisland.org/torrents/107745]"
+            expect:
+              announceTypeEnum: New
+              category: Movie
+              releaseTags: WEB-DL
+              torrentName: Marty Supreme 2025 ITA - ENG 1080p AMZN WEB-DL DD+ 5.1 H.264-cinepth
+              internal: "Yes"
+              freeleechPercent: "0"
+              doubleUp: "No"
+              torrentSize: 11.14 GiB
+              uploader: Ovebello
+              baseUrl: https://shareisland.org/
+              torrentId: "107745"
+          - line: "[Featured]-[Movie]-[WEB-DL]-[Buen Camino 2025 ITA - ENG 1080p NF WEB-DL DD+ 5.1 H.264-iSlaNd]-[Internal: Yes]-[FL: 100%]-[DU: Yes]-[Size: 3.93 GiB]-[Uploader: Fabriz]-[URL: https://shareisland.org/torrents/107256]"
+            expect:
+              announceTypeEnum: Featured
+              category: Movie
+              releaseTags: WEB-DL
+              torrentName: Buen Camino 2025 ITA - ENG 1080p NF WEB-DL DD+ 5.1 H.264-iSlaNd
+              internal: "Yes"
+              freeleechPercent: "100"
+              doubleUp: "Yes"
+              torrentSize: 3.93 GiB
+              uploader: Fabriz
+              baseUrl: https://shareisland.org/
+              torrentId: "107256"
+        pattern: '\[([^\]]+)\]-\[([^\]]+)\]-\[([^\]]+)\]-\[(.+)\]-\[Internal: ([^\]]+)\]-\[FL: (\d+)%\]-\[DU: ([^\]]+)\]-\[Size: ([^\]]+)\]-\[Uploader: ([^\]]+)\]-\[URL: (https?:\/\/[^\/]+\/)[^\d]*(\d+)\]'
+        vars:
+          - announceTypeEnum
+          - category
+          - releaseTags
+          - torrentName
+          - internal
+          - freeleechPercent
+          - doubleUp
+          - torrentSize
+          - uploader
+          - baseUrl
+          - torrentId
+
+    mappings:
+      announceTypeEnum:
+        "New":
+          announceType: NEW
+        "Featured":
+          announceType: PROMO
+      internal:
+        "Yes":
+          origin: INTERNAL
+        "No":
+          origin: ""
+
+    match:
+      infourl: "/torrents/{{ .torrentId }}"
+      torrenturl: "/torrent/download/{{ .torrentId }}.{{ .rsskey }}"

--- a/internal/indexer/definitions/shareisland.yaml
+++ b/internal/indexer/definitions/shareisland.yaml
@@ -96,11 +96,6 @@ irc:
           announceType: NEW
         "Featured":
           announceType: PROMO
-      internal:
-        "Yes":
-          origin: INTERNAL
-        "No":
-          origin: ""
 
     match:
       infourl: "/torrents/{{ .torrentId }}"


### PR DESCRIPTION
#### What is the relevant ticket/issue

N/A - new tracker indexer

#### Details of the indexer

ShareIsland is an Italian private tracker (Movies, TV, General) running UNIT3D.
Authentication uses SASL PLAIN with site username + IRC Key (not NickServ).

IRC:
network: `ShareIsland`
server: `irc.shareisland.org`
port: `6697`
tls: `true`
channel: `#announce`

Announce example:
`[New]-[Movie]-[WEB-DL]-[Marty Supreme 2025 ITA - ENG 1080p AMZN WEB-DL DD+ 5.1 H.264-cinepth]-[Internal: Yes]-[FL: 0%]-[DU: No]-[Size: 11.14 GiB]-[Uploader: Ovebello]-[URL: https://shareisland.org/torrents/107745]`

Groups:
- Group 1: `New` - announceTypeEnum
- Group 2: `Movie` - category
- Group 3: `WEB-DL` - releaseTags
- Group 4: `Marty Supreme 2025 ITA - ENG 1080p AMZN WEB-DL DD+ 5.1 H.264-cinepth` - torrentName
- Group 5: `Yes` - internal
- Group 6: `0` - freeleechPercent
- Group 7: `No` - doubleUp
- Group 8: `11.14 GiB` - torrentSize
- Group 9: `Ovebello` - uploader
- Group 10: `https://shareisland.org/` - baseUrl
- Group 11: `107745` - torrentId

##### Add

* ShareIsland

##### Change

* None

##### Remove

* None

#### Where should the reviewer start?

`internal/indexer/definitions/shareisland.yaml`

#### How should this be manually tested?

Configure IRC network in autobrr: server `irc.shareisland.org`, port `6697`, TLS enabled, SASL PLAIN with site username and IRC Key from user profile. Add ShareIsland indexer and verify `#announce` shows "Monitoring channel".

#### Risk involved?

Low - new file only

#### Does the documentation or dependencies need an update?

Yes