### PR TITLE
feat(macros): add MetaTMDB field

### DIFF
--- a/internal/domain/macros.go
+++ b/internal/domain/macros.go
@@ -66,6 +66,7 @@ type Macro struct {
 	LogScore                  int
 	MagnetURI                 string
 	MetaIMDB                  string
+	MetaTMDB                  int
 	Origin                    string
 	Other                     []string
 	PreTime                   string
@@ -147,6 +148,7 @@ func NewMacro(release Release) Macro {
 		LogScore:                  release.LogScore,
 		MagnetURI:                 release.MagnetURI,
 		MetaIMDB:                  release.MetaIMDB,
+		MetaTMDB:                  release.MetaTMDB,
 		Origin:                    release.Origin,
 		Other:                     release.Other,
 		PreTime:                   release.PreTime,

--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -348,6 +348,7 @@ type WebhookRelease struct {
 	Seeders          int          `json:"seeders,omitempty"`
 	Leechers         int          `json:"leechers,omitempty"`
 	MetaIMDB         string       `json:"meta_imdb,omitempty"`
+	MetaTMDB         int          `json:"meta_tmdb,omitempty"`
 }
 
 // WebhookIndexer contains indexer information
@@ -468,6 +469,7 @@ func NewWebhookEvent(event NotificationEvent, payload NotificationPayload, id st
 			Seeders:          release.Seeders,
 			Leechers:         release.Leechers,
 			MetaIMDB:         release.MetaIMDB,
+			MetaTMDB:         release.MetaTMDB,
 		}
 	} else if payload.ReleaseName != "" {
 		// Fallback if full release object is missing but we have basic info in payload

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -114,6 +114,7 @@ type Release struct {
 	Filter                             *Filter               `json:"-"`
 	ActionStatus                       []ReleaseActionStatus `json:"action_status"`
 	MetaIMDB                           string                `json:"-"`
+	MetaTMDB                           int                   `json:"-"`
 }
 
 // Hash return md5 hashed normalized release name
@@ -1204,8 +1205,19 @@ func (r *Release) MapVars(varMap map[string]string, forceSizeUnit string) error 
 		r.Episode = episode
 	}
 
-	if metaImdb, err := getStringMapValue(varMap, "imdb"); err == nil {
-		r.MetaIMDB = metaImdb
+	if metaId, err := getStringMapValue(varMap, "imdb"); err == nil {
+		r.MetaIMDB = metaId
+		if !strings.HasPrefix(metaId, "tt") {
+			r.MetaIMDB = "tt" + metaId
+		} else {
+			r.MetaIMDB = metaId
+		}
+	}
+
+	if metaId, err := getStringMapValueAlt(varMap, "tmdb", "tmdbid"); err == nil {
+		if tmdbId, err := strconv.Atoi(metaId); err == nil {
+			r.MetaTMDB = tmdbId
+		}
 	}
 
 	return nil

--- a/internal/feed/newznab.go
+++ b/internal/feed/newznab.go
@@ -124,6 +124,14 @@ func (j *NewznabJob) processItems(items []newznab.FeedItem) ([]*domain.Release, 
 		rls.InfoURL = item.GUID
 
 		rls.ParseString(item.Title)
+
+		rls.MetaIMDB = item.ImdbId
+		if item.TmdbId != "" {
+			if tmdbId, err := strconv.Atoi(item.TmdbId); err == nil {
+				rls.MetaTMDB = tmdbId
+			}
+		}
+
 		rls.Size = item.Size
 
 		if item.Enclosure != nil && item.Enclosure.Type == "application/x-nzb" {

--- a/internal/feed/torznab.go
+++ b/internal/feed/torznab.go
@@ -162,6 +162,13 @@ func (j *TorznabJob) processItems(items []torznab.FeedItem) ([]*domain.Release, 
 		rls.Leechers = item.Leechers
 		rls.Uploader = item.Author
 
+		rls.MetaIMDB = item.ImdbId
+		if item.TmdbId != "" {
+			if tmdbId, err := strconv.Atoi(item.TmdbId); err == nil {
+				rls.MetaTMDB = tmdbId
+			}
+		}
+
 		// Get freeleech percentage between 0 - 100
 		if freeleechPercentage := parseFreeleechTorznab(item.DownloadVolumeFactor); freeleechPercentage >= 0 {
 			if freeleechPercentage == 100 {

--- a/internal/indexer/definitions/capybarabr.yaml
+++ b/internal/indexer/definitions/capybarabr.yaml
@@ -50,7 +50,7 @@ irc:
       parse:
         type: single
         lines:
-          - pattern: '\[(?P<category>.+?)\] \[(?P<releaseTags>.+?)\] (?:\[(?P<resolution>.+?)\] )?\[(?P<releaseName>.+?)\] \[(?P<baseUrl>https?:\/\/[^\/]+\/).+?(?P<torrentId>\d+)\] \[(?P<torrentSize>.+?)\] \[FL: (?P<freeleechPercent>.+?)\] \[INTERNAL: (?P<internal>.+?)\](?: \[tmdb-(?P<tags>\d+)\])?'
+          - pattern: '\[(?P<category>.+?)\] \[(?P<releaseTags>.+?)\] (?:\[(?P<resolution>.+?)\] )?\[(?P<releaseName>.+?)\] \[(?P<baseUrl>https?:\/\/[^\/]+\/).+?(?P<torrentId>\d+)\] \[(?P<torrentSize>.+?)\] \[FL: (?P<freeleechPercent>.+?)\] \[INTERNAL: (?P<internal>.+?)\](?: \[tmdb-(?P<tmdb>\d+)\])?'
             tests:
               - line: "[Series] [Encode] [576p] [A Barreira Ainda Não Virou Baile 2024 S02 576p DVDRip FLAC 2.0 x264 MULTI-SleepCOUTO] [https://capybarabr.com/torrents/15123] [25.36 GiB] [FL: 100%] [INTERNAL: 1] [tmdb-28136]"
                 expect:
@@ -63,7 +63,7 @@ irc:
                   torrentSize: 25.36 GiB
                   freeleechPercent: "100%"
                   internal: "1"
-                  tags: "28136"
+                  tmdb: "28136"
 
               - line: "[Cursos] [Saúde] [NOTSMART: Como ficar pobre [2022]] [https://capybarabr.com/torrents/15049] [6.76 GiB] [FL: 100%] [INTERNAL: 0]"
                 expect:
@@ -76,7 +76,7 @@ irc:
                   torrentSize: 6.76 GiB
                   freeleechPercent: "100%"
                   internal: "0"
-                  tags: ""
+                  tmdb: ""
 
               - line: "[Jogos] [PC] [Damas - FREE [MULTI]] [https://capybarabr.com/torrents/15046] [568.96 MiB] [FL: 50%] [INTERNAL: 0]"
                 expect:
@@ -89,7 +89,7 @@ irc:
                   torrentSize: 568.96 MiB
                   freeleechPercent: "50%"
                   internal: "0"
-                  tags: ""
+                  tmdb: ""
 
               - line: "[Esportes] [WEB-DL] [Rinha de Patos 1080p COMB WEB-DL AAC2.0 H.264 MULTI-LiberaARINHA] [https://capybarabr.com/torrents/8773] [6.06 GiB] [FL: 100%] [INTERNAL: 0]"
                 expect:
@@ -102,7 +102,7 @@ irc:
                   torrentSize: 6.06 GiB
                   freeleechPercent: "100%"
                   internal: "0"
-                  tags: ""
+                  tmdb: ""
 
               - line: "[Programas] [Arquitetura] [Castelos de areia 3D [PT-BR]] [https://capybarabr.com/torrents/13381] [4.48 GiB] [FL: 100%] [INTERNAL: 0]"
                 expect:
@@ -115,7 +115,7 @@ irc:
                   torrentSize: 4.48 GiB
                   freeleechPercent: "100%"
                   internal: "0"
-                  tags: ""
+                  tmdb: ""
 
               - line: "[HQs] [CBR] [Num seir le - Vol. 02 - FundoDeQuintal [2024]] [https://capybarabr.com/torrents/14021] [186.16 MiB] [FL: 0%] [INTERNAL: 0]"
                 expect:
@@ -128,7 +128,7 @@ irc:
                   torrentSize: 186.16 MiB
                   freeleechPercent: "0%"
                   internal: "0"
-                  tags: ""
+                  tmdb: ""
 
               - line: "[Revistas] [PDF] [Cavalos Voadores - Editora Quatro Cascos [2024]] [https://capybarabr.com/torrents/15094] [15.81 MiB] [FL: 0%] [INTERNAL: 0]"
                 expect:
@@ -141,7 +141,7 @@ irc:
                   torrentSize: 15.81 MiB
                   freeleechPercent: "0%"
                   internal: "0"
-                  tags: ""
+                  tmdb: ""
 
         match:
           infourl: "/torrents/{{ .torrentId }}"

--- a/internal/indexer/definitions/locadora.yaml
+++ b/internal/indexer/definitions/locadora.yaml
@@ -51,7 +51,7 @@ irc:
       parse:
         type: single
         lines:
-          - pattern: '\[(?P<category>.+)\] \[(?P<releaseTags>.+)\] \[(?P<resolution>.+)\] \[(?P<releaseName>.+?)\] \[(?P<baseUrl>https?\:\/\/.+\/).+\/(?P<torrentId>\d+)\] \[(?P<torrentSize>.+?)\] \[(?P<freeleechPercent>.+?)\] \[Internal:(?P<internal>\d)\] \[[a-z]+-(?P<tags>\d+)\]'
+          - pattern: '\[(?P<category>.+)\] \[(?P<releaseTags>.+)\] \[(?P<resolution>.+)\] \[(?P<releaseName>.+?)\] \[(?P<baseUrl>https?\:\/\/.+\/).+\/(?P<torrentId>\d+)\] \[(?P<torrentSize>.+?)\] \[(?P<freeleechPercent>.+?)\] \[Internal:(?P<internal>\d)\] \[[a-z]+-(?P<tmdb>\d+)\]'
             tests:
               - line: '[Filmes] [WEB-DL] [1080p] [Paul 2011 1080p AMZN WEB-DL DDP5.1 H.264 pt-BR ENG-LCD / Portuguese (BR) English (US)] [https://locadora.cc/torrents/28808] [7.61 GiB] [100%] [Internal:1] [tmdb-39513]'
                 expect:
@@ -64,7 +64,7 @@ irc:
                   torrentSize: 7.61 GiB
                   freeleechPercent: 100%
                   internal: "1"
-                  tags: "39513"
+                  tmdb: "39513"
 
         match:
           infourl: "/torrents/{{ .torrentId }}"

--- a/internal/indexer/definitions/samaritano.yaml
+++ b/internal/indexer/definitions/samaritano.yaml
@@ -50,7 +50,7 @@ irc:
       parse:
         type: single
         lines:
-          - pattern: '\[(?P<category>.+?)\] \[(?P<releaseTags>.+?)\] \[(?P<releaseName>.+?)\] \[TORRENT ID: (?P<torrentId>\d+)\] \[(?P<torrentSize>.+?)\](?: \[tmdb-(?P<tags>\d+)\])?'
+          - pattern: '\[(?P<category>.+?)\] \[(?P<releaseTags>.+?)\] \[(?P<releaseName>.+?)\] \[TORRENT ID: (?P<torrentId>\d+)\] \[(?P<torrentSize>.+?)\](?: \[tmdb-(?P<tmdb>\d+)\])?'
             tests:
               - line: "[Filmes] [WEB-DL] [Venom The Last Dance 2024 1080p HMAX WEB-DL DDP2.0 H.265 DUAL-Potatin] [TORRENT ID: 10837] [2.1 GiB] [tmdb-912649]"
                 expect:
@@ -59,7 +59,7 @@ irc:
                   releaseName: Venom The Last Dance 2024 1080p HMAX WEB-DL DDP2.0 H.265 DUAL-Potatin
                   torrentId: "10837"
                   torrentSize: "2.1 GiB"
-                  tags: 912649
+                  tmdb: 912649
 
               - line: "[Series] [WEB-DL] [The Continental From the World of John Wick S01 2160p AMZN WEB-DL DTS-HD MA 5.1 DV HDR H.265-BTBN] [TORRENT ID: 10840] [43.1 GiB] [tmdb-72710]"
                 expect:
@@ -68,7 +68,7 @@ irc:
                   releaseName: The Continental From the World of John Wick S01 2160p AMZN WEB-DL DTS-HD MA 5.1 DV HDR H.265-BTBN
                   torrentId: "10840"
                   torrentSize: "43.1 GiB"
-                  tags: 72710
+                  tmdb: 72710
 
         match:
           infourl: "/torrents/{{ .torrentId }}"

--- a/pkg/newznab/feed.go
+++ b/pkg/newznab/feed.go
@@ -166,7 +166,7 @@ func (f *FeedItem) parseAttributes() {
 				f.Files = int(parsedInt)
 				break
 			}
-		case "imdb":
+		case "imdb", "imdbid":
 			if f.ImdbId == "" {
 				if !strings.HasPrefix(attr.Value, "tt") {
 					f.ImdbId = "tt" + attr.Value
@@ -180,7 +180,7 @@ func (f *FeedItem) parseAttributes() {
 				f.TvdbId = attr.Value
 				break
 			}
-		case "tmdb":
+		case "tmdb", "tmdbid":
 			if f.TmdbId == "" {
 				f.TmdbId = attr.Value
 				break

--- a/pkg/torznab/feed.go
+++ b/pkg/torznab/feed.go
@@ -201,7 +201,7 @@ func (f *FeedItem) parseAttributes() {
 				f.UploadVolumeFactor = parsedFloat
 				break
 			}
-		case "imdb":
+		case "imdb", "imdbid":
 			if f.ImdbId == "" {
 				if !strings.HasPrefix(attr.Value, "tt") {
 					f.ImdbId = "tt" + attr.Value
@@ -215,7 +215,7 @@ func (f *FeedItem) parseAttributes() {
 				f.TvdbId = attr.Value
 				break
 			}
-		case "tmdb":
+		case "tmdb", "tmdbid":
 			if f.TmdbId == "" {
 				f.TmdbId = attr.Value
 				break


### PR DESCRIPTION
# Description

Adds a `MetaTMDB` field alongside the existing `MetaIMDB` so releases carry a TMDB ID, exposed as a new `MetaTMDB` macro and `meta_tmdb` webhook field.

- `Release.MetaTMDB` is populated from IRC-parsed `tmdb`/`tmdbid` vars and from Newznab/Torznab feed items' `imdb`/`imdbid`/`tmdb`/`tmdbid` attributes (feed parsing previously only recognized `imdb`/`tmdb`, not the `...id` variants).
- `MetaIMDB` parsing from IRC vars now consistently normalizes to the `tt`-prefixed form (previously only the feed parsers did this).
- Renamed the `tags` capture group to `tmdb` in the capybarabr, locadora, and samaritano indexer definitions so the TMDB ID is mapped correctly instead of landing in the generic `tags` field.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

* Ran `go test ./...` for the affected packages
* Verified updated indexer definition regex tests (capybarabr, locadora, samaritano) against their embedded test fixtures

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed
