### PR TITLE
fix(irc): keep live updates in sync with history when skipping message cleaning

### DIFF
--- a/internal/irc/channel.go
+++ b/internal/irc/channel.go
@@ -147,9 +147,12 @@ func NewChannel(log zerolog.Logger, networkID int64, name string, defaultChannel
 	}
 }
 
-func (c *Channel) OnMsg(msg ircmsg.Message) {
+// OnMsg records the message in the channel history and queues it for announce
+// parsing. It returns the stored message so callers broadcast the same text
+// that went into history, honoring SkipCleanMessage.
+func (c *Channel) OnMsg(msg ircmsg.Message) (domain.IrcMessage, bool) {
 	if len(msg.Params) < 2 {
-		return
+		return domain.IrcMessage{}, false
 	}
 
 	// parse announce
@@ -177,15 +180,17 @@ func (c *Channel) OnMsg(msg ircmsg.Message) {
 	// check if the message is from announce bot, if not return
 	if !c.IsValidAnnouncer(nick) {
 		c.log.Trace().Str("nick", nick).Str("msg", cleanedMsg).Msg("not a valid announcer, ignoring")
-		return
+		return newMsg, true
 	}
 
 	if err := c.QueueAnnounceLine(cleanedMsg); err != nil {
-		return
+		return newMsg, true
 	}
 	c.UpdateLastAnnounce()
 
 	c.log.Debug().Str("nick", nick).Str("msg", cleanedMsg).Msg("got message")
+
+	return newMsg, true
 }
 
 // IsValidAnnouncer reports whether nick is a registered announcer for this

--- a/internal/irc/channel_test.go
+++ b/internal/irc/channel_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/featureflags"
 
+	"github.com/ergochat/irc-go/ircmsg"
 	"github.com/rs/zerolog"
 )
 
@@ -61,6 +62,48 @@ func TestChannel_IsValidAnnouncer_Exp_Flag(t *testing.T) {
 			c := newAnnouncerChannel(tt.announcers)
 			if got := c.IsValidAnnouncer(tt.nick); got != tt.want {
 				t.Errorf("IsValidAnnouncer(%q) = %v, want %v", tt.nick, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChannel_OnMsg_SkipCleanMessage(t *testing.T) {
+	const raw = "\x02New Torrent\x02: \x0304Some.Release-GRP\x03"
+
+	tests := []struct {
+		name string
+		skip bool
+		want string
+	}{
+		{name: "cleans by default", skip: false, want: "New Torrent: Some.Release-GRP"},
+		{name: "keeps raw when skipping", skip: true, want: raw},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewChannel(zerolog.Nop(), 1, "#chan", true, tt.skip, nil)
+
+			msg := ircmsg.Message{
+				Source:  "announce-bot!bot@host",
+				Command: "PRIVMSG",
+				Params:  []string{"#chan", raw},
+			}
+
+			got, ok := c.OnMsg(msg)
+			if !ok {
+				t.Fatal("OnMsg() returned ok = false")
+			}
+			if got.Message != tt.want {
+				t.Errorf("OnMsg() message = %q, want %q", got.Message, tt.want)
+			}
+
+			// the broadcast message must match what went into history
+			history := c.Messages.GetMessages()
+			if len(history) != 1 {
+				t.Fatalf("history has %d messages, want 1", len(history))
+			}
+			if history[0].Message != got.Message {
+				t.Errorf("history message = %q, broadcast = %q", history[0].Message, got.Message)
 			}
 		})
 	}

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -989,16 +989,13 @@ func (h *Handler) onPrivMessage(msg ircmsg.Message) {
 	channel := strings.ToLower(msg.Params[0])
 	message := msg.Params[1]
 
-	// clean message
-	cleanedMsg := cleanMessage(message)
-
 	if message == "CLIENTINFO" {
 		return
 	}
 
 	if channel == h.CurrentNick() {
 		// this is a DM - possibly an invite bot answering our invite command
-		h.log.Debug().Str("direct-message", channel).Str("from-nick", nick).Str("msg", cleanedMsg).Msg("got direct-message")
+		h.log.Debug().Str("direct-message", channel).Str("from-nick", nick).Str("msg", cleanMessage(message)).Msg("got direct-message")
 
 		// a DM from an invite bot while a channel is still awaiting its invite is
 		// a rejection, not the invite itself (that arrives as INVITE)
@@ -1014,14 +1011,13 @@ func (h *Handler) onPrivMessage(msg ircmsg.Message) {
 		return
 	}
 
-	ircChannel.OnMsg(msg)
+	ircMsg, ok := ircChannel.OnMsg(msg)
+	if !ok {
+		return
+	}
 
 	// publish to SSE stream
-	h.broadcastMessage(domain.IrcMessage{Network: h.GetNetwork().ID, Channel: channel, Nick: nick, Message: cleanedMsg, Time: time.Now()})
-
-	//h.log.Debug().Str("channel", channel).Str("nick", nick).Msg(cleanedMsg)
-
-	return
+	h.broadcastMessage(ircMsg)
 }
 
 // JoinChannels sends multiple join commands


### PR DESCRIPTION
# Description

When a channel has `parse.skipcleanmessage` enabled, the stored history and the live SSE stream showed different text for the same announce. `Channel.OnMsg` honored the setting when adding to the message buffer, but `Handler.onPrivMessage` built its own `cleanMessage(message)` and broadcast that unconditionally, so the web UI's live view always showed stripped text while `/history` kept the raw line.

`OnMsg` now returns the message it stored, and `onPrivMessage` broadcasts that exact value instead of re-deriving it. The two paths can no longer disagree, since they are literally the same struct. Side effects: `cleanMessage` runs once per PRIVMSG instead of twice, and the broadcast and history entries share one timestamp rather than two `time.Now()` calls taken microseconds apart.

The DM branch keeps its own `cleanMessage` call for its log line, as there is no channel there to take the setting from.

Nothing in `internal/indexer/definitions/` sets `skipcleanmessage` yet, so this was latent until the first definition opts in. Parsing and filter matching were never affected - announce lines already went through the correct path in `OnMsg`.

Introduced in #2518.

Fixes #2521

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Added `TestChannel_OnMsg_SkipCleanMessage`, covering both flag states and asserting the returned (broadcast) message matches what landed in the history buffer
* `go test ./...` passes locally

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed
