### PR TITLE
fix(indexers): GGn IRC parser

### DIFF
--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -136,7 +136,6 @@ func (i *IndexerDefinition) Prepare() {
 				ch.Parse.parser = IRCParserRedacted{}
 			default:
 				ch.Parse.parser = DefaultIRCParser
-
 			}
 
 			// key by lowercase channel name: the IRC and announce layers

--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -121,13 +121,27 @@ func (i *IndexerDefinition) Prepare() {
 		i.IRC.ChannelsMap = map[string]*IndexerIRCV2Channel{}
 
 		for _, channel := range i.IRC.Channels {
-			// key by lowercase channel name: the IRC and announce layers
-			// canonicalize channel names to lowercase, so lookups use lowercase.
-			i.IRC.ChannelsMap[strings.ToLower(channel.Name)] = &IndexerIRCV2Channel{
+			ch := &IndexerIRCV2Channel{
 				Name:       channel.Name,
 				Announcers: channel.Announcers,
 				Parse:      channel.Parse,
 			}
+
+			switch i.Identifier {
+			case "ggn":
+				ch.Parse.parser = IRCParserGazelleGames{}
+			case "ops":
+				ch.Parse.parser = IRCParserOrpheus{}
+			case "redacted":
+				ch.Parse.parser = IRCParserRedacted{}
+			default:
+				ch.Parse.parser = DefaultIRCParser
+
+			}
+
+			// key by lowercase channel name: the IRC and announce layers
+			// canonicalize channel names to lowercase, so lookups use lowercase.
+			i.IRC.ChannelsMap[strings.ToLower(channel.Name)] = ch
 		}
 	}
 }
@@ -246,6 +260,17 @@ func (i *IndexerDefinitionCustom) ToIndexerDefinition() *IndexerDefinition {
 				},
 			}
 
+			switch i.Identifier {
+			case "ggn":
+				channel.Parse.parser = IRCParserGazelleGames{}
+			case "ops":
+				channel.Parse.parser = IRCParserOrpheus{}
+			case "redacted":
+				channel.Parse.parser = IRCParserRedacted{}
+			default:
+				channel.Parse.parser = DefaultIRCParser
+			}
+
 			d.IRC.Channels = append(d.IRC.Channels, channel)
 			d.IRC.ChannelsMap[strings.ToLower(channelName)] = &channel
 		}
@@ -296,6 +321,26 @@ type FeedSettings struct {
 	Settings    []IndexerSetting `json:"settings"`
 }
 
+/*
+Indexer definition v1 / custom / legacy
+*/
+
+type IndexerIRCParse struct {
+	Type          string                `json:"type"`
+	ForceSizeUnit string                `json:"forcesizeunit"`
+	Lines         []IndexerIRCParseLine `json:"lines"`
+	Match         IndexerIRCParseMatch  `json:"match"`
+	Mappings      IRCMappings           `json:"mappings"`
+}
+
+type IndexerIRCParseMatch struct {
+	TorrentURL  string   `json:"torrenturl"`
+	TorrentName string   `json:"torrentname"`
+	MagnetURI   string   `json:"magneturi"`
+	InfoURL     string   `json:"infourl"`
+	Encode      []string `json:"encode"`
+}
+
 type IndexerIRC struct {
 	Network     string            `json:"network"`
 	Server      string            `json:"server"`
@@ -342,6 +387,8 @@ type IndexerIRCV2Parse struct {
 	Lines            []IndexerIRCParseLine  `json:"lines"`
 	Match            IndexerIRCV2ParseMatch `json:"match"`
 	Mappings         IRCMappings            `json:"mappings"`
+
+	parser IRCParser
 }
 
 type IndexerIRCV2ParseMatch struct {
@@ -350,14 +397,6 @@ type IndexerIRCV2ParseMatch struct {
 	MagnetURI   string   `json:"magnetURI"`
 	InfoURL     string   `json:"infoURL"`
 	Encode      []string `json:"encode"`
-}
-
-type IndexerIRCParse struct {
-	Type          string                `json:"type"`
-	ForceSizeUnit string                `json:"forcesizeunit"`
-	Lines         []IndexerIRCParseLine `json:"lines"`
-	Match         IndexerIRCParseMatch  `json:"match"`
-	Mappings      IRCMappings           `json:"mappings"`
 }
 
 type LineTest struct {
@@ -478,14 +517,6 @@ func parseLineMatchRegexp(pattern string, tmpVars map[string]string, line string
 	}
 
 	return true, nil
-}
-
-type IndexerIRCParseMatch struct {
-	TorrentURL  string   `json:"torrenturl"`
-	TorrentName string   `json:"torrentname"`
-	MagnetURI   string   `json:"magneturi"`
-	InfoURL     string   `json:"infourl"`
-	Encode      []string `json:"encode"`
 }
 
 func parseTemplateURL(baseURL, sourceURL string, vars map[string]string, basename string) (*url.URL, error) {
@@ -671,163 +702,7 @@ func (p *IndexerIRCV2Parse) Parse(def *IndexerDefinition, channelName string, va
 		return errors.Wrap(err, "could not parse release name")
 	}
 
-	var parser IRCParser
-
-	switch def.Identifier {
-	case "ggn":
-		parser = IRCParserGazelleGames{}
-	case "ops":
-		parser = IRCParserOrpheus{}
-	case "redacted":
-		parser = IRCParserRedacted{}
-	default:
-		parser = IRCParserDefault{}
-	}
-
-	if err := parser.Parse(rls, vars); err != nil {
-		return errors.Wrap(err, "could not parse release")
-	}
-
-	if v, ok := def.SettingsMap["cookie"]; ok {
-		rls.RawCookie = v
-	}
-
-	return nil
-}
-
-/*
- indexer definition v1
-*/
-
-func (p *IndexerIRCParseMatch) ParseURLs(baseURL string, vars map[string]string, rls *Release) error {
-	// handle url encode of values
-	for _, e := range p.Encode {
-		if v, ok := vars[e]; ok {
-			// url encode  value
-			t := url.QueryEscape(v)
-			vars[e] = t
-		}
-	}
-
-	if p.InfoURL != "" {
-		infoURL, err := parseTemplateURL(baseURL, p.InfoURL, vars, "infourl")
-		if err != nil {
-			return err
-		}
-
-		rls.InfoURL = infoURL.String()
-	}
-
-	if p.TorrentURL != "" {
-		downloadURL, err := parseTemplateURL(baseURL, p.TorrentURL, vars, "torrenturl")
-		if err != nil {
-			return err
-		}
-
-		rls.DownloadURL = downloadURL.String()
-	}
-
-	if p.MagnetURI != "" {
-		magnetURI, err := parseTemplateURL("magnet:", p.MagnetURI, vars, "magneturi")
-		if err != nil {
-			return err
-		}
-
-		rls.MagnetURI = magnetURI.String()
-	}
-
-	return nil
-}
-
-func (p *IndexerIRCParseMatch) ParseTorrentName(vars map[string]string, rls *Release) error {
-	if p.TorrentName != "" {
-		// setup text template to inject variables into
-		tmplName, err := template.New("torrentname").Funcs(sprig.TxtFuncMap()).Parse(p.TorrentName)
-		if err != nil {
-			return err
-		}
-
-		var nameBytes bytes.Buffer
-		if err := tmplName.Execute(&nameBytes, &vars); err != nil {
-			return errors.New("could not write torrent name template output")
-		}
-
-		rls.TorrentName = nameBytes.String()
-	}
-
-	return nil
-}
-
-func (p *IndexerIRCParse) MapCustomVariables(vars map[string]string) error {
-	for varsKey, varsKeyMap := range p.Mappings {
-		varsValue, ok := vars[varsKey]
-		if !ok {
-			continue
-		}
-
-		keyValueMap, ok := varsKeyMap[varsValue]
-		if !ok {
-			continue
-		}
-
-		for k, v := range keyValueMap {
-			vars[k] = v
-		}
-	}
-
-	return nil
-}
-
-func (p *IndexerIRCParse) Parse(def *IndexerDefinition, vars map[string]string, rls *Release) error {
-	channel, ok := def.IRC.ChannelsMap[""]
-	if !ok {
-		return errors.New("could not find default channel")
-	}
-
-	if err := p.MapCustomVariables(vars); err != nil {
-		return errors.Wrap(err, "could not map custom variables for release")
-	}
-
-	if err := rls.MapVars(vars, channel.Parse.ForceSizeUnit); err != nil {
-		return errors.Wrap(err, "could not map variables for release")
-	}
-
-	// merge vars from regex captures on announce and vars from settings
-	mergedVars := mergeVars(vars, def.SettingsMap)
-
-	baseUrl := def.BaseURL
-	if baseUrl == "" {
-		if len(def.URLS) == 0 {
-			return errors.New("could not find a valid indexer baseUrl")
-		}
-
-		baseUrl = def.URLS[0]
-	}
-
-	// parse urls
-	if err := channel.Parse.Match.ParseURLs(baseUrl, mergedVars, rls); err != nil {
-		return errors.Wrap(err, "could not parse urls for release")
-	}
-
-	// parse torrent name
-	if err := channel.Parse.Match.ParseTorrentName(mergedVars, rls); err != nil {
-		return errors.Wrap(err, "could not parse release name")
-	}
-
-	var parser IRCParser
-
-	switch def.Identifier {
-	case "ggn":
-		parser = IRCParserGazelleGames{}
-	case "ops":
-		parser = IRCParserOrpheus{}
-	case "redacted":
-		parser = IRCParserRedacted{}
-	default:
-		parser = IRCParserDefault{}
-	}
-
-	if err := parser.Parse(rls, vars); err != nil {
+	if err := p.parser.Parse(rls, vars); err != nil {
 		return errors.Wrap(err, "could not parse release")
 	}
 

--- a/internal/domain/indexer_test.go
+++ b/internal/domain/indexer_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
+func TestIndexerIRCV2ParseMatch_ParseUrls(t *testing.T) {
 	t.Parallel()
 	type fields struct {
-		TorrentURL  string
-		TorrentName string
+		ReleaseName string
+		DownloadURL string
 		MagnetURI   string
 		InfoURL     string
 		Encode      []string
@@ -32,14 +32,14 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 		{
 			name: "",
 			fields: fields{
-				TorrentURL: "rss/download/{{ .torrentId }}/{{ .rsskey }}/{{ .torrentName }}.torrent",
-				Encode:     []string{"torrentName"},
+				DownloadURL: "rss/download/{{ .torrentId }}/{{ .rsskey }}/{{ .releaseName }}.torrent",
+				Encode:      []string{"releaseName"},
 			},
 			args: args{
 				baseURL: "https://mock.local/",
 				vars: map[string]string{
 					"category":    "TV :: Episodes HD",
-					"torrentName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
+					"releaseName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
 					"uploader":    "Anonymous",
 					"freeleech":   "",
 					"baseUrl":     "https://mock.local/",
@@ -55,13 +55,13 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 		{
 			name: "",
 			fields: fields{
-				TorrentURL: "/torrent/{{ .torrentId }}/download/{{ .passkey }}",
-				Encode:     nil,
+				DownloadURL: "/torrent/{{ .torrentId }}/download/{{ .passkey }}",
+				Encode:      nil,
 			},
 			args: args{
 				baseURL: "https://mock.local/",
 				vars: map[string]string{
-					"torrentName":    "Great BluRay SoftSubbed Anime",
+					"releaseName":    "Great BluRay SoftSubbed Anime",
 					"category":       "TV Series",
 					"year":           "2020",
 					"releaseTags":    "Blu-ray / MKV / h264 10-bit / 1080p / FLAC 2.0 / Dual Audio / Softsubs (Sub Group) / Freeleech",
@@ -83,14 +83,14 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 		{
 			name: "",
 			fields: fields{
-				TorrentURL: "{{ .baseUrl }}rss/download/{{ .torrentId }}/{{ .rsskey }}/{{ .torrentName }}.torrent",
-				Encode:     []string{"torrentName"},
+				DownloadURL: "{{ .baseUrl }}rss/download/{{ .torrentId }}/{{ .rsskey }}/{{ .releaseName }}.torrent",
+				Encode:      []string{"releaseName"},
 			},
 			args: args{
 				baseURL: "https://mock.local/",
 				vars: map[string]string{
 					"category":    "TV :: Episodes HD",
-					"torrentName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
+					"releaseName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
 					"uploader":    "Anonymous",
 					"freeleech":   "",
 					"baseUrl":     "https://mock.local/",
@@ -106,14 +106,14 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 		{
 			name: "",
 			fields: fields{
-				TorrentURL: "https://mock.local/rss/download/{{ .torrentId }}/{{ .rsskey }}/{{ .torrentName }}.torrent",
-				Encode:     []string{"torrentName"},
+				DownloadURL: "https://mock.local/rss/download/{{ .torrentId }}/{{ .rsskey }}/{{ .releaseName }}.torrent",
+				Encode:      []string{"releaseName"},
 			},
 			args: args{
 				baseURL: "https://mock.local/",
 				vars: map[string]string{
 					"category":    "TV :: Episodes HD",
-					"torrentName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
+					"releaseName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
 					"uploader":    "Anonymous",
 					"freeleech":   "",
 					"baseUrl":     "https://mock.local/",
@@ -129,14 +129,14 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 		{
 			name: "",
 			fields: fields{
-				TorrentURL: "/rss/?action=download&key={{ .key }}&token={{ .token }}&hash={{ .torrentId }}&title={{ .torrentName }}",
-				Encode:     []string{"torrentName"},
+				DownloadURL: "/rss/?action=download&key={{ .key }}&token={{ .token }}&hash={{ .torrentId }}&title={{ .releaseName }}",
+				Encode:      []string{"releaseName"},
 			},
 			args: args{
 				baseURL: "https://mock.local/",
 				vars: map[string]string{
 					"category":    "Movies/Remux",
-					"torrentName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
+					"releaseName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
 					"uploader":    "Anonymous",
 					"torrentSize": "",
 					"baseUrl":     "https://mock.local/",
@@ -154,12 +154,12 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 		{
 			name: "magnet_uri",
 			fields: fields{
-				MagnetURI: "magnet:?xt=urn:btih:{{ .torrentHash }}&dn={{ urlquery .torrentName }}",
+				MagnetURI: "magnet:?xt=urn:btih:{{ .torrentHash }}&dn={{ urlquery .releaseName }}",
 			},
 			args: args{
 				vars: map[string]string{
 					"torrentHash": "81c758d0eca5372d59e43879ecf2e2bce33a06c4",
-					"torrentName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
+					"releaseName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
 				},
 				rls: &Release{},
 			},
@@ -170,9 +170,9 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &IndexerIRCParseMatch{
-				TorrentURL:  tt.fields.TorrentURL,
-				TorrentName: tt.fields.TorrentName,
+			p := &IndexerIRCV2ParseMatch{
+				ReleaseName: tt.fields.ReleaseName,
+				DownloadURL: tt.fields.DownloadURL,
 				MagnetURI:   tt.fields.MagnetURI,
 				InfoURL:     tt.fields.InfoURL,
 				Encode:      tt.fields.Encode,
@@ -184,11 +184,11 @@ func TestIndexerIRCParseMatch_ParseUrls(t *testing.T) {
 	}
 }
 
-func TestIndexerIRCParseMatch_ParseTorrentName(t *testing.T) {
+func TestIndexerIRCV2ParseMatch_ParseTorrentName(t *testing.T) {
 	t.Parallel()
 	type fields struct {
-		TorrentURL  string
-		TorrentName string
+		ReleaseName string
+		DownloadURL string
 		InfoURL     string
 		Encode      []string
 	}
@@ -205,11 +205,11 @@ func TestIndexerIRCParseMatch_ParseTorrentName(t *testing.T) {
 		{
 			name: "",
 			fields: fields{
-				TorrentName: "",
+				ReleaseName: "",
 			},
 			args: args{
 				vars: map[string]string{
-					"torrentName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
+					"releaseName": "The Show 2019 S03E08 2160p DV WEBRip 6CH x265 HEVC-GROUP",
 				},
 				rls: &Release{},
 			},
@@ -220,11 +220,11 @@ func TestIndexerIRCParseMatch_ParseTorrentName(t *testing.T) {
 		{
 			name: "",
 			fields: fields{
-				TorrentName: `{{ if .releaseGroup }}[{{ .releaseGroup }}] {{ end }}{{ .torrentName }} [{{ .year }}] {{ if .releaseEpisode }}{{ printf "- %02s " .releaseEpisode }}{{ end }}{{ print "[" .releaseTags "]" | replace " / " "][" }}`,
+				ReleaseName: `{{ if .releaseGroup }}[{{ .releaseGroup }}] {{ end }}{{ .releaseName }} [{{ .year }}] {{ if .releaseEpisode }}{{ printf "- %02s " .releaseEpisode }}{{ end }}{{ print "[" .releaseTags "]" | replace " / " "][" }}`,
 			},
 			args: args{
 				vars: map[string]string{
-					"torrentName":    "Great BluRay SoftSubbed Anime",
+					"releaseName":    "Great BluRay SoftSubbed Anime",
 					"category":       "TV Series",
 					"year":           "2020",
 					"releaseTags":    "Blu-ray / MKV / h264 10-bit / 1080p / FLAC 2.0 / Dual Audio / Softsubs (Sub Group) / Freeleech",
@@ -246,123 +246,20 @@ func TestIndexerIRCParseMatch_ParseTorrentName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &IndexerIRCParseMatch{
-				TorrentURL:  tt.fields.TorrentURL,
-				TorrentName: tt.fields.TorrentName,
+			p := &IndexerIRCV2ParseMatch{
+				ReleaseName: tt.fields.ReleaseName,
+				DownloadURL: tt.fields.DownloadURL,
 				InfoURL:     tt.fields.InfoURL,
 				Encode:      tt.fields.Encode,
 			}
-			p.ParseTorrentName(tt.args.vars, tt.args.rls)
+			err := p.ParseTorrentName(tt.args.vars, tt.args.rls)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, tt.args.rls)
 		})
 	}
 }
 
-func TestIndexerIRCParse_MapCustomVariables1(t *testing.T) {
-	type fields struct {
-		Type          string
-		ForceSizeUnit string
-		Lines         []IndexerIRCParseLine
-		Match         IndexerIRCParseMatch
-		Mappings      IRCMappings
-	}
-	type args struct {
-		vars       map[string]string
-		expectVars map[string]string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "",
-			fields: fields{
-				Mappings: map[string]map[string]map[string]string{
-					"announceType": {
-						"0": map[string]string{
-							"announceType": "NEW",
-						},
-						"1": map[string]string{
-							"announceType": "PROMO",
-						},
-					},
-					"categoryEnum": {
-						"0": map[string]string{
-							"category": "Feature Film",
-						},
-						"1": map[string]string{
-							"category": "Short Film",
-						},
-						"2": map[string]string{
-							"category": "Miniseries",
-						},
-						"3": map[string]string{
-							"category": "Stand-up Comedy",
-						},
-						"4": map[string]string{
-							"category": "Live Performance",
-						},
-						"5": map[string]string{
-							"category": "Movie Collection",
-						},
-					},
-					"freeleechEnum": {
-						"0": map[string]string{
-							"downloadVolumeFactor": "1.0",
-							"uploadVolumeFactor":   "1.0",
-						},
-						"1": map[string]string{
-							"downloadVolumeFactor": "0",
-							"uploadVolumeFactor":   "1.0",
-						},
-						"2": map[string]string{
-							"downloadVolumeFactor": "0.5",
-							"uploadVolumeFactor":   "1.0",
-						},
-						"3": map[string]string{
-							"downloadVolumeFactor": "0",
-							"uploadVolumeFactor":   "0",
-						},
-					},
-				},
-			},
-			args: args{
-				vars: map[string]string{
-					"announceType":  "1",
-					"categoryEnum":  "0",
-					"freeleechEnum": "1",
-				},
-				expectVars: map[string]string{
-					"announceType":         "PROMO",
-					"category":             "Feature Film",
-					"categoryEnum":         "0",
-					"freeleechEnum":        "1",
-					"downloadVolumeFactor": "0",
-					"uploadVolumeFactor":   "1.0",
-				},
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			p := &IndexerIRCParse{
-				Type:          tt.fields.Type,
-				ForceSizeUnit: tt.fields.ForceSizeUnit,
-				Lines:         tt.fields.Lines,
-				Match:         tt.fields.Match,
-				Mappings:      tt.fields.Mappings,
-			}
-			err := p.MapCustomVariables(tt.args.vars)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.args.expectVars, tt.args.vars)
-		})
-	}
-}
-
-func TestIndexerIRCV2Parse_MapCustomVariables1(t *testing.T) {
+func TestIndexerIRCV2Parse_MapCustomVariables(t *testing.T) {
 	type fields struct {
 		Type          string
 		ForceSizeUnit string

--- a/internal/domain/irc_parser.go
+++ b/internal/domain/irc_parser.go
@@ -10,6 +10,8 @@ type IRCParser interface {
 	Parse(rls *Release, vars map[string]string) error
 }
 
+var DefaultIRCParser IRCParser = IRCParserDefault{}
+
 type IRCParserDefault struct{}
 
 func (p IRCParserDefault) Parse(rls *Release, _ map[string]string) error {
@@ -27,7 +29,11 @@ var ggnSwitchWindowsRegex = regexp.MustCompile(`^(?P<releaseName>.+?)(?:\s*-\s*(
 var ggnWindowsFallback = regexp.MustCompile(`^(?P<releaseName>.+?)(?:\s*-\s*(?P<version>Version\s.+))?$`)
 
 func (p IRCParserGazelleGames) Parse(rls *Release, vars map[string]string) error {
-	torrentName := vars["torrentName"]
+	torrentName, ok := vars["releaseName"]
+	if !ok {
+		return fmt.Errorf("ggn irc parser: releaseName is missing from vars")
+	}
+
 	category := vars["category"]
 
 	releaseName := ""
@@ -92,7 +98,7 @@ var lastDecimalTag = regexp.MustCompile(`^\d{1,2}$|^100$`)
 func (p IRCParserOrpheus) Parse(rls *Release, vars map[string]string) error {
 	// OPS uses en-dashes as separators, which causes moistari/rls to not parse the torrentName properly,
 	// we replace the en-dashes with hyphens here
-	torrentName := p.replaceSeparator(vars["torrentName"])
+	//torrentName := p.replaceSeparator(vars["releaseName"])
 	title := p.replaceSeparator(vars["title"])
 
 	year := vars["year"]
@@ -137,12 +143,12 @@ func (p IRCParserOrpheus) Parse(rls *Release, vars map[string]string) error {
 	rls.HasCue = tags.HasCue
 
 	// Construct new release name so we have full control. We remove category such as EP/Single/Album because EP is being mis-parsed.
-	torrentName = fmt.Sprintf("%s [%s] (%s)", title, year, strings.Join(audio, " "))
+	releaseName := fmt.Sprintf("%s [%s] (%s)", title, year, strings.Join(audio, " "))
 
-	rls.ParseString(torrentName)
+	rls.ParseString(releaseName)
 
 	// use parsed values from raw rls.Release struct
-	raw := rls.Raw(torrentName)
+	raw := rls.Raw(releaseName)
 	rls.Artists = raw.Artist
 	rls.Title = raw.Title
 

--- a/internal/domain/irc_parser_test.go
+++ b/internal/domain/irc_parser_test.go
@@ -26,7 +26,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Trouble.in.Paradise-GROUP in Trouble in Paradise",
+					"releaseName": "Trouble.in.Paradise-GROUP in Trouble in Paradise",
 				},
 			},
 			want: want{
@@ -39,7 +39,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "F.I.L.F. Game Walkthrough v.0.18 in F.I.L.F.",
+					"releaseName": "F.I.L.F. Game Walkthrough v.0.18 in F.I.L.F.",
 				},
 			},
 			want: want{
@@ -52,7 +52,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Ni no Kuni: Dominion of the Dark Djinn in Ni no Kuni: Dominion of the Dark Djinn",
+					"releaseName": "Ni no Kuni: Dominion of the Dark Djinn in Ni no Kuni: Dominion of the Dark Djinn",
 				},
 			},
 			want: want{
@@ -65,7 +65,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Year 2 Remastered by Insaneintherainmusic",
+					"releaseName": "Year 2 Remastered by Insaneintherainmusic",
 					"category":    "OST",
 				},
 			},
@@ -79,7 +79,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Lanota - Version 2.23.1 in Lanota",
+					"releaseName": "Lanota - Version 2.23.1 in Lanota",
 					"category":    "iOS",
 				},
 			},
@@ -93,7 +93,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "After Inc. - Version 1.7.1",
+					"releaseName": "After Inc. - Version 1.7.1",
 					"category":    "iOS",
 				},
 			},
@@ -107,7 +107,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Through the Ages - Version 2.19.1128",
+					"releaseName": "Through the Ages - Version 2.19.1128",
 					"category":    "iOS",
 				},
 			},
@@ -121,7 +121,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Through the Ages - Version 2.19.1128 in Through the Ages",
+					"releaseName": "Through the Ages - Version 2.19.1128 in Through the Ages",
 					"category":    "iOS",
 				},
 			},
@@ -135,7 +135,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Asphalt 8: Airborne+ - Version 2.6.0b in Asphalt 8: Airborne",
+					"releaseName": "Asphalt 8: Airborne+ - Version 2.6.0b in Asphalt 8: Airborne",
 					"category":    "iOS",
 				},
 			},
@@ -149,7 +149,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Through the Ages - Version 2025-10-12 in Group",
+					"releaseName": "Through the Ages - Version 2025-10-12 in Group",
 					"category":    "iOS",
 				},
 			},
@@ -163,7 +163,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Korean_Drone_Flying_Tour_Han_River_NSW-SUXXORS in Korean Drone Flying Tour Han River",
+					"releaseName": "Korean_Drone_Flying_Tour_Han_River_NSW-SUXXORS in Korean Drone Flying Tour Han River",
 					"category":    "Switch",
 				},
 			},
@@ -177,7 +177,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Carmen_Sandiego_Update_v1.4.0_NSW-VENOM - Update - Version 1.4.0 in Carmen Sandiego",
+					"releaseName": "Carmen_Sandiego_Update_v1.4.0_NSW-VENOM - Update - Version 1.4.0 in Carmen Sandiego",
 					"category":    "Switch",
 				},
 			},
@@ -191,7 +191,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Colin McRae Rally 3 - Version 1.1 in Colin McRae Rally 3",
+					"releaseName": "Colin McRae Rally 3 - Version 1.1 in Colin McRae Rally 3",
 					"category":    "Windows",
 				},
 			},
@@ -205,7 +205,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Soulstone Survivors - Version 1.1.5 (83772) in Soulstone Survivors",
+					"releaseName": "Soulstone Survivors - Version 1.1.5 (83772) in Soulstone Survivors",
 					"category":    "Windows",
 				},
 			},
@@ -219,7 +219,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Digger: Galactic Treasures - Version 1.07",
+					"releaseName": "Digger: Galactic Treasures - Version 1.07",
 					"category":    "Windows",
 				},
 			},
@@ -233,7 +233,7 @@ func TestIRCParserGazelleGames_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "GazelleGames", "ggn", "GazelleGames"}),
 				vars: map[string]string{
-					"torrentName": "Bee.Simulator.The.Hive-RUNE - Version Unknown in Bee Simulator: The Hive",
+					"releaseName": "Bee.Simulator.The.Hive-RUNE - Version Unknown in Bee Simulator: The Hive",
 					"category":    "Windows",
 				},
 			},
@@ -273,7 +273,7 @@ func TestIRCParserOrpheus_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "Orpheus", "ops", "Orpheus"}),
 				vars: map[string]string{
-					"torrentName": "Busta Rhymes – BEACH BALL (feat. BIA) – [2023] [Single] WEB/FLAC/24bit Lossless",
+					"releaseName": "Busta Rhymes – BEACH BALL (feat. BIA) – [2023] [Single] WEB/FLAC/24bit Lossless",
 					"title":       "Busta Rhymes – BEACH BALL (feat. BIA)",
 					"year":        "2023",
 					"releaseTags": "WEB/FLAC/24bit Lossless",
@@ -289,7 +289,7 @@ func TestIRCParserOrpheus_Parse(t *testing.T) {
 			args: args{
 				rls: NewRelease(IndexerMinimal{0, "Orpheus", "ops", "Orpheus"}),
 				vars: map[string]string{
-					"torrentName": "Busta Rhymes – BEACH BALL (feat. BIA) – [2023] [Single] CD/FLAC/Lossless",
+					"releaseName": "Busta Rhymes – BEACH BALL (feat. BIA) – [2023] [Single] CD/FLAC/Lossless",
 					"title":       "Busta Rhymes – BEACH BALL (feat. BIA)",
 					"year":        "2023",
 					"releaseTags": "CD/FLAC/Lossless",


### PR DESCRIPTION
# Description

Fixes the GGn (and OPS) custom IRC parsers after the v2 announce variable rename from `torrentName` to `releaseName`. The custom parsers still read `vars["torrentName"]`, which no longer exists in v2 definitions, so GGn announces were parsed from an empty string and produced broken releases.

Changes:

- `IRCParserGazelleGames` and `IRCParserOrpheus` now read `releaseName`; the GGn parser returns an explicit error if the variable is missing instead of silently parsing an empty string
- Parser selection (GGn/OPS/RED/default) now happens once per channel in `IndexerDefinition.Prepare()` and `IndexerDefinitionCustom.ToIndexerDefinition()` instead of on every announce in `Parse()`
- Removed the dead v1 parse methods (`IndexerIRCParse.Parse`, `ParseURLs`, `ParseTorrentName`, `MapCustomVariables`); the v1 structs are kept for custom/legacy definition decoding and grouped under a v1 section
- Migrated the corresponding tests to the v2 types

Reported on Discord.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Updated the GGn and OPS parser unit tests to the `releaseName` variable; `go test ./internal/domain/` passes

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [ ] I have linked any related issue and updated docs if needed