### PR TITLE
fix(irc): announce processor channel lookup order

### DIFF
--- a/internal/announce/announce.go
+++ b/internal/announce/announce.go
@@ -66,16 +66,16 @@ func (a *announceProcessor) setupQueueConsumers() {
 }
 
 func (a *announceProcessor) processQueue(channelName string, queue chan string) {
+	channel, ok := a.indexer.IRC.ChannelsMap[channelName]
+	if !ok {
+		a.log.Error().Msgf("announce: no channel found for name: %s", channelName)
+		return
+	}
+
 	for {
 		tmpVars := map[string]string{}
 		parseFailed := false
 		//patternParsed := false
-
-		channel, ok := a.indexer.IRC.ChannelsMap[channelName]
-		if !ok {
-			a.log.Error().Msgf("announce: no channel found for name: %s", channelName)
-			continue
-		}
 
 		for _, parseLine := range channel.Parse.Lines {
 			line, err := a.getNextLine(queue)


### PR DESCRIPTION
#### What is the relevant ticket/issue

* Reported on Discord

#### What's this PR do?

##### Change

* Move the channel lookup in announce processor outside the queue loop.


#### Where should the reviewer start?

*

#### How should this be manually tested?

*

#### Risk involved?

* Low
