### PR TITLE
feat(indexers): update TorrentHR for UNIT3D migration

### DIFF
--- a/internal/indexer/definitions/torrenthr.yaml
+++ b/internal/indexer/definitions/torrenthr.yaml
@@ -12,13 +12,13 @@ protocol: torrent
 supports:
   - irc
   - rss
-# source: unknown
+# source: UNIT3D
 settings:
-  - name: passkey
+  - name: rsskey
     type: secret
     required: true
-    label: Passkey
-    help: "Copy the torrent passkey for your account"
+    label: RSS key (RID)
+    help: "Go to your profile, General > RSS key, and copy the RSS Key (RID)"
 
 irc:
   network: THR
@@ -58,16 +58,16 @@ irc:
       parse:
         type: single
         lines:
-          - pattern: 'Novi torrent uploadan \-> Ime: (?P<releaseName>.*) \.:\. Kategorija: (?P<category>.*) \.:\. Velicina: (?P<torrentSize>.*) \.:\. URL: https?\:\/\/(?P<baseUrl>[^\/]+\/).*[&amp;\?]id=(?P<torrentId>\d+)'
+          - pattern: 'Novi torrent uploadan \-> Ime: (?P<releaseName>.*) \.:\. Kategorija: (?P<category>.*) \.:\. Velicina: (?P<torrentSize>.*) \.:\. URL: (?P<baseUrl>https?\:\/\/.+\/).+\/(?P<torrentId>\d+)'
             tests:
-              - line: 'Novi torrent uploadan -> Ime: A.torrent.name.here.WEBRip.x264-tina .:. Kategorija: Serije/SD .:. Velicina: 283.94 MB .:. URL: http://www.torrenthr.org/details.php?id=000000'
+              - line: 'Novi torrent uploadan -> Ime: A.torrent.name.here.WEBRip.x264-tina .:. Kategorija: Filmovi/HD .:. Velicina: 6.70 GB .:. URL: https://www.torrenthr.org/torrents/000000'
                 expect:
                   releaseName: A.torrent.name.here.WEBRip.x264-tina
-                  category: Serije/SD
-                  torrentSize: 283.94 MB
-                  baseUrl: www.torrenthr.org/
+                  category: Filmovi/HD
+                  torrentSize: 6.70 GB
+                  baseUrl: https://www.torrenthr.org/
                   torrentId: "000000"
 
         match:
-          infourl: "/details.php?id={{ .torrentId }}"
-          downloadurl: "/rssdownload.php?id={{ .torrentId }}&passkey={{ .passkey }}"
+          infourl: "/torrents/{{ .torrentId }}"
+          downloadurl: "/torrent/download/{{ .torrentId }}.{{ .rsskey }}"


### PR DESCRIPTION
# Description

TorrentHR (THR) migrated from its legacy codebase to UNIT3D, which changed its endpoints and announce URL format. This updates the indexer definition accordingly:

- Announce regex: torrent URLs are now `https://www.torrenthr.org/torrents/{id}` instead of `/details.php?id={id}`; `baseUrl` now captures the scheme, matching other UNIT3D definitions (e.g. aither.yaml)
- Settings: `passkey` replaced with `rsskey` (RSS Key/RID from Settings > Security)
- Info URL: `/torrents/{{ .torrentId }}`
- Download URL: `/torrent/download/{{ .torrentId }}.{{ .rsskey }}` (standard UNIT3D)
- `# source` comment updated to UNIT3D

The IRC network, channel, announcer, and announce line prefix are unchanged. Existing THR users will need to re-enter their key (RSS Key instead of passkey) in Settings → Indexers.

Fixes #2522

## Type of change

<!--- Delete options that are not relevant. --->

- [x] Indexer definition update

## How has this been tested?

* Updated the embedded YAML test case to the new-format announce line from #2522; `go test ./internal/indexer/ -run TestIndexerYamlExpectations` passes (all 5 capture groups parse as expected).
* End-to-end via the mock indexer (`test/mockindexer` with `--irc-channel "#announce" --irc-announcer THR` and a localhost copy of this definition as a custom definition): the new-format announce line was parsed correctly (`info_url: .../torrents/000000`, `download_url: .../torrent/download/000000.<rsskey>`), matched a filter, and a WATCH_FOLDER action successfully downloaded the torrent file from the UNIT3D-style download URL.
* Full non-integration test suite passes locally.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally (no Go files changed)
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Yes - the definition update was written with Claude Code (Claude Fable 5), based on issue #2522 and the existing aither.yaml UNIT3D definition. Verified locally via the definition test suite.
