### PR TITLE
build(deps): bump Go to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build web
-FROM node:22.17.0-alpine3.22 AS web-builder
+FROM node:24.18.0-alpine3.24 AS web-builder
 # Update and enable Corepack
 RUN npm install -g corepack@latest && \
     corepack enable
@@ -13,7 +13,7 @@ COPY web ./
 RUN pnpm run build
 
 # build app
-FROM golang:1.25-alpine3.22 AS app-builder
+FROM golang:1.26-alpine3.24 AS app-builder
 
 ARG VERSION=dev
 ARG REVISION=dev
@@ -39,7 +39,7 @@ RUN go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISIO
     go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o bin/autobrrctl cmd/autobrrctl/main.go
 
 # build runner
-FROM alpine:latest
+FROM alpine:3.24
 
 LABEL org.opencontainers.image.source="https://github.com/autobrr/autobrr"
 

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.22 AS app-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.24 AS app-builder
 RUN apk add --no-cache git tzdata
 
 ENV SERVICE=autobrr
@@ -33,11 +33,11 @@ go build -pgo=cpu.pprof -ldflags "-s -w -X main.version=${VERSION} -X main.commi
 go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/autobrrctl cmd/autobrrctl/main.go
 
 # build runner
-FROM alpine:latest AS runner
+FROM alpine:3.24 AS runner
 
 LABEL org.opencontainers.image.source="https://github.com/autobrr/autobrr"
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later"
-LABEL org.opencontainers.image.base.name="alpine:latest"
+LABEL org.opencontainers.image.base.name="alpine:3.24"
 
 ENV HOME="/config" \
     XDG_CONFIG_HOME="/config" \

--- a/ciwindows.Dockerfile
+++ b/ciwindows.Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.22 AS app-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.24 AS app-builder
 RUN apk add --no-cache git tzdata
 
 ENV SERVICE=autobrr

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/autobrr
 
-go 1.25.0
+go 1.26
 
 replace github.com/r3labs/sse/v2 => github.com/autobrr/sse/v2 v2.0.0-20230520125637-530e06346d7d
 


### PR DESCRIPTION
#### What's this PR do?

##### Change

* Update Go to version 1.26 in go.mod and Dockerfiles (with `alpine:3.24`)
* Update Node in Dockerfiles to latest LTS `24.18.0`

#### Where should the reviewer start?

* `go.mod`

#### How should this be manually tested?

* `make build`

#### Risk involved?

* Low