### PR TITLE
feat(indexers): make NickServ optional and channel password required for BIT-HDTV

### DIFF
--- a/internal/indexer/definitions/bit-hdtv.yaml
+++ b/internal/indexer/definitions/bit-hdtv.yaml
@@ -38,15 +38,21 @@ irc:
 
     - name: auth.account
       type: text
-      required: true
+      required: false
       label: NickServ Account
       help: NickServ account. Make sure to group your user and bot.
 
     - name: auth.password
       type: secret
-      required: true
+      required: false
       label: NickServ Password
       help: NickServ password
+
+    - name: channels.password
+      type: secret
+      required: true
+      label: Channel Password
+      help: Channel password for #bit-hdtv
 
   parse:
     type: single

--- a/internal/indexer/definitions/bit-hdtv.yaml
+++ b/internal/indexer/definitions/bit-hdtv.yaml
@@ -52,7 +52,7 @@ irc:
       type: secret
       required: true
       label: Channel Password
-      help: Channel password for #bit-hdtv
+      help: "Channel password for #bit-hdtv"
 
   parse:
     type: single


### PR DESCRIPTION
## Summary

- Makes `auth.account` (NickServ Account) optional for the BIT-HDTV indexer
- Makes `auth.password` (NickServ Password) optional for the BIT-HDTV indexer
- Adds mandatory `channels.password` (Channel Password) field for the `#bit-hdtv` channel