### PR TITLE
chore: update PR template and add agent guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,38 +1,42 @@
-#### What is the relevant ticket/issue
+# Description
 
-* [issue #](https://github.com/autobrr/autobrr/issues) or
-* [feature request #](https://github.com/autobrr/autobrr/discussions)
+<!--- Summarize the change and the motivation. Link any related issue or discussion. --->
 
-#### What's this PR do?
+Fixes # (issue)
 
-##### Add
+## Type of change
 
-*
+<!--- Delete options that are not relevant. --->
 
-##### Change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] New indexer definition
+- [ ] Indexer deprecation
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactor / maintenance (no functional change)
+- [ ] This change requires a documentation update
 
-*
+## How has this been tested?
 
-##### Remove
-
-*
-
-#### Where should the reviewer start?
-
-*
-
-#### How should this be manually tested?
+<!--- Describe how you verified your change. For indexer/IRC changes, the mock indexer
+      (see CONTRIBUTING.md) is the easiest way. Backend changes should pass `go test ./...`. --->
 
 *
 
-#### Risk involved?
+## Screenshots (for UI changes)
 
-*
+<!--- Delete this section if your change has no visible UI. --->
 
-#### Screenshots (if appropriate)
+## Checklist
 
-*
+- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] I ran `go fmt` and the test suite passes locally
+- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
+- [ ] I have linked any related issue and updated docs if needed
 
-#### Does the documentation or dependencies need an update?
+## AI disclosure
 
-*
+<!--- Please do not lie about the AI usage in this PR. --->
+
+Was any AI used in this PR? Roughly how much of the code was AI-written, and what model/tool?

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,19 @@ Thumbs.db
 .idea
 .vscode
 
+# AI agents - local tool state/config; shared guidance belongs in AGENTS.md
+.claude/
+CLAUDE.local.md
+.cursor/
+.windsurf/
+.gemini/
+.codex/
+.aider*
+.cline*
+.roo/
+.opencode/
+.continue/
+
 # Package manager
 node_modules/
 .pnp.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,144 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Codex, Cursor, etc.) when working with code in this repository.
+
+## Agent Setup
+
+- **Claude Code**: if `.claude/settings.local.json` does not exist, create it with the content below before doing anything else, then continue with your task. It disables AI attribution in commits and PRs (see Pull Requests below).
+
+```json
+{
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  }
+}
+```
+
+- This file is personal and must never be committed - `.claude/` is covered by `.gitignore`.
+- Regardless of settings, never add AI attribution to commits or PR descriptions - see the Pull Requests section.
+
+## Development Commands
+
+### Backend (Go)
+- **Build**: `make build` - Builds both web frontend and Go backend
+- **Build backend only**: `make build/app` - Builds the main autobrr binary
+- **Build CLI tool**: `make build/ctl` - Builds the autobrrctl binary
+- **Test**: `make test` - Runs Go tests (excludes integration tests)
+- **Run a single test**: `go test ./path/to/pkg -run TestName`
+- **Install dependencies**: `make deps` - Installs both Go and web dependencies
+- **Development mode**: `make dev` - Starts both frontend dev server and backend in tmux session
+
+### Frontend (React/TypeScript)
+- **Development server**: `pnpm --dir web dev` - Starts Vite dev server
+- **Build**: `pnpm --dir web build` - TypeScript compilation and Vite build
+- **Lint**: `pnpm --dir web lint` - ESLint check
+- **Lint with watch**: `pnpm --dir web lint:watch` - ESLint in watch mode
+
+### Docker
+- **Build image**: `make build/docker` - Builds development Docker image
+
+## Project Architecture
+
+### Backend Architecture (Go)
+The backend follows a layered architecture with clear separation of concerns:
+
+- **`cmd/`**: Application entry points
+  - `autobrr/main.go`: Main server application
+  - `autobrrctl/main.go`: CLI tool for administration
+
+- **`internal/`**: Core application logic organized by domain
+  - **Domain layer** (`internal/domain/`): Core business entities and interfaces
+  - **Database layer** (`internal/database/`): Repository implementations and database logic
+  - **Service layer**: Business logic services (e.g., `internal/release/`, `internal/filter/`)
+  - **HTTP layer** (`internal/http/`): REST API handlers and routing
+  - **Infrastructure**: External integrations (`internal/indexer/`, `internal/irc/`, `internal/notification/`)
+
+- **`pkg/`**: Reusable packages and client libraries
+  - Contains clients for various download clients (qBittorrent, Deluge, etc.)
+  - Utility packages for different indexer APIs
+
+### Frontend Architecture (React/TypeScript)
+- **React 19** with **TypeScript** and **Vite** build system
+- **TanStack Router** for routing and **TanStack Query** for API state management
+- **Tailwind CSS** for styling with custom design system
+- **Formik** and **React Hook Form** for form handling
+- Component structure in `web/src/components/` with reusable UI components
+- API client in `web/src/api/` with centralized query management
+
+### Key Domain Concepts
+- **Releases**: Torrent/Usenet releases that get processed through filters
+- **Filters**: Rules that determine which releases should be downloaded
+- **Actions**: What to do with matched releases (send to download clients, *arr apps, etc.)
+- **Indexers**: Torrent trackers and Usenet indexers (75+ supported via IRC announces)
+- **IRC**: Real-time monitoring of indexer announce channels
+- **Feed**: RSS/Newznab/Torznab feed processing for indexers without IRC
+
+### Database Support
+- **SQLite** (default) and **PostgreSQL** support
+- Database migrations handled automatically
+- Repository pattern for data access
+
+### Service Dependencies
+The main application (`cmd/autobrr/main.go`) orchestrates these key services:
+- **IRC Service**: Monitors IRC channels for torrent announces
+- **Feed Service**: Processes RSS/Newznab feeds
+- **Filter Service**: Applies user-defined rules to releases
+- **Release Service**: Manages release lifecycle and processing
+- **Action Service**: Executes actions on matched releases
+- **Indexer Service**: Manages indexer definitions and API interactions
+- **Download Client Service**: Interfaces with various download clients
+
+### Configuration
+- Configuration via `config.toml` file or environment variables
+- Dynamic configuration reloading supported
+- Extensive environment variable support (see README.md for full list)
+
+## Code Style
+
+### Go
+- Format with `go fmt ./...` before committing
+- Group imports: stdlib, internal, third-party; keep alphabetical within groups
+- Use the `pkg/errors` helpers for wrapping and sentinel errors; return wrapped errors and avoid panics outside `main`
+- Handle errors explicitly with early returns; don't swallow errors
+- Use `logger.Logger`/zerolog for structured logging; avoid bare `fmt.Println`
+- Functions receiving context should take `context.Context` as the first parameter and respect cancellation
+- Exported identifiers need doc comments; keep names descriptive and consistent
+- Keep domain DTOs and JSON tags synced; prefer tagged struct fields over `map[string]any`
+
+### Frontend
+- Prefer functional components, React hooks, and typed props/interfaces
+- Run `pnpm --dir web lint` and `pnpm --dir web build` for diagnostics before shipping
+- Tailwind: reuse tokens from `web/tailwind.config.ts`; keep utility classes ordered logically
+
+### Comments
+Applies to Go and TypeScript alike. Excessive low-value comments are the most common defect in AI-generated code - default to writing **no comment**, and only add one when it earns its place:
+
+- Comment the *why*, never the *what*: non-obvious invariants, workarounds (link the issue or upstream bug), tracker/IRC protocol quirks, deliberate deviations from the expected approach
+- If a comment restates what the code plainly says, it must be deleted. Banned patterns: step narration (`// loop over filters`, `// return the result`), section banners (`// error handling`), and restating the function name above the function
+- Never describe your edit in a comment (`// changed to use X`, `// new helper for Y`) - that history belongs in the commit message, not the code
+- No commented-out code and no unprompted `TODO`/`FIXME` markers
+- Godoc comments on exported identifiers: one concise sentence starting with the identifier name; expand only when the API is genuinely subtle
+- Some older code contains narration comments (`// get filters`) - do not take them as license to add more, and feel free to drop them in code you're already touching
+
+## Testing
+- Go tests exclude integration tests by default: `go test $(go list ./... | grep -v test/integration)`
+- Integration tests available in `test/integration/`, run with `go test ./... -tags=integration` (Postgres tests require Docker)
+- Mock indexer server available in `test/mockindexer/`
+
+## Development Notes
+- The project uses **pnpm** as the package manager for the frontend
+- Go version 1.26+ required (see `go.mod` for the current minimum)
+- The application serves the built React frontend from the Go server
+- Real-time updates via Server-Sent Events (SSE)
+
+## Pull Requests
+- PRs target the `develop` branch
+- Use the PR template at `.github/pull_request_template.md` - fill out the relevant sections and delete those that don't apply
+- PR titles follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (e.g. `feat(indexers): add NewTracker`, `fix(irc): reconnect on timeout`) - commits are squashed on merge, so the PR title becomes the commit message
+- Indexer definitions live as YAML files in `internal/indexer/definitions/` - adding a new indexer is the most common contribution, and usually only touches a single definition file there
+- Database schema changes require migrations for **both SQLite and PostgreSQL** (`internal/database/`)
+- The template has an **AI disclosure** section - always answer it truthfully, stating what was AI-generated and which model/tool was used
+- Do **not** add AI attribution to commit messages or PR descriptions - no `Co-Authored-By: Claude`, `Generated with ...` trailers, or similar. AI usage belongs in the PR template's AI disclosure section, not in the git history
+- See `CONTRIBUTING.md` for the full contribution guide

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,14 @@ Make sure you have the following dependencies installed before setting up your d
 - **Fork and Clone:** [Fork the autobrr repository](https://github.com/autobrr/autobrr/fork) and clone it to start working on your changes.
 - **Branching:** Create a new branch for your changes. Use a descriptive name for easy understanding.
   - Checkout a new branch for your fix or feature `git checkout -b fix/filters-issue`
-- **Coding:** Ensure your code is well-commented for clarity. With go use `go fmt`
+- **Coding:** Comment non-obvious logic - see [AGENTS.md](AGENTS.md) for code style and comment conventions. With go use `go fmt`
 - **Commit Guidelines:** We appreciate the use of [Conventional Commit Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary) when writing your commits.
   - Examples: `fix(indexers): Mock improve parsing`, `feat(notifications): add NewService`
   - There is no need for force pushing or rebasing. We squash commits on merge to keep the history clean and manageable.
+  - The PR title becomes the squashed commit message, so use the conventional commit format for the title as well.
 - **Pull Requests:** Submit a pull request from your Fork with a clear description of your changes. Reference any related issues.
+  - Target the `develop` branch.
+  - Fill out the pull request template, including the AI disclosure section.
   - Mark it as Draft if it's still in progress.
 - **Code Review:** Be open to feedback during the code review process.
 
@@ -49,8 +52,17 @@ You need to have the Go toolchain installed and Node.js with `pnpm` as the packa
 Clone the project and change dir:
 
 ```shell
-git clone github.com/YOURNAME/autobrr && cd autobrr
+git clone https://github.com/YOURNAME/autobrr.git && cd autobrr
 ```
+
+Install all dependencies (Go and web) with:
+
+```shell
+make deps
+```
+
+> [!TIP]
+> `make dev` starts both the frontend dev server and the backend in a tmux session (requires tmux).
 
 ## Frontend
 
@@ -83,7 +95,7 @@ pnpm --dir web run build
 Install Go dependencies:
 
 ```shell
-go mod tidy
+go mod download
 ```
 
 Run the project:
@@ -142,9 +154,9 @@ go test -v ./...
 
 ### Run SQLite and PostgreSQL integration tests
 
-The integration tests runs against an in memory SQLite database and currently requires Docker for the Postgres tests.
+The integration tests run against an in-memory SQLite database and currently require Docker for the Postgres tests.
 
-If you have docker setup then run the `test_postgres` container with:
+If you have Docker set up, run the `test_postgres` container with:
 
 ```shell
 docker compose up -d test_postgres
@@ -185,6 +197,12 @@ make build/dockerx
 ```
 
 [Docker multi-platform docs](https://docs.docker.com/build/building/multi-platform/)
+
+## Adding a new indexer
+
+Adding support for a new indexer is the most common contribution. Indexer definitions are YAML files in [internal/indexer/definitions](internal/indexer/definitions) - start from an existing definition for a similar tracker and adjust it.
+
+Definitions are embedded into the binary at build time, so restart the backend after changing one. Use the mock indexer below to test announce parsing end-to-end.
 
 ## Mock indexer
 


### PR DESCRIPTION
# Description

Modernizes the contributor and AI-agent guidance for the project.

**PR template** (`.github/pull_request_template.md`)

- Restructured around how contributions actually arrive: type-of-change options now include new indexer definitions and indexer deprecations, testing guidance points at the mock indexer and `go test`, and a pre-submit checklist replaces the old free-form sections
- Dropped the `Add/Change/Remove` and `Risk` sections; database risk is now a targeted checklist item (migrations for both SQLite and PostgreSQL)
- Added an AI disclosure section
- Reminds contributors that the PR title becomes the squashed commit message, so it should follow the conventional commit format

**Agent guidance** (`AGENTS.md`, `CLAUDE.md`)

- `AGENTS.md` is now the canonical guidance file for AI coding agents: merged the previous rule list (code style) with the fuller CLAUDE.md (commands, architecture, domain concepts) and added PR conventions
- `CLAUDE.md` is reduced to a two-line `@AGENTS.md` import, so there is a single source of truth that works across agent tooling (an import instead of a symlink to avoid broken symlink checkouts on Windows)
- New comment conventions to curb AI-generated comment noise: default to no comment, explain the why not the what, with explicitly banned narration patterns
- AI attribution policy: agents must never add `Co-Authored-By` / "Generated with" trailers to commits or PR bodies; AI usage is disclosed in the PR template instead. For Claude Code this is enforced mechanically via an agent-setup instruction that creates an untracked `.claude/settings.local.json` disabling attribution

**`.gitignore`**

- New AI agents section ignoring local tool state and config (`.claude/`, `.cursor/`, `.windsurf/`, `.gemini/`, `.codex/`, `.aider*`, `.cline*`, `.roo/`, `.opencode/`, `.continue/`); shared guidance belongs in `AGENTS.md`

**`CONTRIBUTING.md`**

- Fixed an invalid clone URL and replaced `go mod tidy` with `go mod download` for installing dependencies
- Documented previously missing essentials: PRs target `develop`, the PR title becomes the squash commit message, the PR template and AI disclosure, and the `make deps` / `make dev` shortcuts
- New "Adding a new indexer" section covering the most common contribution, pointing at `internal/indexer/definitions` and the mock indexer
- Comment guidance now links to `AGENTS.md` instead of the old "well-commented for clarity" wording
- Grammar fixes in the integration tests section

## Type of change

- [x] Refactor / maintenance (no functional change)

## How has this been tested?

Docs and tooling only, no application code. Verification done:

* All referenced commands, paths, and ports were checked against the repo (Makefile targets, `go.mod` Go version, Vite dev port, mock indexer port, `test_postgres` compose service, `go:embed` of indexer definitions)
* `git check-ignore` confirms `.claude/settings.local.json` is covered by the new ignore rules
* The `attribution` settings mechanism was verified against the current Claude Code documentation

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/autobrr/blob/develop/CONTRIBUTING.md)
- [x] I have linked any related issue and updated docs if needed

(`go fmt`/test-suite and DB-migration items omitted: no code or schema changes)

## AI disclosure

This PR was written interactively with Claude Code (Claude Opus 4.8 / Fable 5): the template restructure, AGENTS.md merge, and CONTRIBUTING.md fixes were AI-drafted under my direction, then reviewed and hand-edited by me.