### PR TITLE
fix(irc): surface channel JOIN errors as connection errors

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -301,6 +301,11 @@ func (h *Handler) Run() (err error) {
 	}
 	client.AddCallback("INVITE", h.handleInvite)
 	client.AddCallback("366", h.handleJoined)
+	client.AddCallback("471", h.handleJoinError) // ERR_CHANNELISFULL
+	client.AddCallback("473", h.handleJoinError) // ERR_INVITEONLYCHAN
+	client.AddCallback("474", h.handleJoinError) // ERR_BANNEDFROMCHAN
+	client.AddCallback("475", h.handleJoinError) // ERR_BADCHANNELKEY
+	client.AddCallback("477", h.handleJoinError) // ERR_NEEDREGGEDNICK
 	client.AddCallback("PART", h.handlePart)
 	client.AddCallback("PRIVMSG", h.onMessage)
 	client.AddCallback("NOTICE", h.onNotice)
@@ -899,6 +904,22 @@ func (h *Handler) handleJoined(msg ircmsg.Message) {
 	}
 
 	h.log.Info().Msgf("Monitoring channel %s", channel)
+}
+
+// handleJoinError handles IRC error numerics for failed JOIN attempts.
+// Covers: 471 (full), 473 (invite-only), 474 (banned), 475 (bad key), 477 (need registered nick).
+func (h *Handler) handleJoinError(msg ircmsg.Message) {
+	if len(msg.Params) < 2 {
+		return
+	}
+	channel := msg.Params[1]
+	reason := ""
+	if len(msg.Params) > 2 {
+		reason = msg.Params[2]
+	}
+	errMsg := fmt.Sprintf("could not join %s: %s (%s)", channel, reason, msg.Command)
+	h.log.Error().Msgf("JOIN error: %s", errMsg)
+	h.addConnectError(errMsg)
 }
 
 // sendConnectCommands sends invite commands

--- a/internal/irc/handler_test.go
+++ b/internal/irc/handler_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package irc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/ergochat/irc-go/ircmsg"
+	"github.com/rs/zerolog"
+)
+
+// newTestHandler returns a Handler suitable for unit tests.
+func newTestHandler(network domain.IrcNetwork) *Handler {
+	return &Handler{
+		log:              zerolog.Nop(),
+		network:          &network,
+		connectionErrors: []string{},
+		channelHealth:    map[string]*channelHealth{},
+		validChannels:    map[string]struct{}{},
+		validAnnouncers:  map[string]struct{}{},
+	}
+}
+
+// joinErrorMsg builds a JOIN-error numeric message as the server would send it.
+func joinErrorMsg(numeric, botnick, channel, reason string) ircmsg.Message {
+	if reason == "" {
+		return ircmsg.MakeMessage(nil, "server.example.net", numeric, botnick, channel)
+	}
+	return ircmsg.MakeMessage(nil, "server.example.net", numeric, botnick, channel, reason)
+}
+
+// --- handleJoinError ---
+
+func TestHandleJoinErrorTooFewParams(t *testing.T) {
+	h := newTestHandler(domain.IrcNetwork{})
+
+	// zero params
+	h.handleJoinError(ircmsg.MakeMessage(nil, "server", "475"))
+	// one param (botnick only — no channel)
+	h.handleJoinError(ircmsg.MakeMessage(nil, "server", "475", "botnick"))
+
+	if len(h.connectionErrors) != 0 {
+		t.Errorf("expected no errors for short param lists, got: %v", h.connectionErrors)
+	}
+}
+
+func TestHandleJoinErrorChannelNoReason(t *testing.T) {
+	h := newTestHandler(domain.IrcNetwork{})
+	h.handleJoinError(joinErrorMsg("477", "botnick", "#secretchan", ""))
+
+	if len(h.connectionErrors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(h.connectionErrors))
+	}
+	got := h.connectionErrors[0]
+	if !strings.Contains(got, "#secretchan") {
+		t.Errorf("error missing channel name: %s", got)
+	}
+	if !strings.Contains(got, "477") {
+		t.Errorf("error missing numeric: %s", got)
+	}
+}
+
+func TestHandleJoinErrorChannelWithReason(t *testing.T) {
+	h := newTestHandler(domain.IrcNetwork{})
+	h.handleJoinError(joinErrorMsg("475", "botnick", "#locked", "Bad channel key"))
+
+	if len(h.connectionErrors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(h.connectionErrors))
+	}
+	got := h.connectionErrors[0]
+	if !strings.Contains(got, "#locked") {
+		t.Errorf("error missing channel: %s", got)
+	}
+	if !strings.Contains(got, "Bad channel key") {
+		t.Errorf("error missing reason: %s", got)
+	}
+	if !strings.Contains(got, "475") {
+		t.Errorf("error missing numeric: %s", got)
+	}
+}
+
+// TestHandleJoinErrorAllNumerics ensures that every registered JOIN-error numeric
+// produces a connection error entry.
+func TestHandleJoinErrorAllNumerics(t *testing.T) {
+	numerics := []struct {
+		code string
+		desc string
+	}{
+		{"471", "ERR_CHANNELISFULL"},
+		{"473", "ERR_INVITEONLYCHAN"},
+		{"474", "ERR_BANNEDFROMCHAN"},
+		{"475", "ERR_BADCHANNELKEY"},
+		{"477", "ERR_NEEDREGGEDNICK"},
+	}
+	for _, tc := range numerics {
+		t.Run(tc.code+"_"+tc.desc, func(t *testing.T) {
+			h := newTestHandler(domain.IrcNetwork{})
+			h.handleJoinError(joinErrorMsg(tc.code, "bot", "#chan", "reason"))
+			if len(h.connectionErrors) != 1 {
+				t.Errorf("%s (%s): expected 1 error, got %d", tc.code, tc.desc, len(h.connectionErrors))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Register callbacks for IRC error numerics that indicate a failed channel join, and surface them as connection errors so the failure is visible to the user in the UI.

Handled numerics:
- `471` — `ERR_CHANNELISFULL`
- `473` — `ERR_INVITEONLYCHAN`
- `474` — `ERR_BANNEDFROMCHAN`
- `475` — `ERR_BADCHANNELKEY` (wrong or missing channel key)
- `477` — `ERR_NEEDREGGEDNICK` (must be identified with NickServ to join)

Previously these errors were silently dropped; the bot would appear to be running normally but not monitoring the channel.

## Test plan

- Unit tests covering `handleJoinError` for all five numerics, with and without a reason string, and for short/malformed messages.
- Manual: configure a channel with `+k` or `+i` and verify the connection error appears in the network status UI.