### PR TITLE
fix(indexers): DasUnerwartete key settings and NickServ auth

### DIFF
--- a/internal/indexer/definitions/dasunerwartete.yaml
+++ b/internal/indexer/definitions/dasunerwartete.yaml
@@ -77,4 +77,4 @@ irc:
 
         match:
           infourl: "/details.php?id={{ .torrentId }}"
-          downloadurl: "/rss-download.php?uid={{ .userId }}&pk={{ .passkey }}&torrent={{ .torrentId }}"
+          downloadurl: "/rss-download.php?uid={{ .userId }}&pk={{ .rsskey }}&torrent={{ .torrentId }}"

--- a/internal/indexer/definitions/dasunerwartete.yaml
+++ b/internal/indexer/definitions/dasunerwartete.yaml
@@ -1,6 +1,6 @@
 ---
 version: 2
-#id: anthelion
+#id: dasunerwartete
 name: DasUnerwartete
 identifier: dasunerwartete
 description: DasUnerwartete (DU) is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL.
@@ -14,11 +14,11 @@ supports:
   - rss
 # source: unknown
 settings:
-  - name: passkey
+  - name: rsskey
     type: secret
     required: true
-    label: Passkey
-    help: Check your profile.
+    label: RSS Key
+    help: Copy from a direct download RSS link. (Torrents > RSS Feed)
 
   - name: userId
     type: secret
@@ -40,13 +40,13 @@ irc:
 
     - name: auth.account
       type: text
-      required: true
+      required: false
       label: NickServ Account
       help: NickServ account. Make sure to group your user and bot.
 
     - name: auth.password
       type: secret
-      required: true
+      required: false
       label: NickServ Password
       help: NickServ password
 


### PR DESCRIPTION
# Description

<!--- Summarize the change and the motivation. Link any related issue or discussion. --->

This PR fixes 2 issues with the DasUnerwartete definition:
- Their NickServ auth seems to unable to group further usernames to an existing account.
- Even though the URL specifies a pk URL parameter, it does not accept the passkey in the profile.
Instead you have to provide it with the pk parameter of a direct download RSS link.

## Type of change

<!--- Delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New indexer definition
- [ ] Indexer deprecation
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor / maintenance (no functional change)
- [ ] This change requires a documentation update

## How has this been tested?

- [x] Manual replacement of the pk URL parameter with the correct key.
- [ ] Watchfolder action

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Was any AI used in this PR? Roughly how much of the code was AI-written, and what model/tool?

No.

## Miscellaneous

While this theoretically is a breaking change, the definition has not been in any stable branch
making the passkey > rsskey rename not that big of a deal imho.