### PR TITLE
fix(indexers): include group id in infourl for PTP

### DIFF
--- a/internal/indexer/definitions/ptp.yaml
+++ b/internal/indexer/definitions/ptp.yaml
@@ -190,5 +190,5 @@ irc:
           uploadVolumeFactor: 0
 
     match:
-      infourl: "/torrents.php?torrentid={{ .torrentId }}"
+      infourl: "/torrents.php?id={{ .groupId }}&torrentid={{ .torrentId }}"
       torrenturl: "/torrents.php?action=download&id={{ .torrentId }}&authkey={{ .authkey }}&torrent_pass={{ .torrent_pass }}&key={{ .key }}"


### PR DESCRIPTION
#### What's this PR do?

##### Change

* Adding group id to info URLs for PTP indexer, it's needed to reflect the same info URL across Radarr/Prowlarr/Jackett to get history grabs for pushed releases by autobrr when using interactive search.

#### Risk involved?

* Low
