### PR TITLE
fix(feeds): empty imdb id handling

### DIFF
--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -1209,13 +1209,11 @@ func (r *Release) MapVars(varMap map[string]string, forceSizeUnit string) error 
 		r.Episode = episode
 	}
 
-	if metaId, err := getStringMapValue(varMap, "imdb"); err == nil {
-		r.MetaIMDB = metaId
+	if metaId, err := getStringMapValue(varMap, "imdb"); err == nil && metaId != "" {
 		if !strings.HasPrefix(metaId, "tt") {
-			r.MetaIMDB = "tt" + metaId
-		} else {
-			r.MetaIMDB = metaId
+			metaId = "tt" + metaId
 		}
+		r.MetaIMDB = metaId
 	}
 
 	if metaId, err := getStringMapValueAlt(varMap, "tmdb", "tmdbid"); err == nil {

--- a/internal/domain/release_test.go
+++ b/internal/domain/release_test.go
@@ -748,6 +748,47 @@ func TestRelease_MapVars(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "imdb id is prefixed with tt",
+			fields: &Release{},
+			want: &Release{
+				TorrentName: "Good show S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-GROUP2",
+				MetaIMDB:    "tt0133093",
+			},
+			args: args{
+				varMap: map[string]string{
+					"torrentName": "Good show S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-GROUP2",
+					"imdb":        "0133093",
+				},
+			},
+		},
+		{
+			name:   "imdb id already prefixed is kept as is",
+			fields: &Release{},
+			want: &Release{
+				TorrentName: "Good show S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-GROUP2",
+				MetaIMDB:    "tt0133093",
+			},
+			args: args{
+				varMap: map[string]string{
+					"torrentName": "Good show S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-GROUP2",
+					"imdb":        "tt0133093",
+				},
+			},
+		},
+		{
+			name:   "empty imdb id from unmatched optional group is ignored",
+			fields: &Release{},
+			want: &Release{
+				TorrentName: "Good show S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-GROUP2",
+			},
+			args: args{
+				varMap: map[string]string{
+					"torrentName": "Good show S02 2160p ATVP WEB-DL DDP 5.1 Atmos DV HEVC-GROUP2",
+					"imdb":        "",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/newznab/feed.go
+++ b/pkg/newznab/feed.go
@@ -167,7 +167,7 @@ func (f *FeedItem) parseAttributes() {
 				break
 			}
 		case "imdb", "imdbid":
-			if f.ImdbId == "" {
+			if f.ImdbId == "" && attr.Value != "" {
 				if !strings.HasPrefix(attr.Value, "tt") {
 					f.ImdbId = "tt" + attr.Value
 				} else {

--- a/pkg/newznab/feed_test.go
+++ b/pkg/newznab/feed_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package newznab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeedItem_parseAttributes(t *testing.T) {
+	tests := []struct {
+		name       string
+		attributes []ItemAttr
+		want       string
+	}{
+		{
+			name:       "bare id is prefixed with tt",
+			attributes: []ItemAttr{{Name: "imdb", Value: "0133093"}},
+			want:       "tt0133093",
+		},
+		{
+			name:       "prefixed id is kept as is",
+			attributes: []ItemAttr{{Name: "imdbid", Value: "tt0133093"}},
+			want:       "tt0133093",
+		},
+		{
+			name:       "empty value is ignored",
+			attributes: []ItemAttr{{Name: "imdb", Value: ""}},
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &FeedItem{Attributes: tt.attributes}
+			f.parseAttributes()
+
+			assert.Equal(t, tt.want, f.ImdbId)
+		})
+	}
+}

--- a/pkg/torznab/feed.go
+++ b/pkg/torznab/feed.go
@@ -202,7 +202,7 @@ func (f *FeedItem) parseAttributes() {
 				break
 			}
 		case "imdb", "imdbid":
-			if f.ImdbId == "" {
+			if f.ImdbId == "" && attr.Value != "" {
 				if !strings.HasPrefix(attr.Value, "tt") {
 					f.ImdbId = "tt" + attr.Value
 				} else {

--- a/pkg/torznab/feed_test.go
+++ b/pkg/torznab/feed_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package torznab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeedItem_parseAttributes(t *testing.T) {
+	tests := []struct {
+		name       string
+		attributes Attributes
+		want       string
+	}{
+		{
+			name:       "bare id is prefixed with tt",
+			attributes: Attributes{{Name: "imdb", Value: "0133093"}},
+			want:       "tt0133093",
+		},
+		{
+			name:       "prefixed id is kept as is",
+			attributes: Attributes{{Name: "imdbid", Value: "tt0133093"}},
+			want:       "tt0133093",
+		},
+		{
+			name:       "empty value is ignored",
+			attributes: Attributes{{Name: "imdb", Value: ""}},
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &FeedItem{Attributes: tt.attributes}
+			f.parseAttributes()
+
+			assert.Equal(t, tt.want, f.ImdbId)
+		})
+	}
+}


### PR DESCRIPTION
# Description

An empty IMDb ID was turned into the literal string `"tt"` instead of being left unset. The prefix was applied unconditionally, so an absent value came out as a bare prefix with no ID attached, and that garbage reached the `{{.MetaIMDB}}` macro and the `meta_imdb` field in notification payloads.

The IRC path is where this actually fires today. PTP's announce pattern makes the group optional (`(?P<imdb>tt\d+)?`), and `parseLineExtractNamed` stores `""` for unmatched groups rather than omitting the key, so `getStringMapValue` returns an empty value with no error. Every PTP announce without an IMDb ID produced `MetaIMDB = "tt"`. `MapVars` now requires a non-empty value before prefixing, and the redundant assign-then-if/else around it is collapsed.

The feed layer had the same hazard from a different direction: an `imdb`/`imdbid` attribute present but empty took the `!strings.HasPrefix("", "tt")` branch and produced `"tt"` as well. Both `pkg/newznab` and `pkg/torznab` now check the attribute value before prefixing.

Nothing else changes. Values that are already prefixed are still passed through untouched, and bare numeric IDs are still normalized to `tt<id>`.

Unrelated to this fix, but adjacent: #2520 reports that non-numeric `tmdb` values are silently dropped on these same paths. That one is not addressed here. All 8 indexer definitions that capture tmdb use `(?P<tmdb>\d+)`, so a non-numeric value cannot reach `strconv.Atoi` from IRC - only the empty string can, where skipping is the correct behavior and logging it would emit a warning for every announce without a TMDB ID.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Added three cases to the existing `TestRelease_MapVars` table: bare ID gets prefixed, already-prefixed ID is passed through, empty value is ignored
* Added `TestFeedItem_parseAttributes` to `pkg/newznab` and `pkg/torznab` covering the same three cases - neither package had any coverage for `parseAttributes`
* Confirmed all three regression cases fail against the pre-fix code (`MetaIMDB` comes out as `"tt"` on each path) and pass after
* `go test $(go list ./... | grep -v test/integration)` passes locally

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed