### PR TITLE
feat(releases): support type in release search

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -203,6 +203,7 @@ var reservedSearch = map[string]*regexp.Regexp{
 	"r.source":        regexp.MustCompile(`(?i)(?:` + `source` + `:)(?P<value>'.*?'|".*?"|\S+)`),
 	"r.codec":         regexp.MustCompile(`(?i)(?:` + `codec` + `:)(?P<value>'.*?'|".*?"|\S+)`),
 	"r.hdr":           regexp.MustCompile(`(?i)(?:` + `hdr` + `:)(?P<value>'.*?'|".*?"|\S+)`),
+	"r.type":          regexp.MustCompile(`(?i)(?:` + `type` + `:)(?P<value>'.*?'|".*?"|\S+)`),
 	"r.filter":        regexp.MustCompile(`(?i)(?:` + `filter` + `:)(?P<value>'.*?'|".*?"|\S+)`),
 }
 

--- a/internal/database/release_test.go
+++ b/internal/database/release_test.go
@@ -240,6 +240,20 @@ func TestReleaseRepo_Find(t *testing.T) {
 			assert.NotEqual(t, int64(0), resp.TotalCount)
 			assert.True(t, resp.NextCursor >= 0)
 
+			// Search by type
+			queryParams.Search = "type:movie"
+			resp, err = repo.Find(context.Background(), queryParams)
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, uint64(1), resp.TotalCount)
+
+			// Search by type with no matches
+			queryParams.Search = "type:episode"
+			resp, err = repo.Find(context.Background(), queryParams)
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, uint64(0), resp.TotalCount)
+
 			// Cleanup
 			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
 			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)


### PR DESCRIPTION
#### What is the relevant ticket/issue

* n/a

#### What's this PR do?

##### Add

* `type:` as a reserved keyword in the release search, so releases can be filtered by media type (`type:movie`, `type:episode`, `type:series`, ...), same prefix matching as `season:` and `episode:`. The type column was already parsed and stored for every release, just not searchable.

#### Where should the reviewer start?

* `reservedSearch` in `internal/database/release.go`

#### How should this be manually tested?

* Open Releases and search `type:movie` or `type:episode`. Values follow rls types: movie, episode, series, music, game, app, book, etc. Note single episodes parse as `episode`, season packs as `series`.

#### Risk involved?

* Low. One map entry; searches not using `type:` are unaffected.

#### Does the documentation or dependencies need an update?

* No dependency changes. The search keyword list on autobrr.com could mention `type:` if it documents the others.