### PR TITLE
feat(irc): optionally skip message cleaning

### DIFF
--- a/internal/irc/channel.go
+++ b/internal/irc/channel.go
@@ -101,8 +101,9 @@ type Channel struct {
 	// definition) that are allowed to announce in this channel. autobrr does not
 	// track the channel user list or announcer presence - it only validates that
 	// an announce line came from a known announcer.
-	announcers     map[string]struct{}
-	DefaultChannel bool
+	announcers       map[string]struct{}
+	DefaultChannel   bool
+	SkipCleanMessage bool
 
 	Messages *MessageBuffer
 
@@ -123,7 +124,7 @@ type ChannelSnapshot struct {
 	ConnectionErrors []string
 }
 
-func NewChannel(log zerolog.Logger, networkID int64, name string, defaultChannel bool, announceProcessor announce.Processor) *Channel {
+func NewChannel(log zerolog.Logger, networkID int64, name string, defaultChannel bool, skipCleanMessage bool, announceProcessor announce.Processor) *Channel {
 	return &Channel{
 		m:                 deadlock.RWMutex{},
 		log:               log.With().Str("channel", name).Logger(),
@@ -140,6 +141,7 @@ func NewChannel(log zerolog.Logger, networkID int64, name string, defaultChannel
 		inviteCommand:     "",
 		announcers:        make(map[string]struct{}),
 		DefaultChannel:    defaultChannel,
+		SkipCleanMessage:  skipCleanMessage,
 		announceProcessor: announceProcessor,
 		Messages:          NewMessageBuffer(1000), // make opt-in?
 	}
@@ -155,8 +157,11 @@ func (c *Channel) OnMsg(msg ircmsg.Message) {
 	//channel := msg.Params[0]
 	message := msg.Params[1]
 
-	// clean message
-	cleanedMsg := cleanMessage(message)
+	// optionally skip clean message
+	cleanedMsg := message
+	if !c.SkipCleanMessage {
+		cleanedMsg = cleanMessage(message)
+	}
 
 	// Add message to history, maintaining maximum size
 	newMsg := domain.IrcMessage{
@@ -172,7 +177,6 @@ func (c *Channel) OnMsg(msg ircmsg.Message) {
 	// check if the message is from announce bot, if not return
 	if !c.IsValidAnnouncer(nick) {
 		c.log.Trace().Str("nick", nick).Str("msg", cleanedMsg).Msg("not a valid announcer, ignoring")
-
 		return
 	}
 

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -184,7 +184,12 @@ func (h *Handler) InitIndexers(definitions []*domain.IndexerDefinition) {
 				continue
 			}
 
-			ircChannel := NewChannel(h.log, network.ID, channelName, true, announce.NewAnnounceProcessor(h.log.With().Str("channel", channelName).Logger(), h.releaseSvc, definition))
+			skipCleanMessage := false
+			if channel.Parse != nil {
+				skipCleanMessage = channel.Parse.SkipCleanMessage
+			}
+
+			ircChannel := NewChannel(h.log, network.ID, channelName, true, skipCleanMessage, announce.NewAnnounceProcessor(h.log.With().Str("channel", channelName).Logger(), h.releaseSvc, definition))
 			ircChannel.SetStateMachine(NewChannelStateMachine(ircChannel, h, inviteCommand))
 			ircChannel.SetInviteCommand(inviteCommand)
 
@@ -209,7 +214,7 @@ func (h *Handler) InitIndexers(definitions []*domain.IndexerDefinition) {
 				continue
 			}
 
-			ircChannel := NewChannel(h.log, network.ID, channelName, false, nil)
+			ircChannel := NewChannel(h.log, network.ID, channelName, false, false, nil)
 			ircChannel.Configure(channel.ID, channel.Enabled, channel.Password)
 			ircChannel.SetStateMachine(NewChannelStateMachine(ircChannel, h, ""))
 
@@ -1063,7 +1068,7 @@ func (h *Handler) AddChannel(channel domain.IrcChannel) {
 	ircChannel, found := h.channels.Get(channelName)
 	if !found {
 		// a user-defined extra channel has no indexer announce processor
-		ircChannel = NewChannel(h.log, h.GetNetwork().ID, channelName, false, nil)
+		ircChannel = NewChannel(h.log, h.GetNetwork().ID, channelName, false, false, nil)
 		ircChannel.SetStateMachine(NewChannelStateMachine(ircChannel, h, ""))
 		h.channels.Set(channelName, ircChannel)
 	}

--- a/internal/irc/health_test.go
+++ b/internal/irc/health_test.go
@@ -19,11 +19,11 @@ func TestComputeHealthy(t *testing.T) {
 	h, _ := newTestHandler()
 	h.stateMachine.currentState = StateFullyOperational
 
-	announce := NewChannel(zerolog.Nop(), h.network.ID, "#announce", true, nil) // default
+	announce := NewChannel(zerolog.Nop(), h.network.ID, "#announce", true, false, nil) // default
 	announce.SetMonitoring()
 	h.channels.Set(announce.Name, announce)
 
-	extra := NewChannel(zerolog.Nop(), h.network.ID, "#extra", false, nil) // user-added
+	extra := NewChannel(zerolog.Nop(), h.network.ID, "#extra", false, false, nil) // user-added
 	extra.SetConnectionError("could not join #extra: wrong or missing channel password (+k)")
 	h.channels.Set(extra.Name, extra)
 
@@ -43,7 +43,7 @@ func TestComputeHealthy_ConnectionUnhealthy(t *testing.T) {
 	h, _ := newTestHandler()
 	h.stateMachine.currentState = StateError
 
-	announce := NewChannel(zerolog.Nop(), h.network.ID, "#announce", true, nil)
+	announce := NewChannel(zerolog.Nop(), h.network.ID, "#announce", true, false, nil)
 	announce.SetMonitoring()
 	h.channels.Set(announce.Name, announce)
 
@@ -59,11 +59,11 @@ func TestStateEventCarriesHealth(t *testing.T) {
 	h, sse := newTestHandler()
 	h.stateMachine.currentState = StateFullyOperational
 
-	announce := NewChannel(zerolog.Nop(), h.network.ID, "#announce", true, nil)
+	announce := NewChannel(zerolog.Nop(), h.network.ID, "#announce", true, false, nil)
 	announce.SetMonitoring()
 	h.channels.Set(announce.Name, announce)
 
-	extra := NewChannel(zerolog.Nop(), h.network.ID, "#extra", false, nil)
+	extra := NewChannel(zerolog.Nop(), h.network.ID, "#extra", false, false, nil)
 	sm := NewChannelStateMachine(extra, h, "")
 	extra.SetStateMachine(sm)
 	sm.state = ChannelStateJoining

--- a/internal/irc/invite_failed_test.go
+++ b/internal/irc/invite_failed_test.go
@@ -25,7 +25,7 @@ const testInviteGrace = 20 * time.Millisecond
 // Joining transition that a config change would. The invite-response grace is
 // shortened so tests resolve quickly.
 func addAwaitingInviteChannel(h *Handler, name, inviteCommand string) *ChannelStateMachine {
-	ch := NewChannel(zerolog.Nop(), h.network.ID, name, true, nil)
+	ch := NewChannel(zerolog.Nop(), h.network.ID, name, true, false, nil)
 	ch.inviteCommand = inviteCommand
 	sm := NewChannelStateMachine(ch, h, inviteCommand)
 	sm.inviteResponseGrace = testInviteGrace
@@ -384,7 +384,7 @@ func TestInviteTimeoutDefersToGraceAfterBotResponse(t *testing.T) {
 func TestNetworkRecoversFromErrorWhenChannelMonitors(t *testing.T) {
 	h, _ := newTestHandler()
 
-	ch := NewChannel(zerolog.Nop(), h.network.ID, "#chan", true, nil)
+	ch := NewChannel(zerolog.Nop(), h.network.ID, "#chan", true, false, nil)
 	sm := NewChannelStateMachine(ch, h, "")
 	ch.SetStateMachine(sm)
 	ch.SetConnectionError("could not join")

--- a/internal/irc/reconnect_test.go
+++ b/internal/irc/reconnect_test.go
@@ -117,7 +117,7 @@ func newTestHandler() (*Handler, *mockSSEServer) {
 // addMonitoredChannel registers a channel that is already joined and being
 // monitored, i.e. the steady state right before a connection drop.
 func addMonitoredChannel(h *Handler, name, inviteCommand string) *ChannelStateMachine {
-	ch := NewChannel(zerolog.Nop(), h.network.ID, name, true, nil)
+	ch := NewChannel(zerolog.Nop(), h.network.ID, name, true, false, nil)
 	sm := NewChannelStateMachine(ch, h, inviteCommand)
 	ch.SetStateMachine(sm)
 	h.channels.Set(ch.Name, ch)

--- a/internal/irc/recovery_test.go
+++ b/internal/irc/recovery_test.go
@@ -12,7 +12,7 @@ import (
 
 // newIdleSM builds a fresh Idle channel state machine (not yet monitoring).
 func newIdleSM(h *Handler, name, invite string) *ChannelStateMachine {
-	ch := NewChannel(zerolog.Nop(), h.network.ID, name, true, nil)
+	ch := NewChannel(zerolog.Nop(), h.network.ID, name, true, false, nil)
 	sm := NewChannelStateMachine(ch, h, invite)
 	ch.SetStateMachine(sm)
 	h.channels.Set(ch.Name, ch)


### PR DESCRIPTION
# Description

This PR wires up an option that was added during the indexer definitions v2 work in #2502.

The new `skipcleanmessage` option of irc channel parse settings now controls if the message should skip the default clean function and instead use the raw announce which can use useful on for example #817 for improved parsing when the announces include special characters.

```yaml
irc:
  channels:
    - name: "#test_announce"
      announcers:
        - _AnnounceBot_
      parse:
        type: single
        skipcleanmessage: true
        lines:
          - pattern: New Torrent Announcement:\s*<(?P<category>[^>]*)>\s*Name:'(?P<releaseName>.*)' uploaded by '(?P<uploader>[^']*)'\s*(?P<freeleech>freeleech)*\s*-\s*(?P<baseUrl>https?\:\/\/[^\/]+\/)torrent\/(?P<torrentId>\d+)
            tests:
              - line: "New Torrent Announcement: <PC :: Iso>  Name:'debian live 10 6 0 amd64 standard iso' uploaded by 'Anonymous' -  http://localhost:3999/torrent/000000"
                expect:
                  category: "PC :: Iso"
                  releaseName: "debian live 10 6 0 amd64 standard iso"
                  uploader: "Anonymous"
                  freeleech:
                  baseUrl: http://localhost:3999/
                  torrentId: "000000"
```

Fixes #817

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

* Manually with mockindexer

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed
