### PR TITLE
feat(filters): update Perfect FLAC to match RED/OPS definition

### DIFF
--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -611,9 +611,15 @@ func (f *Filter) CheckFilter(r *Release) (*RejectionReasons, bool) {
 		f.RejectReasons.Add("albums", r.Title, f.Albums)
 	}
 
-	// Perfect flac requires Cue, Log, Log Score 100, FLAC and 24bit Lossless
-	if f.PerfectFlac && !f.isPerfectFLAC(r) {
-		f.RejectReasons.Add("perfect flac", r.Audio, "Cue, Log, Log Score 100, FLAC and 24bit Lossless")
+	// Perfect flac: FLAC and either CD with 100% log score,
+	// or any non-CD media where log/cue don't apply (RED/OPS definition)
+	if f.PerfectFlac {
+		if rejections, ok := f.IsPerfectFLAC(r); !ok {
+			f.RejectReasons.Add("perfect flac",
+				fmt.Sprintf("%s %s %s (log: %t, score: %d)", r.Source, r.AudioFormat, r.Bitrate, r.HasLog, r.LogScore),
+				strings.Join(rejections, ", "),
+			)
+		}
 	}
 
 	if len(f.Formats) > 0 && !sliceContainsSlice(r.Audio, f.Formats) {
@@ -705,30 +711,6 @@ func (f *Filter) checkMaxDownloads() bool {
 	return f.Downloads.BelowCount(f.MaxDownloadsUnit, f.MaxDownloads)
 }
 
-// isPerfectFLAC Perfect is "CD FLAC Cue Log 100% Lossless or 24bit Lossless"
-func (f *Filter) isPerfectFLAC(r *Release) bool {
-	if !contains(r.Source, "CD") {
-		return false
-	}
-	if !containsAny(r.Audio, "Cue") {
-		return false
-	}
-	if !containsAny(r.Audio, "Log") {
-		return false
-	}
-	if !containsAny(r.Audio, "Log100") || r.LogScore != 100 {
-		return false
-	}
-	if !containsAny(r.Audio, "FLAC") {
-		return false
-	}
-	if !containsAnySlice(r.Audio, []string{"Lossless", "24bit Lossless"}) {
-		return false
-	}
-
-	return true
-}
-
 // checkSizeFilter compares the filter size limits to a release's size if it is
 // known from the announce line.
 func (f *Filter) checkSizeFilter(r *Release) bool {
@@ -793,27 +775,35 @@ func (f *Filter) checkRecordLabel(r *Release) bool {
 	return true
 }
 
-// IsPerfectFLAC Perfect is "CD FLAC Cue Log 100% Lossless or 24bit Lossless"
+// IsPerfectFLAC matches the RED/OPS definition of a Perfect FLAC:
+// FLAC and either a CD rip with a 100% log score, or a rip from any
+// non-CD media (Vinyl/WEB/DVD/Soundboard/Cassette/SACD/Blu-ray/DAT),
+// where log/cue do not apply.
 func (f *Filter) IsPerfectFLAC(r *Release) ([]string, bool) {
 	rejections := []string{}
 
-	if r.Source != "CD" {
-		rejections = append(rejections, fmt.Sprintf("wanted Source CD, got %s", r.Source))
-	}
 	if r.AudioFormat != "FLAC" {
 		rejections = append(rejections, fmt.Sprintf("wanted Format FLAC, got %s", r.AudioFormat))
 	}
-	if !r.HasCue {
-		rejections = append(rejections, fmt.Sprintf("wanted Cue, got %t", r.HasCue))
-	}
-	if !r.HasLog {
-		rejections = append(rejections, fmt.Sprintf("wanted Log, got %t", r.HasLog))
-	}
-	if r.LogScore != 100 {
-		rejections = append(rejections, fmt.Sprintf("wanted Log Score 100, got %d", r.LogScore))
-	}
+
 	if !containsSlice(r.Bitrate, []string{"Lossless", "24bit Lossless"}) {
 		rejections = append(rejections, fmt.Sprintf("wanted Bitrate Lossless / 24bit Lossless, got %s", r.Bitrate))
+	}
+
+	switch {
+	case containsSlice(r.Source, []string{"CD"}):
+		if !r.HasLog {
+			rejections = append(rejections, fmt.Sprintf("wanted Log, got %t", r.HasLog))
+		}
+		if r.LogScore != 100 {
+			rejections = append(rejections, fmt.Sprintf("wanted Log Score 100, got %d", r.LogScore))
+		}
+
+	case containsSlice(r.Source, []string{"Vinyl", "WEB", "DVD", "Soundboard", "Cassette", "SACD", "Blu-Ray", "Blu-ray", "BD", "DAT"}):
+		// perfect by definition for FLAC; log/cue don't apply to non-CD media
+
+	default:
+		rejections = append(rejections, fmt.Sprintf("wanted Source CD (100%% log) or Vinyl/WEB/DVD/Soundboard/Cassette/SACD/Blu-ray/DAT, got %s", r.Source))
 	}
 
 	return rejections, len(rejections) == 0

--- a/internal/domain/filter_test.go
+++ b/internal/domain/filter_test.go
@@ -1233,7 +1233,7 @@ func TestFilter_CheckFilter(t *testing.T) {
 					Artists:         "Artist",
 					PerfectFlac:     true,
 				},
-				rejectionReasons: &RejectionReasons{data: []Rejection{{key: "perfect flac", got: []string{"320", "MP3"}, want: "Cue, Log, Log Score 100, FLAC and 24bit Lossless"}}},
+				rejectionReasons: &RejectionReasons{data: []Rejection{{key: "perfect flac", got: "SINGLE MP3 320 (log: false, score: 0)", want: "wanted Format FLAC, got MP3, wanted Bitrate Lossless / 24bit Lossless, got 320, wanted Source CD (100% log) or Vinyl/WEB/DVD/Soundboard/Cassette/SACD/Blu-ray/DAT, got SINGLE"}}},
 			},
 			want: false,
 		},
@@ -1251,9 +1251,9 @@ func TestFilter_CheckFilter(t *testing.T) {
 					Artists:         "Artist",
 					PerfectFlac:     true,
 				},
-				rejectionReasons: &RejectionReasons{data: []Rejection{{key: "perfect flac", got: []string{"FLAC", "Lossless", "Log100", "Log"}, want: "Cue, Log, Log Score 100, FLAC and 24bit Lossless"}}},
+				rejectionReasons: &RejectionReasons{data: []Rejection{}},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "match_music_4",
@@ -2438,6 +2438,98 @@ func Test_containsFuzzy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, containsFuzzy(tt.args.tag, tt.args.filter), "containsFuzzy(%v, %v)", tt.args.tag, tt.args.filter)
+		})
+	}
+}
+
+func TestFilter_IsPerfectFLAC(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		release        *Release
+		wantRejections []string
+		wantOk         bool
+	}{
+		{
+			name:    "cd_log_100_lossless",
+			release: &Release{Source: "CD", AudioFormat: "FLAC", Bitrate: "Lossless", HasLog: true, LogScore: 100},
+			wantOk:  true,
+		},
+		{
+			name:    "cd_log_100_24bit_lossless",
+			release: &Release{Source: "CD", AudioFormat: "FLAC", Bitrate: "24bit Lossless", HasLog: true, LogScore: 100},
+			wantOk:  true,
+		},
+		{
+			name:           "cd_missing_log",
+			release:        &Release{Source: "CD", AudioFormat: "FLAC", Bitrate: "Lossless", HasLog: false, LogScore: 0},
+			wantRejections: []string{"wanted Log, got false", "wanted Log Score 100, got 0"},
+			wantOk:         false,
+		},
+		{
+			name:           "cd_log_score_99",
+			release:        &Release{Source: "CD", AudioFormat: "FLAC", Bitrate: "Lossless", HasLog: true, LogScore: 99},
+			wantRejections: []string{"wanted Log Score 100, got 99"},
+			wantOk:         false,
+		},
+		{
+			name:    "web_lossless",
+			release: &Release{Source: "WEB", AudioFormat: "FLAC", Bitrate: "Lossless"},
+			wantOk:  true,
+		},
+		{
+			name:    "vinyl_24bit_lossless",
+			release: &Release{Source: "Vinyl", AudioFormat: "FLAC", Bitrate: "24bit Lossless"},
+			wantOk:  true,
+		},
+		{
+			name:    "sacd_lossless",
+			release: &Release{Source: "SACD", AudioFormat: "FLAC", Bitrate: "Lossless"},
+			wantOk:  true,
+		},
+		{
+			name:    "blu_ray_lossless",
+			release: &Release{Source: "Blu-Ray", AudioFormat: "FLAC", Bitrate: "24bit Lossless"},
+			wantOk:  true,
+		},
+		{
+			name:    "dat_lossless",
+			release: &Release{Source: "DAT", AudioFormat: "FLAC", Bitrate: "Lossless"},
+			wantOk:  true,
+		},
+		{
+			name:           "web_mp3_320",
+			release:        &Release{Source: "WEB", AudioFormat: "MP3", Bitrate: "320"},
+			wantRejections: []string{"wanted Format FLAC, got MP3", "wanted Bitrate Lossless / 24bit Lossless, got 320"},
+			wantOk:         false,
+		},
+		{
+			name:           "unknown_source",
+			release:        &Release{Source: "Unknown", AudioFormat: "FLAC", Bitrate: "Lossless"},
+			wantRejections: []string{"wanted Source CD (100% log) or Vinyl/WEB/DVD/Soundboard/Cassette/SACD/Blu-ray/DAT, got Unknown"},
+			wantOk:         false,
+		},
+		{
+			name:    "empty_release",
+			release: &Release{},
+			wantRejections: []string{
+				"wanted Format FLAC, got ",
+				"wanted Bitrate Lossless / 24bit Lossless, got ",
+				"wanted Source CD (100% log) or Vinyl/WEB/DVD/Soundboard/Cassette/SACD/Blu-ray/DAT, got ",
+			},
+			wantOk: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := Filter{}
+			rejections, ok := f.IsPerfectFLAC(tt.release)
+			assert.Equal(t, tt.wantOk, ok)
+			if tt.wantRejections == nil {
+				assert.Empty(t, rejections)
+			} else {
+				assert.Equal(t, tt.wantRejections, rejections)
+			}
 		})
 	}
 }


### PR DESCRIPTION
# Description

Reworks the Perfect FLAC filter to match the RED/OPS definition instead of the old hardcoded "CD + Cue + Log 100%" rule.

Previously `PerfectFlac` only matched CD rips with Cue, Log, 100% log score, FLAC and (24bit) Lossless, which silently excluded WEB, Vinyl and other media where log/cue don't exist. Now a release is considered perfect when it is FLAC with Lossless / 24bit Lossless bitrate and either:

- a **CD** rip with a log and a 100% log score (cue is no longer required), or
- a rip from any **non-CD media** (Vinyl, WEB, DVD, Soundboard, Cassette, SACD, Blu-ray, DAT), where log/cue don't apply

Changes:

- `IsPerfectFLAC` now checks the typed release fields (`Source`, `AudioFormat`, `Bitrate`, `HasLog`, `LogScore`) and returns per-condition rejection reasons
- `CheckFilter` uses `IsPerfectFLAC` and surfaces those reasons in the rejection output instead of the generic "Cue, Log, Log Score 100, FLAC and 24bit Lossless" string
- Added `TestFilter_IsPerfectFLAC` covering CD (log/score variants), all non-CD media, wrong format/bitrate, unknown source and empty release
- Updated the two `TestFilter_CheckFilter` music cases that encoded the old behavior (a CD FLAC with 100% log but no cue now matches)

Fixes #1688 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

* `go test ./internal/domain` passes, including the new `TestFilter_IsPerfectFLAC` table tests

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed