### PR TITLE
chore(deps): Dependabot ignore problematic submodule dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
       golang:
         patterns:
           - "*"
+    # Untagged submodule (no semver tags upstream); Dependabot's version
+    # discovery walks up to the v1 parent module and fails to resolve it.
+    # Pin/bump it manually with `go get .../postgresstore@latest`.
+    ignore:
+      - dependency-name: "github.com/alexedwards/scs/postgresstore"
 
   - package-ecosystem: npm
     directory: /web


### PR DESCRIPTION
#### What's this PR do?

##### Add

* Add Dependabot ignore for `github.com/alexedwards/scs/postgresstore`. They don't publish packages for the store implementations and Dependabot error due to it.

#### Risk involved?

* None