### PR TITLE
fix(web): replace HeadlessUI slide-overs with non-modal Base UI drawers

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "lint:watch": "pnpm run lint -- --watch"
   },
   "dependencies": {
+    "@base-ui/react": "^1.6.0",
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "@fortawesome/free-brands-svg-icons": "^7.3.0",
     "@fortawesome/react-fontawesome": "^3.3.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.6.0
+        version: 1.6.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@fortawesome/fontawesome-svg-core':
         specifier: ^7.3.0
         version: 7.3.0
@@ -774,6 +777,33 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^19.2.7
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^19.2.7
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1593,9 +1623,6 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/node@26.0.1':
-    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
@@ -3284,6 +3311,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4666,6 +4696,30 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@base-ui/react@1.6.0(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      date-fns: 4.4.0
+
+  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -4689,7 +4743,7 @@ snapshots:
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.27.1
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -4716,7 +4770,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -5414,10 +5468,6 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@26.0.1':
-    dependencies:
-      undici-types: 8.3.0
-
   '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
@@ -5438,7 +5488,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.0
 
   '@types/trusted-types@2.0.7': {}
 
@@ -5693,7 +5743,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.29.7
       cosmiconfig: 7.1.0
       resolve: 1.22.10
 
@@ -5948,7 +5998,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.29.7
       csstype: 3.1.2
 
   dot-case@3.0.4:
@@ -6750,7 +6800,7 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.0
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
@@ -7266,7 +7316,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.29.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -7327,6 +7377,8 @@ snapshots:
       jsesc: 3.1.0
 
   require-from-string@2.0.2: {}
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 

--- a/web/src/components/panels/index.tsx
+++ b/web/src/components/panels/index.tsx
@@ -42,9 +42,17 @@ export function SlideOverShell({ isOpen, toggle, initialFocus, zIndexClass, chil
       <Drawer.Portal>
         <Drawer.Backdrop
           className={classNames("fixed inset-0", zIndexClass ?? "")}
-          onClick={toggle}
+          onClick={(e) => {
+            e.stopPropagation();
+            toggle();
+          }}
         />
-        <Drawer.Viewport className={classNames("fixed inset-0 flex justify-end pointer-events-none", zIndexClass ?? "")}>
+        {/* Clicks bubble through the React portal to ancestors (e.g. the expandable
+            network row an update form is mounted in), so stop them at the boundary. */}
+        <Drawer.Viewport
+          className={classNames("fixed inset-0 flex justify-end pointer-events-none", zIndexClass ?? "")}
+          onClick={(e) => e.stopPropagation()}
+        >
           <Drawer.Popup
             initialFocus={initialFocus}
             className="pointer-events-auto h-full w-screen max-w-2xl shadow-xl [transform:translateX(var(--drawer-swipe-movement-x))] transition-transform ease-in-out duration-500 sm:duration-700 data-starting-style:[transform:translateX(100%)] data-ending-style:[transform:translateX(100%)]"

--- a/web/src/components/panels/index.tsx
+++ b/web/src/components/panels/index.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Fragment, useRef, ReactNode, ReactElement } from "react";
+import { useRef, ReactNode, ReactElement, RefObject } from "react";
 import { XMarkIcon } from "@heroicons/react/24/solid";
-import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
+import { Drawer } from "@base-ui/react/drawer";
 import { Form, Formik } from "formik";
 import type { FormikValues, FormikProps } from "formik";
 import { useTranslation } from "react-i18next";
@@ -14,6 +14,66 @@ import { DEBUG } from "@components/debug";
 import { useToggle } from "@hooks/hooks";
 import { DeleteModal } from "@components/modals";
 import { classNames } from "@utils";
+
+interface SlideOverShellProps {
+  isOpen: boolean;
+  toggle: () => void;
+  initialFocus?: RefObject<HTMLElement | null>;
+  zIndexClass?: string;
+  children: ReactNode;
+}
+
+// Deliberately non-modal: a modal drawer locks page scroll and closes on any
+// outside pointer press, which fights the overlays password managers inject
+// and freezes the panel. See https://github.com/autobrr/autobrr/issues/2536.
+export function SlideOverShell({ isOpen, toggle, initialFocus, zIndexClass, children }: SlideOverShellProps): ReactElement {
+  return (
+    <Drawer.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          toggle();
+        }
+      }}
+      modal={false}
+      disablePointerDismissal
+      swipeDirection="right"
+    >
+      <Drawer.Portal>
+        <Drawer.Backdrop
+          className={classNames("fixed inset-0", zIndexClass ?? "")}
+          onClick={toggle}
+        />
+        <Drawer.Viewport className={classNames("fixed inset-0 flex justify-end pointer-events-none", zIndexClass ?? "")}>
+          <Drawer.Popup
+            initialFocus={initialFocus}
+            className="pointer-events-auto h-full w-screen max-w-2xl shadow-xl [transform:translateX(var(--drawer-swipe-movement-x))] transition-transform ease-in-out duration-500 sm:duration-700 data-starting-style:[transform:translateX(100%)] data-ending-style:[transform:translateX(100%)]"
+          >
+            {/* Swipe-to-dismiss would discard form input on stray touch drags. */}
+            <div className="h-full min-h-0" data-base-ui-swipe-ignore>
+              {children}
+            </div>
+          </Drawer.Popup>
+        </Drawer.Viewport>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+}
+
+interface SlideOverTitleProps {
+  children: ReactNode;
+  className?: string;
+}
+
+// Accessible drawer title; use once per drawer. For section headings inside
+// the drawer body, use a plain heading element instead.
+export function SlideOverTitle({ children, className }: SlideOverTitleProps): ReactElement {
+  return (
+    <Drawer.Title className={className ?? "text-lg font-medium text-gray-900 dark:text-white"}>
+      {children}
+    </Drawer.Title>
+  );
+}
 
 interface SlideOverProps<DataType> {
   title: string;
@@ -55,187 +115,160 @@ function SlideOver<DataType extends FormikValues>({
   const [deleteModalIsOpen, toggleDeleteModal] = useToggle(false);
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" static className="fixed inset-0 overflow-hidden" open={isOpen} onClose={toggle}>
-        {deleteAction && (
-          <DeleteModal
-            isOpen={deleteModalIsOpen}
-            isLoading={isTesting || false}
-            toggle={toggleDeleteModal}
-            buttonRef={cancelModalButtonRef}
-            deleteAction={deleteAction}
-            title={t("panel.removeTitle", { title })}
-            text={t("panel.removeText", { title })}
-          />
-        )}
+    <SlideOverShell isOpen={isOpen} toggle={toggle}>
+      {deleteAction && (
+        <DeleteModal
+          isOpen={deleteModalIsOpen}
+          isLoading={isTesting || false}
+          toggle={toggleDeleteModal}
+          buttonRef={cancelModalButtonRef}
+          deleteAction={deleteAction}
+          title={t("panel.removeTitle", { title })}
+          text={t("panel.removeText", { title })}
+        />
+      )}
 
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel
-            className="fixed inset-y-0 right-0 max-w-full flex"
-            onClick={(e) => {
+      <Formik
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+        validate={validate}
+        innerRef={formRef}
+      >
+        {({ handleSubmit, values }) => (
+          <Form
+            className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800"
+            onSubmit={(e) => {
               e.preventDefault();
-              e.stopPropagation();
+              handleSubmit(e);
             }}
           >
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
-            >
-              <div className="w-screen max-w-2xl">
-
-                <Formik
-                  initialValues={initialValues}
-                  onSubmit={onSubmit}
-                  validate={validate}
-                  innerRef={formRef}
-                >
-                  {({ handleSubmit, values }) => (
-                    <Form
-                      className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto"
-                      onSubmit={(e) => {
-                        e.preventDefault();
-                        handleSubmit(e);
-                      }}
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <SlideOverTitle>
+                      {type === "CREATE"
+                        ? t("panel.createTitle", { title })
+                        : t("panel.updateTitle", { title })}
+                    </SlideOverTitle>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {type === "CREATE"
+                        ? t("panel.createDescription", { title })
+                        : t("panel.updateDescription", { title })}
+                    </p>
+                  </div>
+                  <div className="h-7 flex items-center">
+                    <button
+                      type="button"
+                      className="bg-white dark:bg-gray-900 rounded-md text-gray-400 hover:text-gray-500 cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                      onClick={toggle}
                     >
-
-                      <div className="flex-1">
-                        <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                          <div className="flex items-start justify-between space-x-3">
-                            <div className="space-y-1">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                {type === "CREATE"
-                                  ? t("panel.createTitle", { title })
-                                  : t("panel.updateTitle", { title })}
-                              </DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
-                                {type === "CREATE"
-                                  ? t("panel.createDescription", { title })
-                                  : t("panel.updateDescription", { title })}
-                              </p>
-                            </div>
-                            <div className="h-7 flex items-center">
-                              <button
-                                type="button"
-                                className="bg-white dark:bg-gray-900 rounded-md text-gray-400 hover:text-gray-500 cursor-pointer focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                                onClick={toggle}
-                              >
-                                <span className="sr-only">{t("panel.closePanel")}</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        {!!values && children !== undefined ? (
-                          children(values)
-                        ) : null}
-                      </div>
-
-                      <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
-                        <div className={classNames(type === "CREATE" ? "justify-end" : "justify-between", "space-x-3 flex")}>
-                          {type === "UPDATE" && (
-                            <button
-                              type="button"
-                              className="inline-flex items-center justify-center px-4 py-2 border border-transparent cursor-pointer font-medium rounded-md text-red-700 dark:text-white bg-red-100 dark:bg-red-700 hover:bg-red-200 dark:hover:bg-red-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:text-sm"
-                              onClick={toggleDeleteModal}
-                            >
-                              {t("panel.remove")}
-                            </button>
-                          )}
-                          <div className="flex">
-                            {!!values && extraButtons !== undefined && (
-                              extraButtons(values)
-                            )}
-
-                            {testFn && (
-                              <button
-                                type="button"
-                                className={classNames(
-                                  isTestSuccessful
-                                    ? "text-green-500 border-green-500 bg-green-50"
-                                    : isTestError
-                                      ? "text-red-500 border-red-500 bg-red-50"
-                                      : "border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:border-rose-700 active:bg-rose-700",
-                                  isTesting ? "cursor-not-allowed" : "",
-                                  "mr-2 inline-flex items-center px-4 py-2 border font-medium rounded-md shadow-xs text-sm transition ease-in-out duration-150 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                                )}
-                                disabled={isTesting}
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  testFn(values);
-                                }}
-                              >
-                                {isTesting ? (
-                                  <svg
-                                    className="animate-spin h-5 w-5 text-green-500"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <circle
-                                      className="opacity-25"
-                                      cx="12"
-                                      cy="12"
-                                      r="10"
-                                      stroke="currentColor"
-                                      strokeWidth="4"
-                                    ></circle>
-                                    <path
-                                      className="opacity-75"
-                                      fill="currentColor"
-                                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                                    ></path>
-                                  </svg>
-                                ) : isTestSuccessful ? (
-                                  t("panel.ok")
-                                ) : isTestError ? (
-                                  t("panel.error")
-                                ) : (
-                                  t("panel.test")
-                                )}
-                              </button>
-                            )}
-
-                            <button
-                              type="button"
-                              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                toggle();
-                              }}
-                            >
-                              {t("panel.cancel")}
-                            </button>
-                            <button
-                              type="button"
-                              className="ml-4 inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                formRef.current?.submitForm();
-                              }}
-                            >
-                              {type === "CREATE" ? t("panel.create") : t("panel.save")}
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-
-                      <DEBUG values={values} />
-                    </Form>
-                  )}
-                </Formik>
+                      <span className="sr-only">{t("panel.closePanel")}</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
               </div>
 
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+              {!!values && children !== undefined ? (
+                children(values)
+              ) : null}
+
+              <DEBUG values={values} />
+            </div>
+
+            <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
+              <div className={classNames(type === "CREATE" ? "justify-end" : "justify-between", "space-x-3 flex")}>
+                {type === "UPDATE" && (
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center px-4 py-2 border border-transparent cursor-pointer font-medium rounded-md text-red-700 dark:text-white bg-red-100 dark:bg-red-700 hover:bg-red-200 dark:hover:bg-red-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:text-sm"
+                    onClick={toggleDeleteModal}
+                  >
+                    {t("panel.remove")}
+                  </button>
+                )}
+                <div className="flex">
+                  {!!values && extraButtons !== undefined && (
+                    extraButtons(values)
+                  )}
+
+                  {testFn && (
+                    <button
+                      type="button"
+                      className={classNames(
+                        isTestSuccessful
+                          ? "text-green-500 border-green-500 bg-green-50"
+                          : isTestError
+                            ? "text-red-500 border-red-500 bg-red-50"
+                            : "border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:border-rose-700 active:bg-rose-700",
+                        isTesting ? "cursor-not-allowed" : "",
+                        "mr-2 inline-flex items-center px-4 py-2 border font-medium rounded-md shadow-xs text-sm transition ease-in-out duration-150 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                      )}
+                      disabled={isTesting}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        testFn(values);
+                      }}
+                    >
+                      {isTesting ? (
+                        <svg
+                          className="animate-spin h-5 w-5 text-green-500"
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                        >
+                          <circle
+                            className="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                          ></circle>
+                          <path
+                            className="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                          ></path>
+                        </svg>
+                      ) : isTestSuccessful ? (
+                        t("panel.ok")
+                      ) : isTestError ? (
+                        t("panel.error")
+                      ) : (
+                        t("panel.test")
+                      )}
+                    </button>
+                  )}
+
+                  <button
+                    type="button"
+                    className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      toggle();
+                    }}
+                  >
+                    {t("panel.cancel")}
+                  </button>
+                  <button
+                    type="button"
+                    className="ml-4 inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      formRef.current?.submitForm();
+                    }}
+                  >
+                    {type === "CREATE" ? t("panel.create") : t("panel.save")}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </SlideOverShell>
   );
 }
 

--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Fragment, useRef } from "react";
+import { useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { XMarkIcon } from "@heroicons/react/24/solid";
-import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
 import type { FieldProps } from "formik";
 import { Field, Form, Formik, FormikErrors, FormikValues } from "formik";
 import { useTranslation } from "react-i18next";
@@ -18,6 +17,7 @@ import { DEBUG } from "@components/debug";
 import { toast } from "@components/hot-toast";
 import Toast from "@components/notifications/Toast";
 import { AddFormProps } from "@forms/_shared";
+import { SlideOverShell, SlideOverTitle } from "@components/panels";
 
 export function FilterAddForm({ isOpen, toggle }: AddFormProps) {
   const { t } = useTranslation("filters");
@@ -48,124 +48,105 @@ export function FilterAddForm({ isOpen, toggle }: AddFormProps) {
   };
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" static className="z-20 fixed inset-0 overflow-hidden" open={isOpen} onClose={toggle} initialFocus={inputRef}>
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
-            >
-              <div className="w-screen max-w-2xl ">
-
-                <Formik
-                  initialValues={{
-                    name: "",
-                    enabled: false,
-                    resolutions: [],
-                    codecs: [],
-                    sources: [],
-                    containers: [],
-                    origins: []
-                  }}
-                  onSubmit={handleSubmit}
-                  validate={validate}
-                >
-                  {({ values }) => (
-                    <Form className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto">
-                      <div className="flex-1">
-                        <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                          <div className="flex items-start justify-between space-x-3">
-                            <div className="space-y-1">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("addForm.title")}</DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
-                                {t("addForm.subtitle")}
-                              </p>
-                            </div>
-                            <div className="h-7 flex items-center">
-                              <button
-                                type="button"
-                                className="light:bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                                onClick={toggle}
-                              >
-                                <span className="sr-only">{t("addForm.closePanel")}</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div
-                          className="py-6 space-y-6 sm:py-0 sm:space-y-0 sm:divide-y sm:divide-gray-200">
-                          <div
-                            className="space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-4">
-                            <div>
-                              <label
-                                htmlFor="name"
-                                className="block text-sm font-medium text-gray-900 dark:text-white sm:mt-px sm:pt-2"
-                              >
-                                {t("addForm.name")}
-                                <span className="text-red-500"> *</span>
-                              </label>
-                            </div>
-                            <Field name="name">
-                              {({
-                                field,
-                                meta
-                              }: FieldProps ) => (
-                                <div className="sm:col-span-2">
-                                  <input
-                                    {...field}
-                                    id="name"
-                                    type="text"
-                                    data-1p-ignore
-                                    autoComplete="off"
-                                    ref={inputRef}
-                                    className="block w-full shadow-xs sm:text-sm rounded-md border py-2.5 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-815 dark:text-gray-100"
-                                  />
-
-                                  {meta.touched && meta.error &&
-                                    <span className="block mt-2 text-red-500">{meta.error}</span>}
-
-                                </div>
-                              )}
-                            </Field>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div
-                        className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
-                        <div className="space-x-3 flex justify-end">
-                          <button
-                            type="button"
-                            className="bg-white dark:bg-gray-800 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={toggle}
-                          >
-                            {t("addForm.cancel")}
-                          </button>
-                          <button
-                            type="submit"
-                            className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                          >
-                            {t("addForm.create")}
-                          </button>
-                        </div>
-                      </div>
-                      <DEBUG values={values} />
-                    </Form>
-                  )}
-                </Formik>
+    <SlideOverShell isOpen={isOpen} toggle={toggle} initialFocus={inputRef} zIndexClass="z-20">
+      <Formik
+        initialValues={{
+          name: "",
+          enabled: false,
+          resolutions: [],
+          codecs: [],
+          sources: [],
+          containers: [],
+          origins: []
+        }}
+        onSubmit={handleSubmit}
+        validate={validate}
+      >
+        {({ values }) => (
+          <Form className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800">
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <SlideOverTitle>{t("addForm.title")}</SlideOverTitle>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {t("addForm.subtitle")}
+                    </p>
+                  </div>
+                  <div className="h-7 flex items-center">
+                    <button
+                      type="button"
+                      className="light:bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                      onClick={toggle}
+                    >
+                      <span className="sr-only">{t("addForm.closePanel")}</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
               </div>
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+
+              <div
+                className="py-6 space-y-6 sm:py-0 sm:space-y-0 sm:divide-y sm:divide-gray-200">
+                <div
+                  className="space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-4">
+                  <div>
+                    <label
+                      htmlFor="name"
+                      className="block text-sm font-medium text-gray-900 dark:text-white sm:mt-px sm:pt-2"
+                    >
+                      {t("addForm.name")}
+                      <span className="text-red-500"> *</span>
+                    </label>
+                  </div>
+                  <Field name="name">
+                    {({
+                      field,
+                      meta
+                    }: FieldProps ) => (
+                      <div className="sm:col-span-2">
+                        <input
+                          {...field}
+                          id="name"
+                          type="text"
+                          data-1p-ignore
+                          autoComplete="off"
+                          ref={inputRef}
+                          className="block w-full shadow-xs sm:text-sm rounded-md border py-2.5 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-815 dark:text-gray-100"
+                        />
+
+                        {meta.touched && meta.error &&
+                          <span className="block mt-2 text-red-500">{meta.error}</span>}
+
+                      </div>
+                    )}
+                  </Field>
+                </div>
+              </div>
+
+              <DEBUG values={values} />
+            </div>
+
+            <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
+              <div className="space-x-3 flex justify-end">
+                <button
+                  type="button"
+                  className="bg-white dark:bg-gray-800 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={toggle}
+                >
+                  {t("addForm.cancel")}
+                </button>
+                <button
+                  type="submit"
+                  className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                >
+                  {t("addForm.create")}
+                </button>
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </SlideOverShell>
   );
 }

--- a/web/src/forms/settings/APIKeyAddForm.tsx
+++ b/web/src/forms/settings/APIKeyAddForm.tsx
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Fragment } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { XMarkIcon } from "@heroicons/react/24/solid";
-import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
 import type { FieldProps } from "formik";
 import { Field, Form, Formik, FormikErrors, FormikValues } from "formik";
 import { useTranslation } from "react-i18next";
@@ -17,6 +15,7 @@ import { DEBUG } from "@components/debug";
 import { toast } from "@components/hot-toast";
 import Toast from "@components/notifications/Toast";
 import { AddFormProps } from "@forms/_shared";
+import { SlideOverShell, SlideOverTitle } from "@components/panels";
 
 export function APIKeyAddForm({ isOpen, toggle }: AddFormProps) {
   const { t } = useTranslation("settings");
@@ -43,113 +42,95 @@ export function APIKeyAddForm({ isOpen, toggle }: AddFormProps) {
   };
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" static className="fixed inset-0 overflow-hidden" open={isOpen} onClose={toggle}>
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
-            >
-              <div className="w-screen max-w-2xl ">
-                <Formik
-                  initialValues={{
-                    name: "",
-                    scopes: []
-                  }}
-                  onSubmit={handleSubmit}
-                  validate={validate}
-                >
-                  {({ values }) => (
-                    <Form className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto">
-                      <div className="flex-1">
-                        <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                          <div className="flex items-start justify-between space-x-3">
-                            <div className="space-y-1">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.apiKey.createTitle")}</DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
-                                {t("forms.apiKey.description")}
-                              </p>
-                            </div>
-                            <div className="h-7 flex items-center">
-                              <button
-                                type="button"
-                                className="light:bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                                onClick={toggle}
-                              >
-                                <span className="sr-only">{t("forms.apiKey.closePanel")}</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div
-                          className="py-6 space-y-6 sm:py-0 sm:space-y-0 sm:divide-y sm:divide-gray-200">
-                          <div
-                            className="space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-4">
-                            <div>
-                              <label
-                                htmlFor="name"
-                                className="block text-sm font-medium text-gray-900 dark:text-white sm:mt-px sm:pt-2"
-                              >
-                                {t("forms.apiKey.name")}
-                              </label>
-                            </div>
-                            <Field name="name">
-                              {({
-                                field,
-                                meta
-                              }: FieldProps) => (
-                                <div className="sm:col-span-2">
-                                  <input
-                                    {...field}
-                                    id="name"
-                                    type="text"
-                                    data-1p-ignore
-                                    autoComplete="off"
-                                    className="block w-full shadow-xs sm:text-sm focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 rounded-md border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-815 dark:text-gray-100"
-                                  />
-                                  {meta.touched && meta.error && <span className="block mt-2 text-red-500">{meta.error}</span>}
-                                </div>
-                              )}
-                            </Field>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div
-                        className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
-                        <div className="space-x-3 flex justify-end">
-                          <button
-                            type="button"
-                            className="bg-white dark:bg-gray-800 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={toggle}
-                          >
-                            {t("forms.apiKey.cancel")}
-                          </button>
-                          <button
-                            type="submit"
-                            className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                          >
-                            {t("forms.apiKey.create")}
-                          </button>
-                        </div>
-                      </div>
-                      <DEBUG values={values}/>
-                    </Form>
-                  )}
-                </Formik>
+    <SlideOverShell isOpen={isOpen} toggle={toggle}>
+      <Formik
+        initialValues={{
+          name: "",
+          scopes: []
+        }}
+        onSubmit={handleSubmit}
+        validate={validate}
+      >
+        {({ values }) => (
+          <Form className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800">
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <SlideOverTitle>{t("forms.apiKey.createTitle")}</SlideOverTitle>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {t("forms.apiKey.description")}
+                    </p>
+                  </div>
+                  <div className="h-7 flex items-center">
+                    <button
+                      type="button"
+                      className="light:bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                      onClick={toggle}
+                    >
+                      <span className="sr-only">{t("forms.apiKey.closePanel")}</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
+                    </button>
+                  </div>
+                </div>
               </div>
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+
+              <div
+                className="py-6 space-y-6 sm:py-0 sm:space-y-0 sm:divide-y sm:divide-gray-200">
+                <div
+                  className="space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-4">
+                  <div>
+                    <label
+                      htmlFor="name"
+                      className="block text-sm font-medium text-gray-900 dark:text-white sm:mt-px sm:pt-2"
+                    >
+                      {t("forms.apiKey.name")}
+                    </label>
+                  </div>
+                  <Field name="name">
+                    {({
+                      field,
+                      meta
+                    }: FieldProps) => (
+                      <div className="sm:col-span-2">
+                        <input
+                          {...field}
+                          id="name"
+                          type="text"
+                          data-1p-ignore
+                          autoComplete="off"
+                          className="block w-full shadow-xs sm:text-sm focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 rounded-md border-gray-300 dark:border-gray-700 bg-gray-100 dark:bg-gray-815 dark:text-gray-100"
+                        />
+                        {meta.touched && meta.error && <span className="block mt-2 text-red-500">{meta.error}</span>}
+                      </div>
+                    )}
+                  </Field>
+                </div>
+              </div>
+
+              <DEBUG values={values}/>
+            </div>
+
+            <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
+              <div className="space-x-3 flex justify-end">
+                <button
+                  type="button"
+                  className="bg-white dark:bg-gray-800 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={toggle}
+                >
+                  {t("forms.apiKey.cancel")}
+                </button>
+                <button
+                  type="submit"
+                  className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                >
+                  {t("forms.apiKey.create")}
+                </button>
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </SlideOverShell>
   );
 }

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Fragment, useRef, useState, ReactElement } from "react";
+import { useRef, useState, ReactElement } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/solid";
 import { Form, Formik, useFormikContext } from "formik";
 import { useTranslation } from "react-i18next";
@@ -19,6 +18,7 @@ import { toast } from "@components/hot-toast";
 import Toast from "@components/notifications/Toast";
 import { useToggle } from "@hooks/hooks";
 import { DeleteModal } from "@components/modals";
+import { SlideOverShell, SlideOverTitle } from "@components/panels";
 import {
   NumberFieldWide,
   PasswordFieldWide,
@@ -462,7 +462,7 @@ function FormFieldsRulesBasic() {
     <div className="border-t border-gray-200 dark:border-gray-700 py-5">
 
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.downloadClient.rulesTitle")}</DialogTitle>
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.downloadClient.rulesTitle")}</h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.downloadClient.rulesDescriptionBasic")}
         </p>
@@ -498,9 +498,9 @@ function FormFieldsRulesArr() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-5 px-2">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.downloadClient.downloadClientTitle")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.downloadClient.downloadClientDescription")}
         </p>
@@ -522,9 +522,9 @@ function FormFieldsRulesQbit() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-5 px-2">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.downloadClient.rulesTitle")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.downloadClient.rulesDescriptionAdvanced")}
         </p>
@@ -591,9 +591,9 @@ function FormFieldsRulesTransmission() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-5 px-2">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.downloadClient.rulesTitle")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.downloadClient.rulesDescriptionAdvanced")}
         </p>
@@ -807,96 +807,72 @@ export function DownloadClientAddForm({ isOpen, toggle }: AddFormProps) {
   };
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog
-        as="div"
-        static
-        className="fixed inset-0 overflow-hidden"
-        open={isOpen}
-        onClose={toggle}
+    <SlideOverShell isOpen={isOpen} toggle={toggle}>
+      <Formik
+        initialValues={initialValues}
+        onSubmit={onSubmit}
       >
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="fixed inset-y-0 right-0 max-w-full flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
-            >
-              <div className="w-screen max-w-2xl ">
-                <Formik
-                  initialValues={initialValues}
-                  onSubmit={onSubmit}
-                >
-                  {({ handleSubmit, values }) => (
-                    <Form
-                      className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto"
-                      onSubmit={handleSubmit}
+        {({ handleSubmit, values }) => (
+          <Form
+            className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800"
+            onSubmit={handleSubmit}
+          >
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <SlideOverTitle>
+                      {t("settings:forms.downloadClient.addTitle")}
+                    </SlideOverTitle>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {t("settings:forms.downloadClient.addDescription")}
+                    </p>
+                  </div>
+                  <div className="h-7 flex items-center">
+                    <button
+                      type="button"
+                      className="bg-white dark:bg-gray-800 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                      onClick={toggle}
                     >
-                      <div className="flex-1">
-                        <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                          <div className="flex items-start justify-between space-x-3">
-                            <div className="space-y-1">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                {t("settings:forms.downloadClient.addTitle")}
-                              </DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
-                                {t("settings:forms.downloadClient.addDescription")}
-                              </p>
-                            </div>
-                            <div className="h-7 flex items-center">
-                              <button
-                                type="button"
-                                className="bg-white dark:bg-gray-800 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                                onClick={toggle}
-                              >
-                                <span className="sr-only">{t("settings:forms.downloadClient.closePanel")}</span>
-                                <XMarkIcon
-                                  className="h-6 w-6"
-                                  aria-hidden="true"
-                                />
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="flex flex-col space-y-4 px-1 py-6 sm:py-0 sm:space-y-0">
-                          <TextFieldWide required name="name" label={t("settings:forms.downloadClient.name")} />
-                          <SwitchGroupWide name="enabled" label={t("settings:forms.downloadClient.enabled")} />
-                          <RadioFieldsetWide
-                            name="type"
-                            legend={t("settings:forms.downloadClient.type")}
-                            options={downloadClientTypeOptions}
-                          />
-                          <div>{componentMap[values.type]}</div>
-                        </div>
-                      </div>
-
-                      {rulesComponentMap[values.type]}
-
-                      <DownloadClientFormButtons
-                        type="CREATE"
-                        isTesting={isTesting}
-                        isSuccessfulTest={isSuccessfulTest}
-                        isErrorTest={isErrorTest}
-                        cancelFn={toggle}
-                        testFn={testClient}
-                        values={values}
+                      <span className="sr-only">{t("settings:forms.downloadClient.closePanel")}</span>
+                      <XMarkIcon
+                        className="h-6 w-6"
+                        aria-hidden="true"
                       />
-
-                      <DEBUG values={values} />
-                    </Form>
-                  )}
-                </Formik>
+                    </button>
+                  </div>
+                </div>
               </div>
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+
+              <div className="flex flex-col space-y-4 px-1 py-6 sm:py-0 sm:space-y-0">
+                <TextFieldWide required name="name" label={t("settings:forms.downloadClient.name")} />
+                <SwitchGroupWide name="enabled" label={t("settings:forms.downloadClient.enabled")} />
+                <RadioFieldsetWide
+                  name="type"
+                  legend={t("settings:forms.downloadClient.type")}
+                  options={downloadClientTypeOptions}
+                />
+                <div>{componentMap[values.type]}</div>
+              </div>
+
+              {rulesComponentMap[values.type]}
+
+              <DEBUG values={values} />
+            </div>
+
+            <DownloadClientFormButtons
+              type="CREATE"
+              isTesting={isTesting}
+              isSuccessfulTest={isSuccessfulTest}
+              isErrorTest={isErrorTest}
+              cancelFn={toggle}
+              testFn={testClient}
+              values={values}
+            />
+          </Form>
+        )}
+      </Formik>
+    </SlideOverShell>
   );
 }
 
@@ -985,108 +961,83 @@ export function DownloadClientUpdateForm({ isOpen, toggle, data: client }: Updat
   };
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog
-        as="div"
-        static
-        className="fixed inset-0 overflow-hidden"
-        open={isOpen}
-        onClose={toggle}
-        initialFocus={cancelButtonRef}
+    <SlideOverShell isOpen={isOpen} toggle={toggle} initialFocus={cancelButtonRef}>
+      <DeleteModal
+        isOpen={deleteModalIsOpen}
+        isLoading={deleteMutation.isPending}
+        toggle={toggleDeleteModal}
+        buttonRef={cancelModalButtonRef}
+        deleteAction={deleteAction}
+        title={t("settings:forms.downloadClient.removeTitle")}
+        text={t("settings:forms.downloadClient.removeText")}
+      />
+      <Formik
+        initialValues={initialValues}
+        onSubmit={onSubmit}
       >
-        <DeleteModal
-          isOpen={deleteModalIsOpen}
-          isLoading={deleteMutation.isPending}
-          toggle={toggleDeleteModal}
-          buttonRef={cancelModalButtonRef}
-          deleteAction={deleteAction}
-          title={t("settings:forms.downloadClient.removeTitle")}
-          text={t("settings:forms.downloadClient.removeText")}
-        />
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
+        {({ handleSubmit, values }) => {
+          return (
+            <Form
+              className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800"
+              onSubmit={handleSubmit}
             >
-              <div className="w-screen max-w-2xl ">
-                <Formik
-                  initialValues={initialValues}
-                  onSubmit={onSubmit}
-                >
-                  {({ handleSubmit, values }) => {
-                    return (
-                      <Form
-                        className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto"
-                        onSubmit={handleSubmit}
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                  <div className="flex items-start justify-between space-x-3">
+                    <div className="space-y-1">
+                      <SlideOverTitle>
+                        {t("settings:forms.downloadClient.editTitle")}
+                      </SlideOverTitle>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        {t("settings:forms.downloadClient.editDescription")}
+                      </p>
+                    </div>
+                    <div className="h-7 flex items-center">
+                      <button
+                        type="button"
+                        className="bg-white dark:bg-gray-800 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                        onClick={toggle}
                       >
-                        <div className="flex-1">
-                          <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                            <div className="flex items-start justify-between space-x-3">
-                              <div className="space-y-1">
-                                <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                  {t("settings:forms.downloadClient.editTitle")}
-                                </DialogTitle>
-                                <p className="text-sm text-gray-500 dark:text-gray-400">
-                                  {t("settings:forms.downloadClient.editDescription")}
-                                </p>
-                              </div>
-                              <div className="h-7 flex items-center">
-                                <button
-                                  type="button"
-                                  className="bg-white dark:bg-gray-800 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                                  onClick={toggle}
-                                >
-                                  <span className="sr-only">{t("settings:forms.downloadClient.closePanel")}</span>
-                                  <XMarkIcon
-                                    className="h-6 w-6"
-                                    aria-hidden="true"
-                                  />
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-
-                          <div className="py-6 space-y-6 sm:py-0 sm:space-y-0 sm:divide-y dark:divide-gray-700">
-                            <TextFieldWide required name="name" label={t("settings:forms.downloadClient.name")} />
-                            <SwitchGroupWide name="enabled" label={t("settings:forms.downloadClient.enabled")} />
-                            <RadioFieldsetWide
-                              name="type"
-                              legend={t("settings:forms.downloadClient.type")}
-                              options={downloadClientTypeOptions}
-                            />
-                            <div>{componentMap[values.type]}</div>
-                          </div>
-                        </div>
-
-                        {rulesComponentMap[values.type]}
-
-                        <DownloadClientFormButtons
-                          type="UPDATE"
-                          toggleDeleteModal={toggleDeleteModal}
-                          isTesting={isTesting}
-                          isSuccessfulTest={isSuccessfulTest}
-                          isErrorTest={isErrorTest}
-                          cancelFn={toggle}
-                          testFn={testClient}
-                          values={values}
+                        <span className="sr-only">{t("settings:forms.downloadClient.closePanel")}</span>
+                        <XMarkIcon
+                          className="h-6 w-6"
+                          aria-hidden="true"
                         />
+                      </button>
+                    </div>
+                  </div>
+                </div>
 
-                        <DEBUG values={values} />
-                      </Form>
-                    );
-                  }}
-                </Formik>
+                <div className="py-6 space-y-6 sm:py-0 sm:space-y-0 sm:divide-y dark:divide-gray-700">
+                  <TextFieldWide required name="name" label={t("settings:forms.downloadClient.name")} />
+                  <SwitchGroupWide name="enabled" label={t("settings:forms.downloadClient.enabled")} />
+                  <RadioFieldsetWide
+                    name="type"
+                    legend={t("settings:forms.downloadClient.type")}
+                    options={downloadClientTypeOptions}
+                  />
+                  <div>{componentMap[values.type]}</div>
+                </div>
+
+                {rulesComponentMap[values.type]}
+
+                <DEBUG values={values} />
               </div>
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+
+              <DownloadClientFormButtons
+                type="UPDATE"
+                toggleDeleteModal={toggleDeleteModal}
+                isTesting={isTesting}
+                isSuccessfulTest={isSuccessfulTest}
+                isErrorTest={isErrorTest}
+                cancelFn={toggle}
+                testFn={testClient}
+                values={values}
+              />
+            </Form>
+          );
+        }}
+      </Formik>
+    </SlideOverShell>
   );
 }

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -9,7 +9,6 @@ import Select from "react-select";
 import type { FieldProps } from "formik";
 import { Field, Form, Formik, FormikValues, useFormikContext } from "formik";
 import { XMarkIcon } from "@heroicons/react/24/solid";
-import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
 import { useTranslation } from "react-i18next";
 
 import { classNames, sleep } from "@utils";
@@ -18,7 +17,7 @@ import { DEBUG } from "@components/debug";
 import { APIClient } from "@api/APIClient";
 import { FeedKeys, IndexerKeys, ReleaseKeys } from "@api/query_keys";
 import { IndexersSchemaQueryOptions, ProxiesQueryOptions } from "@api/queries";
-import { SlideOver } from "@components/panels";
+import { SlideOver, SlideOverShell, SlideOverTitle } from "@components/panels";
 import { toast } from "@components/hot-toast";
 import Toast from "@components/notifications/Toast";
 import { PasswordFieldWide, SwitchButton, SwitchGroupWide, TextFieldWide } from "@components/inputs";
@@ -55,7 +54,7 @@ const IrcSettingFields = (ind: IndexerDefinition, indexer: string) => {
       {ind && ind.implementation == "irc" && ind.irc && ind.irc.settings && (
         <div className="border-t border-gray-200 dark:border-gray-700 py-5">
           <div className="px-4">
-            <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.indexer.settingsIrcTitle")}</DialogTitle>
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.indexer.settingsIrcTitle")}</h2>
             <p className="text-sm text-gray-500 dark:text-gray-200">
               {t("forms.indexer.settingsIrcDesc")}
             </p>
@@ -106,7 +105,7 @@ const TorznabFeedSettingFields = (ind: IndexerDefinition, indexer: string) => {
         {ind && ind.implementation == "torznab" && ind.feed && ind.feed.settings && (
           <div className="">
             <div className="pt-4 px-4">
-              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.indexer.torznabTitle")}</DialogTitle>
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.indexer.torznabTitle")}</h2>
               <p className="text-sm text-gray-500 dark:text-gray-200">
                 {t("forms.indexer.torznabDesc")}
               </p>
@@ -157,7 +156,7 @@ const NewznabFeedSettingFields = (ind: IndexerDefinition, indexer: string) => {
         {ind && ind.implementation == "newznab" && ind.feed && ind.feed.settings && (
           <div className="">
             <div className="pt-4 px-4">
-              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.indexer.newznabTitle")}</DialogTitle>
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.indexer.newznabTitle")}</h2>
               <p className="text-sm text-gray-500 dark:text-gray-200">
                 {t("forms.indexer.newznabDesc")}
               </p>
@@ -200,7 +199,7 @@ const RSSFeedSettingFields = (ind: IndexerDefinition, indexer: string) => {
         {ind && ind.implementation == "rss" && ind.feed && ind.feed.settings && (
           <div className="">
             <div className="pt-4 px-4">
-              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.indexer.rssTitle")}</DialogTitle>
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.indexer.rssTitle")}</h2>
               <p className="text-sm text-gray-500 dark:text-gray-200">
                 {t("forms.indexer.rssDesc")}
               </p>
@@ -601,186 +600,167 @@ export function IndexerAddForm({ isOpen, toggle }: AddFormProps) {
   };
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog as="div" static className="fixed inset-0 overflow-hidden" open={isOpen} onClose={toggle}>
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
-            >
-              <div className="w-screen max-w-2xl">
-                <Formik
-                  enableReinitialize={true}
-                  initialValues={{
-                    enabled: true,
-                    identifier: "",
-                    implementation: "irc",
-                    name: "",
-                    irc: {},
-                    settings: {},
-                    feed: {
-                      categories: [],
-                      capabilities: null,
-                      settings: {}
-                    }
-                  }}
-                  onSubmit={onSubmit}
-                >
-                  {({ values }) => (
-                    <Form className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto">
-                      <div className="flex-1">
-                        <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                          <div className="flex items-start justify-between space-x-3">
-                            <div className="space-y-1">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                {t("forms.indexer.addTitle")}
-                              </DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-200">
-                                {t("forms.indexer.addDescription")}
-                              </p>
-                            </div>
-                            <div className="h-7 flex items-center">
-                              <button
-                                type="button"
-                                className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
-                                onClick={toggle}
-                              >
-                                <span className="sr-only">{t("forms.indexer.closePanel")}</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="divide-y divide-gray-200 dark:divide-gray-700">
-                          <div className="p-4 sm:py-6 flex items-center justify-between sm:grid sm:grid-cols-3 sm:gap-4">
-                            <div>
-                              <label
-                                htmlFor="identifier"
-                                className="block text-sm font-medium text-gray-900 dark:text-white"
-                              >
-                                {t("forms.indexer.indexer")}
-                              </label>
-                            </div>
-                            <div className="sm:col-span-2">
-                              <Field name="identifier" type="select">
-                                {({ field, form: { setFieldValue, resetForm } }: FieldProps) => (
-                                  <Select {...field}
-                                    isClearable={true}
-                                    isSearchable={true}
-                                    components={{
-                                      Input: common.SelectInput,
-                                      Control: common.SelectControl,
-                                      Menu: common.SelectMenu,
-                                      Option: common.SelectOption,
-                                      IndicatorSeparator: common.IndicatorSeparator,
-                                      DropdownIndicator: common.DropdownIndicator
-                                    }}
-                                    placeholder={t("forms.indexer.chooseIndexer")}
-                                    styles={{
-                                      singleValue: (base) => ({
-                                        ...base,
-                                        color: "unset"
-                                      })
-                                    }}
-                                    theme={(theme) => ({
-                                      ...theme,
-                                      spacing: {
-                                        ...theme.spacing,
-                                        controlHeight: 30,
-                                        baseUnit: 2
-                                      }
-                                    })}
-                                    value={field?.value && field.value.value}
-                                    onChange={(option: unknown) => {
-                                      resetForm();
-
-                                      if (option != null) {
-                                        const opt = option as SelectValue;
-                                        setFieldValue("name", opt.label ?? "");
-                                        setFieldValue(field.name, opt.value ?? "");
-
-                                        const ind = data && data.find(i => i.identifier === opt.value);
-                                        if (ind) {
-                                          setIndexer(ind);
-                                          setFieldValue("implementation", ind.implementation);
-
-                                          if (ind.irc && ind.irc.settings) {
-                                            setFieldValue("base_url", ind.urls[0]);
-                                            ind.irc.settings.forEach((s) => {
-                                              setFieldValue(`irc.${s.name}`, s.default ?? "");
-                                            });
-                                          }
-                                        }
-                                      }
-                                    }}
-                                    options={data && data.sort((a, b) => a.name.localeCompare(b.name)).map(v => ({
-                                      label: v.name,
-                                      value: v.identifier
-                                    }))}
-                                  />
-                                )}
-                              </Field>
-
-                            </div>
-                          </div>
-
-                          <SwitchGroupWide name="enabled" label={t("forms.indexer.enabled")} />
-
-                          {indexer.implementation == "irc" && (
-                            <SelectFieldCreatable
-                              name="base_url"
-                              label={t("forms.indexer.baseUrl")}
-                              help={t("forms.indexer.baseUrlHelp")}
-                              options={indexer.urls.map(u => ({ value: u, label: u, key: u }))}
-                            />
-                          )}
-
-                          {SettingFields(indexer, values.identifier)}
-
-                        </div>
-
-                        {IrcSettingFields(indexer, values.identifier)}
-                        {TorznabFeedSettingFields(indexer, values.identifier)}
-                        {NewznabFeedSettingFields(indexer, values.identifier)}
-                        {RSSFeedSettingFields(indexer, values.identifier)}
-                      </div>
-
-                      <div
-                        className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
-                        <div className="space-x-3 flex justify-end">
-                          <button
-                            type="button"
-                            className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={toggle}
-                          >
-                            {t("forms.indexer.cancel")}
-                          </button>
-                          <button
-                            type="submit"
-                            className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                          >
-                            {t("forms.indexer.save")}
-                          </button>
-                        </div>
-                      </div>
-
-                      <DEBUG values={values} />
-                    </Form>
-                  )}
-                </Formik>
+    <SlideOverShell isOpen={isOpen} toggle={toggle}>
+      <Formik
+        enableReinitialize={true}
+        initialValues={{
+          enabled: true,
+          identifier: "",
+          implementation: "irc",
+          name: "",
+          irc: {},
+          settings: {},
+          feed: {
+            categories: [],
+            capabilities: null,
+            settings: {}
+          }
+        }}
+        onSubmit={onSubmit}
+      >
+        {({ values }) => (
+          <Form className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800">
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <SlideOverTitle>
+                      {t("forms.indexer.addTitle")}
+                    </SlideOverTitle>
+                    <p className="text-sm text-gray-500 dark:text-gray-200">
+                      {t("forms.indexer.addDescription")}
+                    </p>
+                  </div>
+                  <div className="h-7 flex items-center">
+                    <button
+                      type="button"
+                      className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                      onClick={toggle}
+                    >
+                      <span className="sr-only">{t("forms.indexer.closePanel")}</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
               </div>
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+
+              <div className="divide-y divide-gray-200 dark:divide-gray-700">
+                <div className="p-4 sm:py-6 flex items-center justify-between sm:grid sm:grid-cols-3 sm:gap-4">
+                  <div>
+                    <label
+                      htmlFor="identifier"
+                      className="block text-sm font-medium text-gray-900 dark:text-white"
+                    >
+                      {t("forms.indexer.indexer")}
+                    </label>
+                  </div>
+                  <div className="sm:col-span-2">
+                    <Field name="identifier" type="select">
+                      {({ field, form: { setFieldValue, resetForm } }: FieldProps) => (
+                        <Select {...field}
+                          isClearable={true}
+                          isSearchable={true}
+                          components={{
+                            Input: common.SelectInput,
+                            Control: common.SelectControl,
+                            Menu: common.SelectMenu,
+                            Option: common.SelectOption,
+                            IndicatorSeparator: common.IndicatorSeparator,
+                            DropdownIndicator: common.DropdownIndicator
+                          }}
+                          placeholder={t("forms.indexer.chooseIndexer")}
+                          styles={{
+                            singleValue: (base) => ({
+                              ...base,
+                              color: "unset"
+                            })
+                          }}
+                          theme={(theme) => ({
+                            ...theme,
+                            spacing: {
+                              ...theme.spacing,
+                              controlHeight: 30,
+                              baseUnit: 2
+                            }
+                          })}
+                          value={field?.value && field.value.value}
+                          onChange={(option: unknown) => {
+                            resetForm();
+
+                            if (option != null) {
+                              const opt = option as SelectValue;
+                              setFieldValue("name", opt.label ?? "");
+                              setFieldValue(field.name, opt.value ?? "");
+
+                              const ind = data && data.find(i => i.identifier === opt.value);
+                              if (ind) {
+                                setIndexer(ind);
+                                setFieldValue("implementation", ind.implementation);
+
+                                if (ind.irc && ind.irc.settings) {
+                                  setFieldValue("base_url", ind.urls[0]);
+                                  ind.irc.settings.forEach((s) => {
+                                    setFieldValue(`irc.${s.name}`, s.default ?? "");
+                                  });
+                                }
+                              }
+                            }
+                          }}
+                          options={data && data.sort((a, b) => a.name.localeCompare(b.name)).map(v => ({
+                            label: v.name,
+                            value: v.identifier
+                          }))}
+                        />
+                      )}
+                    </Field>
+
+                  </div>
+                </div>
+
+                <SwitchGroupWide name="enabled" label={t("forms.indexer.enabled")} />
+
+                {indexer.implementation == "irc" && (
+                  <SelectFieldCreatable
+                    name="base_url"
+                    label={t("forms.indexer.baseUrl")}
+                    help={t("forms.indexer.baseUrlHelp")}
+                    options={indexer.urls.map(u => ({ value: u, label: u, key: u }))}
+                  />
+                )}
+
+                {SettingFields(indexer, values.identifier)}
+
+              </div>
+
+              {IrcSettingFields(indexer, values.identifier)}
+              {TorznabFeedSettingFields(indexer, values.identifier)}
+              {NewznabFeedSettingFields(indexer, values.identifier)}
+              {RSSFeedSettingFields(indexer, values.identifier)}
+
+              <DEBUG values={values} />
+            </div>
+
+            <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
+              <div className="space-x-3 flex justify-end">
+                <button
+                  type="button"
+                  className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={toggle}
+                >
+                  {t("forms.indexer.cancel")}
+                </button>
+                <button
+                  type="submit"
+                  className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                >
+                  {t("forms.indexer.save")}
+                </button>
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </SlideOverShell>
   );
 }
 
@@ -1073,9 +1053,9 @@ export function IndexerUpdateForm({ isOpen, toggle, data: indexer }: UpdateFormP
             <div className="border-t border-gray-200 dark:border-gray-700 py-4">
               <div className="flex justify-between px-4">
                 <div className="space-y-1">
-                  <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+                  <h2 className="text-lg font-medium text-gray-900 dark:text-white">
                     {t("forms.indexer.proxy")}
-                  </DialogTitle>
+                  </h2>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
                     {t("forms.indexer.proxyDesc")}
                   </p>

--- a/web/src/forms/settings/IrcForms.tsx
+++ b/web/src/forms/settings/IrcForms.tsx
@@ -9,7 +9,6 @@ import type { FieldArrayRenderProps, FieldProps } from "formik";
 import { Field, FieldArray, FormikErrors, FormikValues } from "formik";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import Select from "react-select";
-import { DialogTitle } from "@headlessui/react";
 import { useTranslation } from "react-i18next";
 
 import { IrcAuthMechanismTypeOptions, OptionBasicTyped } from "@domain/constants";
@@ -222,7 +221,7 @@ export function IrcNetworkAddForm({ isOpen, toggle }: AddFormProps) {
 
           <div className="border-t border-gray-200 dark:border-gray-700 py-5">
             <div className="px-4 space-y-1 mb-8">
-              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.irc.channels")}</DialogTitle>
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.irc.channels")}</h2>
               <p className="text-sm text-gray-500 dark:text-gray-400">
                 {t("forms.irc.channelsDesc")}
               </p>
@@ -398,9 +397,9 @@ export function IrcNetworkUpdateForm({ isOpen, toggle, data: network }: UpdateFo
           <div className="border-t border-gray-200 dark:border-gray-700 py-4">
             <div className="flex justify-between px-4">
               <div className="space-y-1">
-                <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+                <h2 className="text-lg font-medium text-gray-900 dark:text-white">
                   {t("forms.irc.proxy")}
-                </DialogTitle>
+                </h2>
                 <p className="text-sm text-gray-500 dark:text-gray-400">
                   {t("forms.irc.proxyDesc")}
                 </p>
@@ -422,7 +421,7 @@ export function IrcNetworkUpdateForm({ isOpen, toggle, data: network }: UpdateFo
 
           <div className="border-t border-gray-200 dark:border-gray-700 py-5">
             <div className="px-4 space-y-1 mb-8">
-              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.irc.identification")}</DialogTitle>
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.irc.identification")}</h2>
               <p className="text-sm text-gray-500 dark:text-gray-400">
                 {t("forms.irc.identificationDesc")}
               </p>
@@ -452,7 +451,7 @@ export function IrcNetworkUpdateForm({ isOpen, toggle, data: network }: UpdateFo
 
           <div className="border-t border-gray-200 dark:border-gray-700 py-5">
             <div className="px-4 space-y-1 mb-8">
-              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.irc.channels")}</DialogTitle>
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">{t("forms.irc.channels")}</h2>
               <p className="text-sm text-gray-500 dark:text-gray-400">
                 {t("forms.irc.channelsUpdateDesc")}
               </p>

--- a/web/src/forms/settings/ListForms.tsx
+++ b/web/src/forms/settings/ListForms.tsx
@@ -17,15 +17,11 @@ import {
   useFormikContext
 } from "formik";
 import {
-  Dialog,
-  DialogPanel,
-  DialogTitle,
   Listbox,
   ListboxButton,
   ListboxOption,
   ListboxOptions,
-  Transition,
-  TransitionChild
+  Transition
 } from "@headlessui/react";
 import { CheckIcon, ChevronUpDownIcon, XMarkIcon } from "@heroicons/react/24/solid";
 
@@ -64,6 +60,7 @@ import { DocsTooltip } from "@components/tooltips/DocsTooltip";
 import { MultiSelect as RMSC } from "react-multi-select-component";
 import { useToggle } from "@hooks/hooks.ts";
 import { DeleteModal } from "@components/modals";
+import { SlideOverShell, SlideOverTitle } from "@components/panels";
 import {DocsLink} from "@components/ExternalLink.tsx";
 
 interface ListAddFormValues {
@@ -108,183 +105,158 @@ export function ListAddForm({ isOpen, toggle }: AddFormProps) {
   };
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog
-        as="div"
-        static
-        className="fixed inset-0 overflow-hidden"
-        open={isOpen}
-        onClose={toggle}
+    <SlideOverShell isOpen={isOpen} toggle={toggle}>
+      <Formik
+        enableReinitialize={true}
+        initialValues={{
+          enabled: true,
+          type: "",
+          name: "",
+          client_id: 0,
+          url: "",
+          headers: [],
+          api_key: "",
+          filters: [],
+          match_release: false,
+          tags_included: [],
+          tags_excluded: [],
+          include_unmonitored: false,
+          include_alternate_titles: false,
+          include_year: false,
+          skip_clean_sanitize: false,
+        }}
+        onSubmit={onSubmit}
+        validate={validate}
       >
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
-            >
-              <div className="w-screen max-w-2xl">
-                <Formik
-                  enableReinitialize={true}
-                  initialValues={{
-                    enabled: true,
-                    type: "",
-                    name: "",
-                    client_id: 0,
-                    url: "",
-                    headers: [],
-                    api_key: "",
-                    filters: [],
-                    match_release: false,
-                    tags_included: [],
-                    tags_excluded: [],
-                    include_unmonitored: false,
-                    include_alternate_titles: false,
-                    include_year: false,
-                    skip_clean_sanitize: false,
-                  }}
-                  onSubmit={onSubmit}
-                  validate={validate}
-                >
-                  {({ values }) => (
-                    <Form className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto">
-                      <div className="flex-1">
-                        <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                          <div className="flex items-start justify-between space-x-3">
-                            <div className="space-y-1">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                {t("forms.list.addTitle")}
-                              </DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-200">
-                                {t("forms.list.description")}
-                              </p>
-                            </div>
-                            <div className="h-7 flex items-center">
-                              <button
-                                type="button"
-                                className="cursor-pointer bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
-                                onClick={toggle}
-                              >
-                                <span className="sr-only">{t("forms.list.closePanel")}</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
-                          <TextFieldWide
-                            name="name"
-                            label={t("forms.list.name")}
-                            required={true}
-                          />
-
-                          <div className="flex items-center justify-between space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4">
-                            <div>
-                              <label htmlFor="type" className="block text-sm font-medium text-gray-900 dark:text-white"
-                              >
-                                {t("forms.list.type")}
-                              </label>
-                            </div>
-                            <div className="sm:col-span-2">
-                              <Field name="type" type="select">
-                                {({
-                                    field,
-                                    form: { setFieldValue }
-                                  }: FieldProps) => (
-                                  <Select
-                                    {...field}
-                                    isClearable={true}
-                                    isSearchable={true}
-                                    components={{
-                                      Input: common.SelectInput,
-                                      Control: common.SelectControl,
-                                      Menu: common.SelectMenu,
-                                      Option: common.SelectOption,
-                                      IndicatorSeparator: common.IndicatorSeparator,
-                                      DropdownIndicator: common.DropdownIndicator
-                                    }}
-                                    placeholder={t("forms.list.chooseType")}
-                                    styles={{
-                                      singleValue: (base) => ({
-                                        ...base,
-                                        color: "unset"
-                                      })
-                                    }}
-                                    theme={(theme) => ({
-                                      ...theme,
-                                      spacing: {
-                                        ...theme.spacing,
-                                        controlHeight: 30,
-                                        baseUnit: 2
-                                      }
-                                    })}
-                                    value={field?.value && field.value.value}
-                                    onChange={(newValue: unknown) => {
-                                      const option = newValue as { value: string };
-                                      setFieldValue(field.name, option?.value ?? "");
-                                    }}
-                                    options={ListTypeOptions}
-                                  />
-                                )}
-                              </Field>
-                            </div>
-                          </div>
-
-                          <SwitchGroupWide name="enabled" label={t("forms.list.enabled")}/>
-                        </div>
-
-                        <ListTypeForm listType={values.type as ListType} clients={clients ?? []}/>
-
-                        <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
-                          <div className="border-t border-gray-200 dark:border-gray-700 py-4">
-                            <div className="px-4">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                {t("forms.list.filters")}
-                              </DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
-                                {t("forms.list.filtersDescription")}
-                              </p>
-                            </div>
-
-                            <ListFilterMultiSelectField
-                              name="filters"
-                              label={t("forms.list.filters")}
-                              required={true}
-                              options={filterQuery.data?.map(f => ({ value: f.id, label: f.name })) ?? []}
-                            />
-
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-4 sm:px-6">
-                        <div className="space-x-3 flex justify-end">
-                          <button
-                            type="button"
-                            className="cursor-pointer bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={toggle}
-                          >
-                            {t("forms.list.cancel")}
-                          </button>
-                          <SubmitButton isPending={createMutation.isPending} isError={createMutation.isError} isSuccess={createMutation.isSuccess} />
-                        </div>
-                      </div>
-
-                      <DEBUG values={values}/>
-                    </Form>
-                  )}
-                </Formik>
+        {({ values }) => (
+          <Form className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800">
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <SlideOverTitle>
+                      {t("forms.list.addTitle")}
+                    </SlideOverTitle>
+                    <p className="text-sm text-gray-500 dark:text-gray-200">
+                      {t("forms.list.description")}
+                    </p>
+                  </div>
+                  <div className="h-7 flex items-center">
+                    <button
+                      type="button"
+                      className="cursor-pointer bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                      onClick={toggle}
+                    >
+                      <span className="sr-only">{t("forms.list.closePanel")}</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
+                    </button>
+                  </div>
+                </div>
               </div>
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+
+              <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
+                <TextFieldWide
+                  name="name"
+                  label={t("forms.list.name")}
+                  required={true}
+                />
+
+                <div className="flex items-center justify-between space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4">
+                  <div>
+                    <label htmlFor="type" className="block text-sm font-medium text-gray-900 dark:text-white"
+                    >
+                      {t("forms.list.type")}
+                    </label>
+                  </div>
+                  <div className="sm:col-span-2">
+                    <Field name="type" type="select">
+                      {({
+                          field,
+                          form: { setFieldValue }
+                        }: FieldProps) => (
+                        <Select
+                          {...field}
+                          isClearable={true}
+                          isSearchable={true}
+                          components={{
+                            Input: common.SelectInput,
+                            Control: common.SelectControl,
+                            Menu: common.SelectMenu,
+                            Option: common.SelectOption,
+                            IndicatorSeparator: common.IndicatorSeparator,
+                            DropdownIndicator: common.DropdownIndicator
+                          }}
+                          placeholder={t("forms.list.chooseType")}
+                          styles={{
+                            singleValue: (base) => ({
+                              ...base,
+                              color: "unset"
+                            })
+                          }}
+                          theme={(theme) => ({
+                            ...theme,
+                            spacing: {
+                              ...theme.spacing,
+                              controlHeight: 30,
+                              baseUnit: 2
+                            }
+                          })}
+                          value={field?.value && field.value.value}
+                          onChange={(newValue: unknown) => {
+                            const option = newValue as { value: string };
+                            setFieldValue(field.name, option?.value ?? "");
+                          }}
+                          options={ListTypeOptions}
+                        />
+                      )}
+                    </Field>
+                  </div>
+                </div>
+
+                <SwitchGroupWide name="enabled" label={t("forms.list.enabled")}/>
+              </div>
+
+              <ListTypeForm listType={values.type as ListType} clients={clients ?? []}/>
+
+              <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
+                <div className="border-t border-gray-200 dark:border-gray-700 py-4">
+                  <div className="px-4">
+                    <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+                      {t("forms.list.filters")}
+                    </h2>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {t("forms.list.filtersDescription")}
+                    </p>
+                  </div>
+
+                  <ListFilterMultiSelectField
+                    name="filters"
+                    label={t("forms.list.filters")}
+                    required={true}
+                    options={filterQuery.data?.map(f => ({ value: f.id, label: f.name })) ?? []}
+                  />
+
+                </div>
+              </div>
+              <DEBUG values={values}/>
+            </div>
+
+            <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-4 sm:px-6">
+              <div className="space-x-3 flex justify-end">
+                <button
+                  type="button"
+                  className="cursor-pointer bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={toggle}
+                >
+                  {t("forms.list.cancel")}
+                </button>
+                <SubmitButton isPending={createMutation.isPending} isError={createMutation.isError} isSuccess={createMutation.isSuccess} />
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </SlideOverShell>
   );
 }
 
@@ -330,154 +302,129 @@ export function ListUpdateForm({ isOpen, toggle, data }: UpdateFormProps<List>) 
   const deleteAction = () => deleteMutation.mutate(data.id);
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog
-        as="div"
-        static
-        className="fixed inset-0 overflow-hidden"
-        open={isOpen}
-        onClose={toggle}
+    <SlideOverShell isOpen={isOpen} toggle={toggle}>
+      {deleteAction && (
+        <DeleteModal
+          isOpen={deleteModalIsOpen}
+          isLoading={false}
+          toggle={toggleDeleteModal}
+          buttonRef={cancelModalButtonRef}
+          deleteAction={deleteAction}
+          title={t("forms.list.removeTitle", { name: data.name })}
+          text={t("forms.list.removeText", { name: data.name })}
+        />
+      )}
+      <Formik
+        enableReinitialize={true}
+        initialValues={{
+          id: data.id,
+          enabled: data.enabled,
+          type: data.type,
+          name: data.name,
+          client_id: data.client_id,
+          url: data.url,
+          headers: data.headers || [],
+          api_key: data.api_key,
+          filters: data.filters,
+          match_release: data.match_release,
+          tags_included: data.tags_included,
+          tags_excluded: data.tags_excluded,
+          include_unmonitored: data.include_unmonitored,
+          include_alternate_titles: data.include_alternate_titles,
+          include_year: data.include_year,
+          skip_clean_sanitize: data.skip_clean_sanitize,
+        }}
+        onSubmit={onSubmit}
+        // validate={validate}
       >
-        {deleteAction && (
-          <DeleteModal
-            isOpen={deleteModalIsOpen}
-            isLoading={false}
-            toggle={toggleDeleteModal}
-            buttonRef={cancelModalButtonRef}
-            deleteAction={deleteAction}
-            title={t("forms.list.removeTitle", { name: data.name })}
-            text={t("forms.list.removeText", { name: data.name })}
-          />
-        )}
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
-            >
-              <div className="w-screen max-w-2xl">
-                <Formik
-                  enableReinitialize={true}
-                  initialValues={{
-                    id: data.id,
-                    enabled: data.enabled,
-                    type: data.type,
-                    name: data.name,
-                    client_id: data.client_id,
-                    url: data.url,
-                    headers: data.headers || [],
-                    api_key: data.api_key,
-                    filters: data.filters,
-                    match_release: data.match_release,
-                    tags_included: data.tags_included,
-                    tags_excluded: data.tags_excluded,
-                    include_unmonitored: data.include_unmonitored,
-                    include_alternate_titles: data.include_alternate_titles,
-                    include_year: data.include_year,
-                    skip_clean_sanitize: data.skip_clean_sanitize,
-                  }}
-                  onSubmit={onSubmit}
-                  // validate={validate}
-                >
-                  {({ values }) => (
-                    <Form className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto">
-                      <div className="flex-1">
-                        <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                          <div className="flex items-start justify-between space-x-3">
-                            <div className="space-y-1">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                {t("forms.list.updateTitle")}
-                              </DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-200">
-                                {t("forms.list.description")}
-                              </p>
-                            </div>
-                            <div className="h-7 flex items-center">
-                              <button
-                                type="button"
-                                className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
-                                onClick={toggle}
-                              >
-                                <span className="sr-only">{t("forms.list.closePanel")}</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
-
-                          <TextFieldWide name="name" label={t("forms.list.name")} required={true}/>
-
-                          <TextFieldWide name="type" label={t("forms.list.type")} required={true} disabled={true} />
-
-                          <SwitchGroupWide name="enabled" label={t("forms.list.enabled")}/>
-
-                          <div className="space-y-2 divide-y divide-gray-200 dark:divide-gray-700">
-                            <ListTypeForm listType={values.type} clients={clientsQuery.data ?? []}/>
-                          </div>
-
-                          <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
-                            <div className="border-t border-gray-200 dark:border-gray-700 py-4">
-                              <div className="px-4">
-                                <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                  {t("forms.list.filters")}
-                                </DialogTitle>
-                                <p className="text-sm text-gray-500 dark:text-gray-400">
-                                  {t("forms.list.filtersDescription")}
-                                </p>
-                              </div>
-
-                              <ListFilterMultiSelectField
-                                name="filters"
-                                label={t("forms.list.filters")}
-                                required={true}
-                                options={filterQuery.data?.map(f => ({ value: f.id, label: f.name })) ?? []}
-                              />
-
-                            </div>
-                          </div>
-
-                        </div>
-                      </div>
-
-                      <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-4">
-                        <div className="space-x-3 flex justify-between">
-                          <button
-                            type="button"
-                            className="cursor-pointer inline-flex items-center justify-center px-4 py-2 border border-transparent font-medium rounded-md text-red-700 dark:text-white bg-red-100 dark:bg-red-700 hover:bg-red-200 dark:hover:bg-red-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:text-sm"
-                            onClick={toggleDeleteModal}
-                          >
-                            {t("forms.list.remove")}
-                          </button>
-                          <div className="flex space-x-3">
-                          <button
-                            type="button"
-                            className="cursor-pointer bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={toggle}
-                          >
-                            {t("forms.list.cancel")}
-                          </button>
-                          <SubmitButton isPending={mutation.isPending} isError={mutation.isError} isSuccess={mutation.isSuccess} />
-                          </div>
-                        </div>
-                      </div>
-
-                      <DEBUG values={values}/>
-                    </Form>
-                  )}
-                </Formik>
+        {({ values }) => (
+          <Form className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800">
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <SlideOverTitle>
+                      {t("forms.list.updateTitle")}
+                    </SlideOverTitle>
+                    <p className="text-sm text-gray-500 dark:text-gray-200">
+                      {t("forms.list.description")}
+                    </p>
+                  </div>
+                  <div className="h-7 flex items-center">
+                    <button
+                      type="button"
+                      className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                      onClick={toggle}
+                    >
+                      <span className="sr-only">{t("forms.list.closePanel")}</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true"/>
+                    </button>
+                  </div>
+                </div>
               </div>
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+
+              <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
+
+                <TextFieldWide name="name" label={t("forms.list.name")} required={true}/>
+
+                <TextFieldWide name="type" label={t("forms.list.type")} required={true} disabled={true} />
+
+                <SwitchGroupWide name="enabled" label={t("forms.list.enabled")}/>
+
+                <div className="space-y-2 divide-y divide-gray-200 dark:divide-gray-700">
+                  <ListTypeForm listType={values.type} clients={clientsQuery.data ?? []}/>
+                </div>
+
+                <div className="flex flex-col space-y-4 py-6 sm:py-0 sm:space-y-0">
+                  <div className="border-t border-gray-200 dark:border-gray-700 py-4">
+                    <div className="px-4">
+                      <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+                        {t("forms.list.filters")}
+                      </h2>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        {t("forms.list.filtersDescription")}
+                      </p>
+                    </div>
+
+                    <ListFilterMultiSelectField
+                      name="filters"
+                      label={t("forms.list.filters")}
+                      required={true}
+                      options={filterQuery.data?.map(f => ({ value: f.id, label: f.name })) ?? []}
+                    />
+
+                  </div>
+                </div>
+
+              </div>
+              <DEBUG values={values}/>
+            </div>
+
+            <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-4">
+              <div className="space-x-3 flex justify-between">
+                <button
+                  type="button"
+                  className="cursor-pointer inline-flex items-center justify-center px-4 py-2 border border-transparent font-medium rounded-md text-red-700 dark:text-white bg-red-100 dark:bg-red-700 hover:bg-red-200 dark:hover:bg-red-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:text-sm"
+                  onClick={toggleDeleteModal}
+                >
+                  {t("forms.list.remove")}
+                </button>
+                <div className="flex space-x-3">
+                <button
+                  type="button"
+                  className="cursor-pointer bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={toggle}
+                >
+                  {t("forms.list.cancel")}
+                </button>
+                <SubmitButton isPending={mutation.isPending} isError={mutation.isError} isSuccess={mutation.isSuccess} />
+                </div>
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </SlideOverShell>
   );
 }
 
@@ -628,9 +575,9 @@ function ListTypeArr({ listType, clients }: ListTypeFormProps) {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.list.source")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.list.arrSourceDescription")}
         </p>
@@ -670,9 +617,9 @@ function ListTypeTrakt() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.list.sourceList")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.list.traktSourceDescription")}
         </p>
@@ -708,9 +655,9 @@ function ListTypeAniList() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4 space-y-1">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.list.sourceList")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.list.anilistSourceDescription")}
         </p>
@@ -737,9 +684,9 @@ function ListTypePlainText() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.list.sourceList")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.list.plaintextSourceDescription")}
         </p>
@@ -783,9 +730,9 @@ function ListTypeSteam() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.list.sourceList")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.list.steamSourceDescription")}
         </p>
@@ -801,9 +748,9 @@ function ListTypeMetacritic() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.list.sourceList")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.list.metacriticSourceDescription")}
         </p>
@@ -840,9 +787,9 @@ function ListTypeMDBList() {
     return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.list.sourceList")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.list.mdblistSourceDescription")}
         </p>

--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
-import { Fragment, useMemo } from "react";
+import { useMemo } from "react";
 import type { FieldProps } from "formik";
 import { Field, Form, Formik, FormikErrors, FormikValues, useFormikContext } from "formik";
 import { XMarkIcon } from "@heroicons/react/24/solid";
@@ -18,7 +17,7 @@ import { NotificationKeys } from "@api/query_keys";
 import { PushoverSoundsQueryOptions } from "@api/queries";
 import { ExternalFilterWebhookMethodOptions, getEventOptions, getNotificationTypeOptions, PushoverSoundOptions, SelectOption } from "@domain/constants";
 import { DEBUG } from "@components/debug";
-import { SlideOver } from "@components/panels";
+import { SlideOver, SlideOverShell, SlideOverTitle } from "@components/panels";
 import { ExternalLink } from "@components/ExternalLink";
 import { toast } from "@components/hot-toast";
 import Toast from "@components/notifications/Toast";
@@ -35,9 +34,9 @@ function FormFieldsDiscord() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.notification.settings")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.notification.settingsDescDiscordPrefix")}
           <ExternalLink
@@ -65,9 +64,9 @@ function FormFieldsNotifiarr() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.notification.settings")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.notification.settingsDescNotifiarr")}
         </p>
@@ -87,9 +86,9 @@ function FormFieldsLunaSea() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.notification.settings")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.notification.settingsDescLunasea1")}
         </p>
@@ -120,9 +119,9 @@ function FormFieldsTelegram() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.notification.settings")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.notification.settingsDescTelegramPrefix")}
           <ExternalLink
@@ -180,9 +179,9 @@ function FormFieldsPushover() {
 
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.notification.settings")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.notification.settingsDescPushoverPrefix")}
           <ExternalLink
@@ -216,9 +215,9 @@ function FormFieldsPushover() {
         <div className="flex justify-between items-center p-4">
 
         <div className="">
-          <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+          <h2 className="text-lg font-medium text-gray-900 dark:text-white">
             {t("forms.notification.eventSounds")}
-          </DialogTitle>
+          </h2>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             {t("forms.notification.eventSoundsDesc")}
           </p>
@@ -242,9 +241,9 @@ function FormFieldsGotify() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.notification.settings")}
-        </DialogTitle>
+        </h2>
       </div>
 
       <TextFieldWide
@@ -269,9 +268,9 @@ function FormFieldsNtfy() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.notification.settings")}
-        </DialogTitle>
+        </h2>
       </div>
 
       <TextFieldWide
@@ -321,9 +320,9 @@ function FormFieldsShoutrrr() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.notification.settings")}
-        </DialogTitle>
+        </h2>
       </div>
 
       <TextFieldWide
@@ -352,9 +351,9 @@ function FormFieldsGenericWebhook() {
   return (
     <div className="border-t border-gray-200 dark:border-gray-700 py-4">
       <div className="px-4">
-        <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
           {t("forms.notification.settings")}
-        </DialogTitle>
+        </h2>
         <p className="text-sm text-gray-500 dark:text-gray-400">
           {t("forms.notification.settingsDescWebhook")}
         </p>
@@ -439,189 +438,165 @@ export function NotificationAddForm({ isOpen, toggle }: AddFormProps) {
   };
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog
-        as="div"
-        static
-        className="fixed inset-0 overflow-hidden"
-        open={isOpen}
-        onClose={toggle}
+    <SlideOverShell isOpen={isOpen} toggle={toggle}>
+      <Formik
+        enableReinitialize={true}
+        initialValues={{
+          enabled: true,
+          type: "",
+          name: "",
+          webhook: "",
+          events: [],
+          username: "",
+          sound: "",
+          event_sounds: {}
+        }}
+        onSubmit={onSubmit}
+        validate={validate}
       >
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
-            >
-              <div className="w-screen max-w-2xl">
-                <Formik
-                  enableReinitialize={true}
-                  initialValues={{
-                    enabled: true,
-                    type: "",
-                    name: "",
-                    webhook: "",
-                    events: [],
-                    username: "",
-                    sound: "",
-                    event_sounds: {}
-                  }}
-                  onSubmit={onSubmit}
-                  validate={validate}
-                >
-                  {({ values }) => (
-                    <Form className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto">
-                      <div className="flex-1">
-                        <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                          <div className="flex items-start justify-between space-x-3">
-                            <div className="space-y-1">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                {t("settings:forms.notification.addTitle")}
-                              </DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-200">
-                                {t("settings:forms.notification.addDescription")}
-                              </p>
-                            </div>
-                            <div className="h-7 flex items-center">
-                              <button
-                                type="button"
-                                className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
-                                onClick={toggle}
-                              >
-                                <span className="sr-only">{t("settings:forms.notification.closePanel")}</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="flex flex-col space-y-4 px-1 pt-6 sm:py-0 sm:space-y-0">
-                          <TextFieldWide
-                            name="name"
-                            label={t("settings:forms.notification.name")}
-                            required={true}
-                          />
-
-                          <div className="flex items-center justify-between space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4">
-                            <div>
-                              <label
-                                htmlFor="type"
-                                className="block text-sm font-medium text-gray-900 dark:text-white"
-                              >
-                                {t("settings:forms.notification.type")}
-                              </label>
-                            </div>
-                            <div className="sm:col-span-2">
-                              <Field name="type" type="select">
-                                {({
-                                  field,
-                                  form: { setFieldValue, resetForm }
-                                }: FieldProps) => (
-                                  <Select
-                                    {...field}
-                                    isClearable={true}
-                                    isSearchable={true}
-                                    components={{
-                                      Input: common.SelectInput,
-                                      Control: common.SelectControl,
-                                      Menu: common.SelectMenu,
-                                      Option: common.SelectOption,
-                                      IndicatorSeparator: common.IndicatorSeparator,
-                                      DropdownIndicator: common.DropdownIndicator
-                                    }}
-                                    placeholder={t("settings:forms.notification.chooseType")}
-                                    styles={{
-                                      singleValue: (base) => ({
-                                        ...base,
-                                        color: "unset"
-                                      })
-                                    }}
-                                    theme={(theme) => ({
-                                      ...theme,
-                                      spacing: {
-                                        ...theme.spacing,
-                                        controlHeight: 30,
-                                        baseUnit: 2
-                                      }
-                                    })}
-                                    value={field?.value && field.value.value}
-                                    onChange={(option: unknown) => {
-                                      resetForm();
-
-                                      const opt = option as SelectOption;
-                                      // setFieldValue("name", option?.label ?? "")
-                                      setFieldValue(
-                                        field.name,
-                                        opt.value ?? ""
-                                      );
-                                    }}
-                                    options={notificationTypeOptions}
-                                  />
-                                )}
-                              </Field>
-                            </div>
-                          </div>
-
-                          <SwitchGroupWide name="enabled" label={t("settings:forms.notification.enabled")} />
-
-                          <div className="border-t border-gray-200 dark:border-gray-700 py-4">
-                            <div className="px-4">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                {t("settings:forms.notification.globalEvents")}
-                              </DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
-                                {t("settings:forms.notification.globalEventsDesc")}
-                              </p>
-                            </div>
-
-                            <div className="p-4 sm:grid sm:gap-4">
-                              <EventCheckBoxes />
-                            </div>
-                          </div>
-                        </div>
-                        {componentMap[values.type]}
-                      </div>
-
-                      <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-4 sm:px-6">
-                        <div className="space-x-3 flex justify-end">
-                          <button
-                            type="button"
-                            className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={() => testNotification(values)}
-                          >
-                            {t("settings:forms.notification.test")}
-                          </button>
-                          <button
-                            type="button"
-                            className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={toggle}
-                          >
-                            {t("settings:forms.notification.cancel")}
-                          </button>
-                          <button
-                            type="submit"
-                            className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                          >
-                            {t("settings:forms.notification.save")}
-                          </button>
-                        </div>
-                      </div>
-
-                      <DEBUG values={values} />
-                    </Form>
-                  )}
-                </Formik>
+        {({ values }) => (
+          <Form className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800">
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <SlideOverTitle>
+                      {t("settings:forms.notification.addTitle")}
+                    </SlideOverTitle>
+                    <p className="text-sm text-gray-500 dark:text-gray-200">
+                      {t("settings:forms.notification.addDescription")}
+                    </p>
+                  </div>
+                  <div className="h-7 flex items-center">
+                    <button
+                      type="button"
+                      className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                      onClick={toggle}
+                    >
+                      <span className="sr-only">{t("settings:forms.notification.closePanel")}</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
               </div>
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+
+              <div className="flex flex-col space-y-4 px-1 pt-6 sm:py-0 sm:space-y-0">
+                <TextFieldWide
+                  name="name"
+                  label={t("settings:forms.notification.name")}
+                  required={true}
+                />
+
+                <div className="flex items-center justify-between space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4">
+                  <div>
+                    <label
+                      htmlFor="type"
+                      className="block text-sm font-medium text-gray-900 dark:text-white"
+                    >
+                      {t("settings:forms.notification.type")}
+                    </label>
+                  </div>
+                  <div className="sm:col-span-2">
+                    <Field name="type" type="select">
+                      {({
+                        field,
+                        form: { setFieldValue, resetForm }
+                      }: FieldProps) => (
+                        <Select
+                          {...field}
+                          isClearable={true}
+                          isSearchable={true}
+                          components={{
+                            Input: common.SelectInput,
+                            Control: common.SelectControl,
+                            Menu: common.SelectMenu,
+                            Option: common.SelectOption,
+                            IndicatorSeparator: common.IndicatorSeparator,
+                            DropdownIndicator: common.DropdownIndicator
+                          }}
+                          placeholder={t("settings:forms.notification.chooseType")}
+                          styles={{
+                            singleValue: (base) => ({
+                              ...base,
+                              color: "unset"
+                            })
+                          }}
+                          theme={(theme) => ({
+                            ...theme,
+                            spacing: {
+                              ...theme.spacing,
+                              controlHeight: 30,
+                              baseUnit: 2
+                            }
+                          })}
+                          value={field?.value && field.value.value}
+                          onChange={(option: unknown) => {
+                            resetForm();
+
+                            const opt = option as SelectOption;
+                            // setFieldValue("name", option?.label ?? "")
+                            setFieldValue(
+                              field.name,
+                              opt.value ?? ""
+                            );
+                          }}
+                          options={notificationTypeOptions}
+                        />
+                      )}
+                    </Field>
+                  </div>
+                </div>
+
+                <SwitchGroupWide name="enabled" label={t("settings:forms.notification.enabled")} />
+
+                <div className="border-t border-gray-200 dark:border-gray-700 py-4">
+                  <div className="px-4">
+                    <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+                      {t("settings:forms.notification.globalEvents")}
+                    </h2>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {t("settings:forms.notification.globalEventsDesc")}
+                    </p>
+                  </div>
+
+                  <div className="p-4 sm:grid sm:gap-4">
+                    <EventCheckBoxes />
+                  </div>
+                </div>
+              </div>
+              {componentMap[values.type]}
+
+              <DEBUG values={values} />
+            </div>
+
+            <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-4 sm:px-6">
+              <div className="space-x-3 flex justify-end">
+                <button
+                  type="button"
+                  className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={() => testNotification(values)}
+                >
+                  {t("settings:forms.notification.test")}
+                </button>
+                <button
+                  type="button"
+                  className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={toggle}
+                >
+                  {t("settings:forms.notification.cancel")}
+                </button>
+                <button
+                  type="submit"
+                  className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                >
+                  {t("settings:forms.notification.save")}
+                </button>
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </SlideOverShell>
   );
 }
 
@@ -928,9 +903,9 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
             <SwitchGroupWide name="enabled" label={t("settings:forms.notification.enabled")} />
             <div className="pb-2">
               <div className="p-4">
-                <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+                <h2 className="text-lg font-medium text-gray-900 dark:text-white">
                   {t("settings:forms.notification.globalEvents")}
-                </DialogTitle>
+                </h2>
                 <p className="text-sm text-gray-500 dark:text-gray-400">
                   {t("settings:forms.notification.globalEventsDesc")}
                 </p>
@@ -944,9 +919,9 @@ export function NotificationUpdateForm({ isOpen, toggle, data: notification }: U
 
           <div className="pb-2">
             <div className="p-4">
-                <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
+                <h2 className="text-lg font-medium text-gray-900 dark:text-white">
                   {t("settings:forms.notification.perFilterEvents")}
-                </DialogTitle>
+                </h2>
                 <p className="text-sm text-gray-500 dark:text-gray-400">
                   {t("settings:forms.notification.perFilterEventsDesc")}
                 </p>

--- a/web/src/forms/settings/ProxyForms.tsx
+++ b/web/src/forms/settings/ProxyForms.tsx
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Fragment } from "react";
 import { Form, Formik, FormikValues } from "formik";
-import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from "@headlessui/react";
 import { XMarkIcon } from "@heroicons/react/24/solid";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
@@ -19,7 +17,7 @@ import { APIClient } from "@api/APIClient";
 import { ProxyKeys } from "@api/query_keys";
 import { toast } from "@components/hot-toast";
 import Toast from "@components/notifications/Toast";
-import { SlideOver } from "@components/panels";
+import { SlideOver, SlideOverShell, SlideOverTitle } from "@components/panels";
 
 export function ProxyAddForm({ isOpen, toggle }: AddFormProps) {
   const { t } = useTranslation("settings");
@@ -61,113 +59,87 @@ export function ProxyAddForm({ isOpen, toggle }: AddFormProps) {
   }
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog
-        as="div"
-        static
-        className="fixed inset-0 overflow-hidden"
-        open={isOpen}
-        onClose={toggle}
+    <SlideOverShell isOpen={isOpen} toggle={toggle}>
+      <Formik
+        enableReinitialize={true}
+        initialValues={initialValues}
+        onSubmit={onSubmit}
       >
-        <div className="absolute inset-0 overflow-hidden">
-          <DialogPanel className="absolute inset-y-0 right-0 max-w-full flex">
-            <TransitionChild
-              as={Fragment}
-              enter="transform transition ease-in-out duration-500 sm:duration-700"
-              enterFrom="translate-x-full"
-              enterTo="translate-x-0"
-              leave="transform transition ease-in-out duration-500 sm:duration-700"
-              leaveFrom="translate-x-0"
-              leaveTo="translate-x-full"
-            >
-              <div className="w-screen max-w-2xl">
-                <Formik
-                  enableReinitialize={true}
-                  initialValues={initialValues}
-                  onSubmit={onSubmit}
-                >
-                  {({ values }) => (
-                    <Form className="h-full flex flex-col bg-white dark:bg-gray-800 shadow-xl overflow-y-auto">
-                      <div className="flex-1">
-                        <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
-                          <div className="flex items-start justify-between space-x-3">
-                            <div className="space-y-1">
-                              <DialogTitle className="text-lg font-medium text-gray-900 dark:text-white">
-                                {t("forms.proxy.addTitle")}
-                              </DialogTitle>
-                              <p className="text-sm text-gray-500 dark:text-gray-200">
-                                {t("forms.proxy.addDescription")}
-                              </p>
-                            </div>
-                            <div className="h-7 flex items-center">
-                              <button
-                                type="button"
-                                className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
-                                onClick={toggle}
-                              >
-                                <span className="sr-only">{t("forms.proxy.closePanel")}</span>
-                                <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="divide-y divide-gray-200 dark:divide-gray-700">
-                          <TextFieldWide name="name" label={t("forms.proxy.name")} defaultValue="" required={true} />
-                          <SwitchGroupWide name="enabled" label={t("forms.proxy.enabled")} />
-                          <SelectFieldBasic
-                            name="type"
-                            label={t("forms.proxy.proxyType")}
-                            options={ProxyTypeOptions}
-                            tooltip={<span>{t("forms.proxy.proxyTypeTooltip")}</span>}
-                            help={t("forms.proxy.proxyTypeHelp")}
-                          />
-                          <TextFieldWide name="addr" label={t("forms.proxy.addr")} required={true} help={t("forms.proxy.addrHelp")} autoComplete="off"/>
-                        </div>
-
-                        <div>
-                          <TextFieldWide name="user" label={t("forms.proxy.user")} help={t("forms.proxy.userHelp")} autoComplete="off" />
-                          <PasswordFieldWide name="pass" label={t("forms.proxy.pass")} help={t("forms.proxy.passHelp")} autoComplete="off"/>
-                        </div>
-                      </div>
-
-                      <div
-                        className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
-                        <div className="space-x-3 flex justify-end">
-                          <button
-                            type="button"
-                            className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={() => testProxy(values)}
-                          >
-                            {t("forms.proxy.test")}
-                          </button>
-                          <button
-                            type="button"
-                            className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                            onClick={toggle}
-                          >
-                            {t("forms.proxy.cancel")}
-                          </button>
-                          <button
-                            type="submit"
-                            className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
-                          >
-                            {t("forms.proxy.save")}
-                          </button>
-                        </div>
-                      </div>
-
-                      <DEBUG values={values}/>
-                    </Form>
-                  )}
-                </Formik>
+        {({ values }) => (
+          <Form className="h-full min-h-0 flex flex-col bg-white dark:bg-gray-800">
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="px-4 py-6 bg-gray-50 dark:bg-gray-900 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <SlideOverTitle>
+                      {t("forms.proxy.addTitle")}
+                    </SlideOverTitle>
+                    <p className="text-sm text-gray-500 dark:text-gray-200">
+                      {t("forms.proxy.addDescription")}
+                    </p>
+                  </div>
+                  <div className="h-7 flex items-center">
+                    <button
+                      type="button"
+                      className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                      onClick={toggle}
+                    >
+                      <span className="sr-only">{t("forms.proxy.closePanel")}</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
               </div>
 
-            </TransitionChild>
-          </DialogPanel>
-        </div>
-      </Dialog>
-    </Transition>
+              <div className="divide-y divide-gray-200 dark:divide-gray-700">
+                <TextFieldWide name="name" label={t("forms.proxy.name")} defaultValue="" required={true} />
+                <SwitchGroupWide name="enabled" label={t("forms.proxy.enabled")} />
+                <SelectFieldBasic
+                  name="type"
+                  label={t("forms.proxy.proxyType")}
+                  options={ProxyTypeOptions}
+                  tooltip={<span>{t("forms.proxy.proxyTypeTooltip")}</span>}
+                  help={t("forms.proxy.proxyTypeHelp")}
+                />
+                <TextFieldWide name="addr" label={t("forms.proxy.addr")} required={true} help={t("forms.proxy.addrHelp")} autoComplete="off"/>
+              </div>
+
+              <div>
+                <TextFieldWide name="user" label={t("forms.proxy.user")} help={t("forms.proxy.userHelp")} autoComplete="off" />
+                <PasswordFieldWide name="pass" label={t("forms.proxy.pass")} help={t("forms.proxy.passHelp")} autoComplete="off"/>
+              </div>
+
+              <DEBUG values={values}/>
+            </div>
+
+            <div className="shrink-0 px-4 border-t border-gray-200 dark:border-gray-700 py-5 sm:px-6">
+              <div className="space-x-3 flex justify-end">
+                <button
+                  type="button"
+                  className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={() => testProxy(values)}
+                >
+                  {t("forms.proxy.test")}
+                </button>
+                <button
+                  type="button"
+                  className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  onClick={toggle}
+                >
+                  {t("forms.proxy.cancel")}
+                </button>
+                <button
+                  type="submit"
+                  className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                >
+                  {t("forms.proxy.save")}
+                </button>
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </SlideOverShell>
   );
 }
 


### PR DESCRIPTION
# Description

Users running a password manager extension (reported with NordPass on Brave) had the indexer/IRC slide-over panels freeze: fields stopped responding and the panel could no longer be scrolled once the autofill dropdown appeared.

## Root cause

The bug is not Brave-specific. It is a conflict between Headless UI's modal `Dialog` and the UI password managers inject into the page. Unpacking the NordPass extension (v7.9.2) showed its autofill dropdown is rendered in-page and covers the viewport with a transparent `fixed inset-0 z-[9998]` backdrop while open. On a normal page this is harmless: wheel events over the backdrop scroll-chain to `<body>` and the first click dismisses it. Inside a Headless UI modal dialog three behaviors turn it into a freeze:

1. The dialog's scroll lock sets `overflow: hidden` on the document root, so wheel events landing on the extension backdrop have nowhere to chain - nothing scrolls at all.
2. `useInertOthers` marks every body-level sibling of the dialog portal `inert`, which can make the extension's own UI dead to clicks.
3. The outside-click handler treats any pointer press outside the panel (including clicks meant to dismiss the autofill dropdown) as a reason to close the whole panel, and window blur to an extension iframe as an outside click.

## Fix

All slide-over panels now use the Base UI `Drawer` (`@base-ui/react`, the renamed successor of `@base-ui-components/react`), configured **non-modal**:

- `modal={false}`: no page scroll lock, no `inert` on the rest of the page, no focus trap - all three interference points are gone. With an autofill dropdown open, the panel now behaves like the non-dialog pages do: one click dismisses the dropdown and everything keeps working.
- `disablePointerDismissal`: Base UI's document-level outside-press close is disabled, so interacting with an extension overlay can never close the panel. Outside-click-to-close parity with the old UI is kept via a transparent `Drawer.Backdrop` with a plain `onClick` - a real element click that extension overlays sitting above it never trigger.
- Escape still closes; open/close keeps the same 500ms/700ms slide transition (CSS-driven via `data-starting-style`/`data-ending-style`).
- Swipe-to-dismiss is disabled (`data-base-ui-swipe-ignore` wrapper) so a stray horizontal touch drag cannot discard a half-filled form.

Implementation notes:

- `components/panels` now exports a shared `SlideOverShell` (drawer shell) and `SlideOverTitle` (accessible title), and the existing Formik `SlideOver` is rebuilt on top with an unchanged API.
- The six forms that carried their own copy of the Dialog shell (IndexerForms add, DownloadClientForms add/update, NotificationForms add, ProxyForms add, APIKeyAddForm, FilterAddForm, plus both ListForms drawers) were migrated onto the shared shell, removing the duplicated markup. `DialogTitle`s that were really section headings became plain `h2`s.
- Panels now use a sticky footer (header + scrollable body + pinned action bar) instead of scrolling the whole form. The Headless UI v1-era `preventDefault` click hack on the panel is gone; its legitimate half (clicks inside the portaled drawer bubble up the React tree to ancestors such as the expandable IRC network row an update form is mounted in) is handled once in the shared shell, which stops click propagation at the portal boundary.
- The centered confirm modals (`components/modals`, e.g. DeleteModal) intentionally stay on Headless UI: modal behavior is correct there, and they stack above the drawer as before.
- Drawers carry no z-index (parity with the old dialogs, keeps `z-10` modals on top); FilterAddForm keeps its `z-20`.

Fixes #2536

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* `pnpm --dir web build` (tsc + vite) and `pnpm --dir web lint` pass; no new lint findings in touched files.
* Drove the full app (Go backend + Vite dev server) with headless Chromium via Playwright:
  * With a drawer open, `<html>`/`<body>` keep `overflow: visible` and `#root` has no `inert`/`aria-hidden` - the freeze mechanisms are verified gone.
  * Drawer body scrolls, fields accept input, Escape and backdrop click both close the panel, `initialFocus` still lands on the filter name field.
  * Update flow: Edit proxy -> Remove -> DeleteModal renders above the drawer and blocks it (hit-tested), Cancel returns to the intact drawer.
  * Smoke-opened every migrated drawer (IRC, Indexers, Lists, Notifications, Clients, API keys, Proxies, Filters) with zero console/page errors.
* Simulated the extension scenario: a `fixed inset-0 z-[9998]` overlay no longer blocks panel interaction after dismissal and can never close the panel, since document scroll and outside-press dismissal are no longer in play.

## Screenshots (for UI changes)

<!-- attach: IRC add drawer, indexer add drawer, proxy update drawer with DeleteModal on top -->

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally (no Go changes)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL (n/a)
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

The root-cause investigation (including unpacking the NordPass extension) were done with Claude Fable 5.