### PR TITLE
fix(irc): attempt NickServ IDENTIFY with account on failure

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -58,6 +58,21 @@ const (
 	ircLive                       // (Handler.client) is non-nil and valid
 )
 
+// identifyForm is the argument form of the outstanding NickServ IDENTIFY.
+//
+// The bare form is the default because its failures are always loud and are
+// returned before any password comparison. Services that do not accept an
+// account argument (Anope 1.8 and its derivatives, still deployed on Rizon)
+// parse only the first token as the password, so an account-qualified IDENTIFY
+// there is silently read as a wrong password and burns a bad_password strike.
+// See https://github.com/autobrr/autobrr/issues/2528.
+type identifyForm int
+
+const (
+	identifyFormBare identifyForm = iota
+	identifyFormAccount
+)
+
 type Handler struct {
 	m sync.RWMutex
 
@@ -75,6 +90,10 @@ type Handler struct {
 	haveDisconnected bool
 	authenticated    bool
 	saslauthed       bool
+
+	identifyAttempt     identifyForm
+	identifyEscalated   bool
+	identifyFormLearned identifyForm
 
 	channels *haxmap.Map[string, *Channel]
 
@@ -395,6 +414,7 @@ func (h *Handler) Run() (err error) {
 	h.m.Lock()
 	h.saslauthed = false
 	h.client = client
+	h.resetIdentifyForm()
 	h.m.Unlock()
 
 	if err := func() error {
@@ -533,14 +553,26 @@ func (h *Handler) GetNetwork() *domain.IrcNetwork {
 
 func (h *Handler) UpdateNetwork(network *domain.IrcNetwork) {
 	h.m.Lock()
-	h.network = network
+	h.setNetworkLocked(network)
 	h.m.Unlock()
 }
 
 func (h *Handler) SetNetwork(network *domain.IrcNetwork) {
 	h.m.Lock()
-	h.network = network
+	h.setNetworkLocked(network)
 	h.m.Unlock()
+}
+
+// setNetworkLocked swaps the network config, dropping the learned IDENTIFY form
+// if the credentials changed: which form works is a property of the account we
+// authenticate as, so it cannot outlive an edit to it.
+// The caller must hold h.m.
+func (h *Handler) setNetworkLocked(network *domain.IrcNetwork) {
+	if h.network == nil || h.network.Auth != network.Auth {
+		h.identifyFormLearned = identifyFormBare
+	}
+
+	h.network = network
 }
 
 func (h *Handler) resetChannelState() {
@@ -631,6 +663,10 @@ func (h *Handler) onDisconnect(_ ircmsg.Message) {
 	// reset authenticated
 	h.authenticated = false
 
+	// a reconnect starts the identify ladder over: the nick we get back may
+	// differ, and the previous connection's escalation says nothing about this one
+	h.resetIdentifyForm()
+
 	h.haveDisconnected = true
 
 	manuallyDisconnected := h.clientState == ircStopped
@@ -670,6 +706,10 @@ func (h *Handler) onNotice(msg ircmsg.Message) {
 func (h *Handler) handleNickServ(msg ircmsg.Message) {
 	h.log.Trace().Msgf("NOTICE from nickserv: %v", msg.Params)
 
+	if len(msg.Params) < 2 {
+		return
+	}
+
 	// You're now logged in as test-bot
 	// Password accepted - you are now recognized.
 	if contains(msg.Params[1], "you're now logged in as", "password accepted", "you are now recognized", "you are now identified", "you are already logged in") {
@@ -678,13 +718,32 @@ func (h *Handler) handleNickServ(msg ircmsg.Message) {
 		return
 	}
 
+	// The bare IDENTIFY cannot succeed on this network: either NickServ does not
+	// know the nick we are connected as (it is not the account and has not been
+	// grouped to it), or it wants the account spelled out. Both are fixed by the
+	// account-qualified form, so retry once with it before treating anything as
+	// terminal. Evaluated ahead of the failure branches below, which would
+	// otherwise stop the network on the very notices that make escalation the
+	// right move.
+	if h.shouldEscalateIdentify(msg.Params[1]) {
+		h.escalateIdentify()
+
+		h.log.Debug().Str("notice", msg.Params[1]).Msg("nickserv rejected bare identify, retrying with account")
+
+		h.NickServIdentify()
+		return
+	}
+
 	if contains(msg.Params[1],
 		"Invalid account credentials",
 		"Authentication failed: Invalid account credentials",
 		"password incorrect",
+		"invalid password for", // atheme
 	) {
-		h.addConnectError("authentication failed: Bad account credentials")
+		h.addConnectError(h.badCredentialsError())
 		h.log.Error().Msg("NickServ: authentication failed - bad account credentials")
+
+		h.unlearnIdentifyForm()
 
 		h.stateMachine.OnError("nickserv authentication failed: bad credentials")
 
@@ -696,10 +755,13 @@ func (h *Handler) handleNickServ(msg ircmsg.Message) {
 	if contains(msg.Params[1],
 		"Account does not exist",
 		"Authentication failed: Account does not exist",
-		"isn't registered.", // Nick ANICK isn't registered
+		"isn't registered.",            // Nick ANICK isn't registered
+		"is not a registered nickname", // atheme
 	) {
 		if h.CurrentNick() == h.PreferredNick() {
 			h.addConnectError("authentication failed: account does not exist")
+
+			h.unlearnIdentifyForm()
 
 			h.stateMachine.OnError("nickserv authentication failed: account does not exist")
 
@@ -730,15 +792,6 @@ func (h *Handler) handleNickServ(msg ircmsg.Message) {
 			// stop network and notify user
 			h.Stop()
 		}
-	}
-
-	// fallback for networks that require both password and nick to NickServ IDENTIFY
-	// Invalid parameters. For usage, do /msg NickServ HELP IDENTIFY
-	if contains(msg.Params[1], "invalid parameters", "help identify") {
-		h.log.Debug().Msgf("NOTICE nickserv invalid: %v", msg.Params)
-
-		net := h.GetNetwork()
-		h.Send("PRIVMSG", "NickServ", fmt.Sprintf("IDENTIFY %s %s", net.Auth.Account, net.Auth.Password))
 	}
 }
 
@@ -805,24 +858,34 @@ func (h *Handler) setBotMode() {
 // authenticate sends NickServIdentify if not authenticated
 func (h *Handler) authenticate() {
 	h.m.RLock()
-	password := h.network.Auth.Password
-	shouldSendNickserv := !h.authenticated && !h.saslauthed && password != ""
+	shouldSendNickserv := !h.authenticated && !h.saslauthed && h.network.Auth.Password != ""
 	h.m.RUnlock()
 
 	if shouldSendNickserv {
 		h.log.Trace().Msg("on connect not authenticated and password not empty: send nickserv identify")
-		h.NickServIdentify(password)
+		h.NickServIdentify()
 	} else {
 		h.setAuthenticated()
 	}
 }
 
+// handleLoggedIn handles RPL_LOGGEDIN (900):
+// <nick> <nick>!<user>@<host> <account> :You are now logged in as <account>
+//
+// The source of a numeric is the server, not a nick, so the target has to be
+// read from the parameters.
 func (h *Handler) handleLoggedIn(m ircmsg.Message) {
-	h.log.Trace().Str("event", "900").Msg("logged in")
-	nick := m.Nick()
-	if h.isOurCurrentNick(nick) {
-		h.setAuthenticated()
+	if len(m.Params) < 3 {
+		return
 	}
+
+	if !h.isOurCurrentNick(m.Params[0]) {
+		return
+	}
+
+	h.log.Debug().Str("event", "900").Str("account", m.Params[2]).Msg("logged in")
+
+	h.setAuthenticated()
 }
 
 // handleSASLSuccess we get here early so set saslauthed before we hit onConnect
@@ -879,6 +942,9 @@ func (h *Handler) setAuthenticated() {
 		h.authenticated = true
 		h.connectionErrors = []string{}
 		h.failedNickServAttempts = 0
+
+		// remember the form that worked so the next connect starts on it
+		h.identifyFormLearned = h.identifyAttempt
 	}
 	h.m.Unlock()
 
@@ -1620,14 +1686,123 @@ func (h *Handler) handleInviteResponse(msg ircmsg.Message) {
 	}
 }
 
-// NickServIdentify sends NickServ Identify commands
-func (h *Handler) NickServIdentify(password string) error {
-	if err := h.Send("PRIVMSG", "NickServ", fmt.Sprintf("IDENTIFY %s", password)); err != nil {
-		h.log.Error().Stack().Err(err).Msgf("error identifying with nickserv")
+// identifyCommand builds the NickServ IDENTIFY for the form currently selected
+// for this connection, bare unless escalateIdentify has moved us to the
+// account-qualified form.
+func (h *Handler) identifyCommand() string {
+	h.m.RLock()
+	form := h.identifyAttempt
+	account := h.network.Auth.Account
+	password := h.network.Auth.Password
+	h.m.RUnlock()
+
+	if form == identifyFormAccount && account != "" {
+		return fmt.Sprintf("IDENTIFY %s %s", account, password)
+	}
+
+	return fmt.Sprintf("IDENTIFY %s", password)
+}
+
+// NickServIdentify sends a NickServ IDENTIFY. The whole command is one trailing
+// PRIVMSG parameter: split across parameters it lands past the message body,
+// where every ircd discards it.
+func (h *Handler) NickServIdentify() error {
+	if err := h.Send("PRIVMSG", "NickServ", h.identifyCommand()); err != nil {
+		h.log.Error().Stack().Err(err).Msg("error identifying with nickserv")
 		return err
 	}
 
 	return nil
+}
+
+// canEscalateIdentify reports whether a failed bare IDENTIFY may be retried in
+// the account-qualified form. Escalation is forward-only and happens at most
+// once per connection: on services that do not support the account argument the
+// retry comes back as "password incorrect", which is indistinguishable from
+// genuinely bad credentials and must never drive another attempt.
+func (h *Handler) canEscalateIdentify(currentNick string) bool {
+	h.m.RLock()
+	defer h.m.RUnlock()
+
+	if h.authenticated || h.saslauthed || h.identifyEscalated || h.identifyAttempt != identifyFormBare {
+		return false
+	}
+
+	if h.network.Auth.Account == "" || h.network.Auth.Password == "" {
+		return false
+	}
+
+	// the account form resolves the same target as the bare form, so it can only
+	// help when the account differs from the nick we are connected as
+	return !strings.EqualFold(h.network.Auth.Account, currentNick)
+}
+
+// noticeAllowsIdentifyEscalation reports whether a NickServ NOTICE proves the
+// bare IDENTIFY failed for a reason the account-qualified form can fix: either
+// the nick we are connected as is unknown to NickServ, or NickServ wants the
+// account spelled out.
+func noticeAllowsIdentifyEscalation(notice string) bool {
+	return contains(notice,
+		"isn't registered",             // anope: Nick X isn't registered.
+		"is not a registered nickname", // atheme
+		"account does not exist",       // ergo
+		"insufficient parameters",      // atheme with nickserv::no_nick_ownership
+		"invalid parameters",           // ergo
+		"help identify",                // anope, ircservices
+		"syntax: identify",             // atheme, anope
+	)
+}
+
+// shouldEscalateIdentify reports whether this NOTICE should move the connection
+// to the account-qualified IDENTIFY form.
+func (h *Handler) shouldEscalateIdentify(notice string) bool {
+	return noticeAllowsIdentifyEscalation(notice) && h.canEscalateIdentify(h.CurrentNick())
+}
+
+// badCredentialsError describes a rejected password. An account-qualified
+// attempt is ambiguous: the password may really be wrong, or the network may be
+// running services that took the account name as the password.
+func (h *Handler) badCredentialsError() string {
+	h.m.RLock()
+	escalated := h.identifyAttempt == identifyFormAccount
+	h.m.RUnlock()
+
+	if escalated {
+		return "authentication failed: NickServ rejected the account-qualified IDENTIFY. Either the password is wrong, or this network only supports 'IDENTIFY <password>' and needs the nick grouped to the account instead"
+	}
+
+	return "authentication failed: Bad account credentials"
+}
+
+// escalateIdentify moves this connection to the account-qualified IDENTIFY form.
+func (h *Handler) escalateIdentify() {
+	h.m.Lock()
+	h.identifyAttempt = identifyFormAccount
+	h.identifyEscalated = true
+	h.m.Unlock()
+}
+
+// resetIdentifyForm starts a connection on the form that last authenticated on
+// this network and re-arms escalation. Seeding from the learned form keeps a
+// reconnect from re-sending a bare IDENTIFY already known to fail here; the
+// escalation guards reject escalating out of the account form, so a connection
+// that starts there stays there.
+// The caller must hold h.m.
+func (h *Handler) resetIdentifyForm() {
+	h.identifyAttempt = h.identifyFormLearned
+	h.identifyEscalated = false
+}
+
+// unlearnIdentifyForm drops a remembered account-qualified form once it has
+// itself been rejected, so a later nick grouping or services change heals on the
+// next connect instead of failing the same way forever.
+func (h *Handler) unlearnIdentifyForm() {
+	h.m.Lock()
+	defer h.m.Unlock()
+
+	if h.identifyAttempt == identifyFormAccount {
+		h.identifyFormLearned = identifyFormBare
+	}
 }
 
 // NickChange sets a new nick for our user

--- a/internal/irc/nickserv_identify_test.go
+++ b/internal/irc/nickserv_identify_test.go
@@ -1,0 +1,497 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package irc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/autobrr/autobrr/internal/domain"
+
+	"github.com/ergochat/irc-go/ircmsg"
+)
+
+// hasConnectError reports whether any recorded network-level error contains substr.
+func hasConnectError(h *Handler, substr string) bool {
+	h.m.RLock()
+	defer h.m.RUnlock()
+
+	for _, e := range h.connectionErrors {
+		if strings.Contains(e, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// nickServNotice builds the NOTICE a services package sends us.
+func nickServNotice(nick, text string) ircmsg.Message {
+	return ircmsg.Message{
+		Source:  "NickServ!services@services.example.test",
+		Command: "NOTICE",
+		Params:  []string{nick, text},
+	}
+}
+
+// withNickServAuth configures a handler for NICKSERV auth with a bot nick that
+// differs from the account, i.e. the setup in issue #2528.
+func withNickServAuth(h *Handler, account string) {
+	h.network.Nick = "user_bot"
+	h.network.Auth = domain.IRCAuth{
+		Mechanism: domain.IRCAuthMechanismNickServ,
+		Account:   account,
+		Password:  "hunter2",
+	}
+}
+
+// TestNoticeAllowsIdentifyEscalation covers the verbatim replies of each
+// services package. The "no" cases matter most: escalating on a bad password
+// would loop, and escalating on success would be pointless.
+func TestNoticeAllowsIdentifyEscalation(t *testing.T) {
+	tests := []struct {
+		name   string
+		notice string
+		want   bool
+	}{
+		{"anope unknown nick", "Nick user_bot isn't registered.", true},
+		{"anope 1.8 unknown nick", "Your nick isn't registered.", true},
+		{"atheme unknown nick", "\x02user_bot\x02 is not a registered nickname.", true},
+		{"atheme insufficient params", "Insufficient parameters for \x02IDENTIFY\x02.", true},
+		{"atheme syntax line", "Syntax: IDENTIFY <account> <password>", true},
+		{"ergo bad param count", "Invalid parameters. For usage, do /msg NickServ HELP IDENTIFY", true},
+		{"anope more info", "\x02/msg NickServ HELP IDENTIFY\x02 for more information.", true},
+
+		{"anope success", "Password accepted - you are now recognized.", false},
+		{"atheme success", "You are now identified for \x02test_bot\x02.", false},
+		{"anope bad password", "Password incorrect.", false},
+		{"atheme bad password", "Invalid password for \x02test_bot\x02.", false},
+		{"nick protection warning", "This nickname is registered and protected.", false},
+		{"unrelated chatter", "Your vhost has been activated.", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := noticeAllowsIdentifyEscalation(tt.notice); got != tt.want {
+				t.Errorf("noticeAllowsIdentifyEscalation(%q) = %v, want %v", tt.notice, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCanEscalateIdentify covers the state guards that keep escalation to a
+// single forward-only attempt per connection.
+func TestCanEscalateIdentify(t *testing.T) {
+	tests := []struct {
+		name        string
+		account     string
+		currentNick string
+		setup       func(h *Handler)
+		want        bool
+	}{
+		{
+			name:        "account differs from nick",
+			account:     "test_bot",
+			currentNick: "user_bot",
+			want:        true,
+		},
+		{
+			name:        "account equals nick",
+			account:     "user_bot",
+			currentNick: "user_bot",
+			want:        false,
+		},
+		{
+			name:        "account equals nick case insensitively",
+			account:     "User_Bot",
+			currentNick: "user_bot",
+			want:        false,
+		},
+		{
+			name:        "no account configured",
+			account:     "",
+			currentNick: "user_bot",
+			want:        false,
+		},
+		{
+			name:        "no password configured",
+			account:     "test_bot",
+			currentNick: "user_bot",
+			setup:       func(h *Handler) { h.network.Auth.Password = "" },
+			want:        false,
+		},
+		{
+			name:        "already escalated",
+			account:     "test_bot",
+			currentNick: "user_bot",
+			setup:       func(h *Handler) { h.identifyEscalated = true },
+			want:        false,
+		},
+		{
+			name:        "already on the account form",
+			account:     "test_bot",
+			currentNick: "user_bot",
+			setup:       func(h *Handler) { h.identifyAttempt = identifyFormAccount },
+			want:        false,
+		},
+		{
+			name:        "already authenticated",
+			account:     "test_bot",
+			currentNick: "user_bot",
+			setup:       func(h *Handler) { h.authenticated = true },
+			want:        false,
+		},
+		{
+			name:        "authenticated over sasl",
+			account:     "test_bot",
+			currentNick: "user_bot",
+			setup:       func(h *Handler) { h.saslauthed = true },
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := newTestHandler()
+			withNickServAuth(h, tt.account)
+			if tt.setup != nil {
+				tt.setup(h)
+			}
+
+			if got := h.canEscalateIdentify(tt.currentNick); got != tt.want {
+				t.Errorf("canEscalateIdentify(%q) = %v, want %v", tt.currentNick, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIdentifyEscalationLifecycle verifies the ladder is forward-only within a
+// connection and re-armed by a reconnect.
+func TestIdentifyEscalationLifecycle(t *testing.T) {
+	h, _ := newTestHandler()
+	withNickServAuth(h, "test_bot")
+
+	if !h.canEscalateIdentify("user_bot") {
+		t.Fatal("expected escalation to be available on a fresh connection")
+	}
+
+	h.escalateIdentify()
+
+	if h.identifyAttempt != identifyFormAccount {
+		t.Error("expected identifyAttempt to be identifyFormAccount after escalation")
+	}
+
+	if h.canEscalateIdentify("user_bot") {
+		t.Error("expected escalation to be spent after one attempt")
+	}
+
+	// a reconnect starts over: the nick we get back may differ
+	h.onDisconnect(ircmsg.Message{Command: "DISCONNECT"})
+
+	if h.identifyAttempt != identifyFormBare {
+		t.Error("expected identifyAttempt to reset to identifyFormBare on disconnect")
+	}
+
+	if !h.canEscalateIdentify("user_bot") {
+		t.Error("expected escalation to be re-armed after a disconnect")
+	}
+}
+
+// TestIdentifyFormIsStickyPerNetwork verifies a successful escalation is
+// remembered: reconnecting must not re-send a bare IDENTIFY already known to
+// fail on this network.
+func TestIdentifyFormIsStickyPerNetwork(t *testing.T) {
+	h, _ := newTestHandler()
+	withNickServAuth(h, "test_bot")
+
+	h.handleNickServ(nickServNotice("user_bot", "Nick user_bot isn't registered."))
+	h.handleNickServ(nickServNotice("user_bot", "Password accepted - you are now recognized."))
+
+	if !h.authenticated {
+		t.Fatal("expected the escalated identify to authenticate")
+	}
+
+	h.onDisconnect(ircmsg.Message{Command: "DISCONNECT"})
+
+	if h.identifyAttempt != identifyFormAccount {
+		t.Error("expected the reconnect to start on the account-qualified form")
+	}
+
+	if got := h.identifyCommand(); got != "IDENTIFY test_bot hunter2" {
+		t.Errorf("identifyCommand() = %q, want the account-qualified form", got)
+	}
+}
+
+// TestIdentifyFormStaysBareWhenBareWorks keeps the default path untouched: a
+// network that authenticates bare must never drift onto the account form.
+func TestIdentifyFormStaysBareWhenBareWorks(t *testing.T) {
+	h, _ := newTestHandler()
+	withNickServAuth(h, "test_bot")
+
+	h.handleNickServ(nickServNotice("user_bot", "Password accepted - you are now recognized."))
+	h.onDisconnect(ircmsg.Message{Command: "DISCONNECT"})
+
+	if h.identifyAttempt != identifyFormBare {
+		t.Error("expected a network that authenticates bare to stay on the bare form")
+	}
+}
+
+// TestIdentifyFormUnlearnedAfterRejection covers the heal path: once a
+// remembered account form is itself rejected, the next connect starts over at
+// bare, so a later nick grouping recovers without user action.
+func TestIdentifyFormUnlearnedAfterRejection(t *testing.T) {
+	tests := []struct {
+		name   string
+		notice string
+	}{
+		{"password rejected", "Password incorrect."},
+		{"account unknown", "Nick test_bot isn't registered."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := newTestHandler()
+			withNickServAuth(h, "test_bot")
+			h.identifyFormLearned = identifyFormAccount
+			h.identifyAttempt = identifyFormAccount
+
+			h.handleNickServ(nickServNotice("user_bot", tt.notice))
+
+			if h.identifyFormLearned != identifyFormBare {
+				t.Error("expected the rejected account form to be forgotten")
+			}
+		})
+	}
+}
+
+// TestIdentifyFormClearedOnAuthChange verifies the learned form does not outlive
+// an edit to the credentials it was learned for.
+func TestIdentifyFormClearedOnAuthChange(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(n *domain.IrcNetwork)
+		cleared bool
+	}{
+		{
+			name:    "account changed",
+			mutate:  func(n *domain.IrcNetwork) { n.Auth.Account = "someone_else" },
+			cleared: true,
+		},
+		{
+			name:    "password changed",
+			mutate:  func(n *domain.IrcNetwork) { n.Auth.Password = "correcthorse" },
+			cleared: true,
+		},
+		{
+			name:    "mechanism changed",
+			mutate:  func(n *domain.IrcNetwork) { n.Auth.Mechanism = domain.IRCAuthMechanismSASLPlain },
+			cleared: true,
+		},
+		{
+			name:    "unrelated field changed",
+			mutate:  func(n *domain.IrcNetwork) { n.Name = "Renamed" },
+			cleared: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := newTestHandler()
+			withNickServAuth(h, "test_bot")
+			h.identifyFormLearned = identifyFormAccount
+
+			updated := *h.network
+			tt.mutate(&updated)
+
+			h.UpdateNetwork(&updated)
+
+			if cleared := h.identifyFormLearned == identifyFormBare; cleared != tt.cleared {
+				t.Errorf("learned form cleared = %v, want %v", cleared, tt.cleared)
+			}
+		})
+	}
+}
+
+// TestHandleNickServEscalatesBeforeStopping is the regression test for #2528:
+// "Nick <bot> isn't registered." used to stop the network outright, because the
+// account-does-not-exist branch returned before the account-qualified retry was
+// ever reached.
+func TestHandleNickServEscalatesBeforeStopping(t *testing.T) {
+	h, _ := newTestHandler()
+	withNickServAuth(h, "test_bot")
+
+	h.handleNickServ(nickServNotice("user_bot", "Nick user_bot isn't registered."))
+
+	if h.identifyAttempt != identifyFormAccount {
+		t.Error("expected the notice to escalate to the account-qualified form")
+	}
+
+	if h.Stopped() {
+		t.Error("expected the network to stay up while the account form is retried")
+	}
+
+	if len(h.connectionErrors) != 0 {
+		t.Errorf("expected no connection errors during escalation, got %v", h.connectionErrors)
+	}
+}
+
+// TestHandleNickServStopsWhenAccountUnknownAfterEscalation verifies the ladder
+// terminates: once the account form has been tried, the same notice is fatal.
+func TestHandleNickServStopsWhenAccountUnknownAfterEscalation(t *testing.T) {
+	h, _ := newTestHandler()
+	withNickServAuth(h, "test_bot")
+
+	h.handleNickServ(nickServNotice("user_bot", "Nick user_bot isn't registered."))
+	h.handleNickServ(nickServNotice("user_bot", "Nick test_bot isn't registered."))
+
+	if !h.Stopped() {
+		t.Error("expected the network to stop once the account form also failed")
+	}
+
+	if !hasConnectError(h, "account does not exist") {
+		t.Errorf("expected an account-does-not-exist error, got %v", h.connectionErrors)
+	}
+}
+
+// TestHandleNickServBadCredentialsAfterEscalation covers the Anope 1.8 hazard:
+// services that ignore the account argument read it as the password and answer
+// "Password incorrect.". The network still stops, but the error must not tell
+// the user their credentials are simply wrong.
+func TestHandleNickServBadCredentialsAfterEscalation(t *testing.T) {
+	h, _ := newTestHandler()
+	withNickServAuth(h, "test_bot")
+
+	h.handleNickServ(nickServNotice("user_bot", "Your nick isn't registered."))
+	h.handleNickServ(nickServNotice("user_bot", "Password incorrect."))
+
+	if !h.Stopped() {
+		t.Fatal("expected the network to stop on a rejected password")
+	}
+
+	if !hasConnectError(h, "account-qualified") {
+		t.Errorf("expected the ambiguous account-qualified error, got %v", h.connectionErrors)
+	}
+}
+
+// TestHandleNickServBadCredentialsBare keeps the pre-existing message for a
+// plain wrong password, where there is no ambiguity to report.
+func TestHandleNickServBadCredentialsBare(t *testing.T) {
+	h, _ := newTestHandler()
+	withNickServAuth(h, "test_bot")
+
+	h.handleNickServ(nickServNotice("user_bot", "Password incorrect."))
+
+	if !h.Stopped() {
+		t.Fatal("expected the network to stop on a rejected password")
+	}
+
+	if !hasConnectError(h, "Bad account credentials") {
+		t.Errorf("expected the bad-credentials error, got %v", h.connectionErrors)
+	}
+}
+
+// TestHandleNickServNoEscalationWithoutAccount preserves today's behaviour for
+// networks where the nick is the account: nothing to escalate to, so an unknown
+// nick stays terminal.
+func TestHandleNickServNoEscalationWithoutAccount(t *testing.T) {
+	h, _ := newTestHandler()
+	withNickServAuth(h, "")
+
+	h.handleNickServ(nickServNotice("user_bot", "Nick user_bot isn't registered."))
+
+	if h.identifyAttempt != identifyFormBare {
+		t.Error("expected no escalation without a configured account")
+	}
+
+	if !h.Stopped() {
+		t.Error("expected the network to stop when there is no account to retry with")
+	}
+}
+
+// TestHandleNickServShortParams guards the Params[1] index against a malformed
+// or truncated NOTICE.
+func TestHandleNickServShortParams(t *testing.T) {
+	h, _ := newTestHandler()
+	withNickServAuth(h, "test_bot")
+
+	h.handleNickServ(ircmsg.Message{
+		Source:  "NickServ!services@services.example.test",
+		Command: "NOTICE",
+		Params:  []string{"user_bot"},
+	})
+}
+
+// TestNickServIdentifyCommand verifies the wire form for each ladder state.
+// PRIVMSG carries the whole command as a single trailing parameter: splitting it
+// across parameters puts the password past the message body, where every ircd
+// discards it.
+func TestNickServIdentifyCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		account string
+		form    identifyForm
+		want    string
+	}{
+		{"bare", "test_bot", identifyFormBare, "IDENTIFY hunter2"},
+		{"account qualified", "test_bot", identifyFormAccount, "IDENTIFY test_bot hunter2"},
+		{"account qualified without an account falls back to bare", "", identifyFormAccount, "IDENTIFY hunter2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := newTestHandler()
+			withNickServAuth(h, tt.account)
+			h.identifyAttempt = tt.form
+
+			if got := h.identifyCommand(); got != tt.want {
+				t.Errorf("identifyCommand() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleLoggedIn covers RPL_LOGGEDIN, whose source is the server rather than
+// a nick, so the target has to come from the parameters.
+func TestHandleLoggedIn(t *testing.T) {
+	tests := []struct {
+		name   string
+		params []string
+		want   bool
+	}{
+		{
+			name:   "our nick",
+			params: []string{"", "user_bot!user_bot@host", "test_bot", "You are now logged in as test_bot"},
+			want:   true,
+		},
+		{
+			name:   "another user",
+			params: []string{"someone_else", "someone_else!u@h", "someone", "You are now logged in as someone"},
+			want:   false,
+		},
+		{
+			name:   "truncated",
+			params: []string{"user_bot"},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := newTestHandler()
+			withNickServAuth(h, "test_bot")
+
+			// CurrentNick is "" without a live client, so address the message to it
+			params := append([]string(nil), tt.params...)
+
+			h.handleLoggedIn(ircmsg.Message{
+				Source:  "irc.example.test",
+				Command: "900",
+				Params:  params,
+			})
+
+			if h.authenticated != tt.want {
+				t.Errorf("authenticated = %v, want %v", h.authenticated, tt.want)
+			}
+		})
+	}
+}

--- a/internal/irc/state_machine.go
+++ b/internal/irc/state_machine.go
@@ -262,13 +262,12 @@ func (sm *ConnectionStateMachine) onStateEntry(state ConnectionState) {
 
 func (sm *ConnectionStateMachine) handleAuthentication() {
 	sm.handler.m.RLock()
-	password := sm.handler.network.Auth.Password
-	needsAuth := password != "" && !sm.handler.saslauthed
+	needsAuth := sm.handler.network.Auth.Password != "" && !sm.handler.saslauthed
 	sm.handler.m.RUnlock()
 
 	if needsAuth {
 		sm.log.Trace().Msg("sending NickServ authentication")
-		if err := sm.handler.NickServIdentify(password); err != nil {
+		if err := sm.handler.NickServIdentify(); err != nil {
 			sm.log.Error().Err(err).Msg("failed to send NickServ identify")
 		}
 		// Wait for handleNickServ callback to call OnAuthenticated()

--- a/internal/logger/sanitize.go
+++ b/internal/logger/sanitize.go
@@ -39,7 +39,11 @@ var (
 			repl:    "${1}REDACTED_USER:REDACTED_PW@",
 		},
 		{
-			pattern: regexp.MustCompile(`(NickServ IDENTIFY )([\p{L}0-9!#%&*+/:;<=>?@^_` + "`" + `{|}~]+)`),
+			// The IRC client logs the raw line, where the whole command is one
+			// trailing parameter: "PRIVMSG NickServ :IDENTIFY [account] <password>".
+			// Both argument forms have to be covered, and the optional account is
+			// redacted along with the password rather than being spliced back in.
+			pattern: regexp.MustCompile(`(NickServ :?IDENTIFY )[^\s"\\]+(\s+[^\s"\\]+)?`),
 			repl:    "${1}REDACTED",
 		},
 		{

--- a/internal/logger/sanitize.go
+++ b/internal/logger/sanitize.go
@@ -43,7 +43,12 @@ var (
 			// trailing parameter: "PRIVMSG NickServ :IDENTIFY [account] <password>".
 			// Both argument forms have to be covered, and the optional account is
 			// redacted along with the password rather than being spliced back in.
-			pattern: regexp.MustCompile(`(NickServ :?IDENTIFY )[^\s"\\]+(\s+[^\s"\\]+)?`),
+			// A token runs to whitespace or to an unescaped quote; a backslash is
+			// consumed together with the character it escapes, so a credential
+			// containing one is not split with its tail left behind. Backslash is
+			// legal in an IRC nick and in a password, and JSON-encoded log lines
+			// escape both it and any embedded quote.
+			pattern: regexp.MustCompile(`(NickServ :?IDENTIFY )(?:\\.|[^\s"\\])+(?:\s+(?:\\.|[^\s"\\])+)?`),
 			repl:    "${1}REDACTED",
 		},
 		{

--- a/internal/logger/sanitize_test.go
+++ b/internal/logger/sanitize_test.go
@@ -142,6 +142,28 @@ func TestSanitizeLogFile(t *testing.T) {
 			expected: "\"module\":\"irc\" PRIVMSG NickServ IDENTIFY REDACTED",
 		},
 		{
+			// the form actually put on the wire: the command is one trailing
+			// parameter, so the logged line carries a colon
+			name:     "nickserv_identify_bare",
+			input:    "\"module\":\"irc\" --> PRIVMSG NickServ :IDENTIFY zAPEJEA8ryYnpj3AiE3KJ",
+			expected: "\"module\":\"irc\" --> PRIVMSG NickServ :IDENTIFY REDACTED",
+		},
+		{
+			name:     "nickserv_identify_account_qualified",
+			input:    "\"module\":\"irc\" --> PRIVMSG NickServ :IDENTIFY user|bot zAPEJEA8ryYnpj3AiE3KJ",
+			expected: "\"module\":\"irc\" --> PRIVMSG NickServ :IDENTIFY REDACTED",
+		},
+		{
+			name:     "nickserv_identify_account_with_dash",
+			input:    "\"module\":\"irc\" --> PRIVMSG NickServ :IDENTIFY user-bot zAPEJEA8ryYnpj3AiE3KJ",
+			expected: "\"module\":\"irc\" --> PRIVMSG NickServ :IDENTIFY REDACTED",
+		},
+		{
+			name:     "nickserv_identify_json_quoted",
+			input:    "{\"level\":\"debug\",\"module\":\"irc\",\"message\":\"--> PRIVMSG NickServ :IDENTIFY user-bot hunter2\"}",
+			expected: "{\"level\":\"debug\",\"module\":\"irc\",\"message\":\"--> PRIVMSG NickServ :IDENTIFY REDACTED\"}",
+		},
+		{
 			input:    "\"module\":\"action\" \\\"host\\\":\\\"subdomain.domain.com:42069/subfolder\\\", \\n   \\\"user\\\":\\\"AUserName\\\", \\n   \\\"password\\\":\\\"p4ssw0!rd\\\", \\n",
 			expected: "\"module\":\"action\" \\\"host\\\":\\\"REDACTED\\\", \\n   \\\"user\\\":\\\"REDACTED\\\", \\n   \\\"password\\\":\\\"REDACTED\\\", \\n",
 		},

--- a/internal/logger/sanitize_test.go
+++ b/internal/logger/sanitize_test.go
@@ -164,6 +164,28 @@ func TestSanitizeLogFile(t *testing.T) {
 			expected: "{\"level\":\"debug\",\"module\":\"irc\",\"message\":\"--> PRIVMSG NickServ :IDENTIFY REDACTED\"}",
 		},
 		{
+			// backslash is legal in an IRC nick, and a token that stops at one
+			// leaves the rest of the credential in the log
+			name:     "nickserv_identify_backslash_in_password",
+			input:    `"module":"irc" --> PRIVMSG NickServ :IDENTIFY hunt\er2secret`,
+			expected: `"module":"irc" --> PRIVMSG NickServ :IDENTIFY REDACTED`,
+		},
+		{
+			name:     "nickserv_identify_backslash_in_account",
+			input:    `"module":"irc" --> PRIVMSG NickServ :IDENTIFY user\bot hunter2secret`,
+			expected: `"module":"irc" --> PRIVMSG NickServ :IDENTIFY REDACTED`,
+		},
+		{
+			name:     "nickserv_identify_json_escaped_backslash",
+			input:    `{"level":"debug","module":"irc","message":"--> PRIVMSG NickServ :IDENTIFY user\\bot hunter2secret"}`,
+			expected: `{"level":"debug","module":"irc","message":"--> PRIVMSG NickServ :IDENTIFY REDACTED"}`,
+		},
+		{
+			name:     "nickserv_identify_json_escaped_quote",
+			input:    `{"level":"debug","module":"irc","message":"--> PRIVMSG NickServ :IDENTIFY hun\"ter2secret"}`,
+			expected: `{"level":"debug","module":"irc","message":"--> PRIVMSG NickServ :IDENTIFY REDACTED"}`,
+		},
+		{
 			input:    "\"module\":\"action\" \\\"host\\\":\\\"subdomain.domain.com:42069/subfolder\\\", \\n   \\\"user\\\":\\\"AUserName\\\", \\n   \\\"password\\\":\\\"p4ssw0!rd\\\", \\n",
 			expected: "\"module\":\"action\" \\\"host\\\":\\\"REDACTED\\\", \\n   \\\"user\\\":\\\"REDACTED\\\", \\n   \\\"password\\\":\\\"REDACTED\\\", \\n",
 		},


### PR DESCRIPTION
# Description

autobrr always sent the bare `PRIVMSG NickServ :IDENTIFY <password>` and never used the configured `Auth.Account`, except in a reactive fallback that fired only when a NOTICE contained `invalid parameters` or `help identify`. When the bot nick is not registered or grouped to the account, the bare form cannot succeed, and the fallback was unreachable in exactly that case: the `isn't registered.` branch returned via `Stop()` before it was reached.

This adds a bare-first escalation ladder. The default is unchanged; escalation to `IDENTIFY <account> <password>` happens at most once per connection, and only when NickServ's reply proves the bare form cannot work here. The form that authenticates is remembered per network, so reconnects do not repeat an attempt already known to fail.

## Why not just always send the account-qualified form

That was the original request, and it is not safe. `IDENTIFY <account> <password>` is fine on Atheme, Anope 2.x and Ergo, but Anope 1.8 and its derivatives parse only the first token as the password ([`src/core/ns_identify.c`](https://github.com/anope/anope/blob/1.8/src/core/ns_identify.c): `char *pass = strtok(NULL, " ");`) with the account always taken from the current nick. Sending two arguments there is read as a wrong password, answers `Password incorrect.`, and burns a `bad_password()` strike.

That failure is silent and indistinguishable from genuinely bad credentials, whereas every bare-form failure is loud and returned before any password comparison. That asymmetry is what drives the design.

Rizon runs Anope 1.8-class services, confirmed by a live probe:

```
irc.rizon.net    plexus-4(hybrid-8.1.20)   Syntax: IDENTIFY password
```

Seven shipped definitions sit on Rizon (nyaa, subsplease, tokyotoshokan, animeworld, happyfappy, t66y, rastastugan), all of which declare `auth.account` and would have regressed.

For contrast, the networks that accept both forms, also probed live:

| Network | ircd | NickServ syntax |
|---|---|---|
| irc.myanonamouse.net | InspIRCd-2.0 | `Syntax: IDENTIFY [account] password` |
| irc.p2p-network.net | Unreal3.2.10.7 | `Syntax: IDENTIFY [account] password` |
| irc.scratch-network.net | InspIRCd-2.0 | `Syntax: IDENTIFY [account] password` |
| irc.nebulance.io | UnrealIRCd-6.2.7 | `Syntax: IDENTIFY [account] password` |
| irc.libera.chat | solanum + Atheme | `IDENTIFY <nick> <password>` and `IDENTIFY <password>` |
| irc.digitalirc.org | UnrealIRCd-6.2.6 + Atheme | both forms |

## How the ladder works

`identifyAttempt` and `identifyEscalated` track the form for the current connection; `identifyFormLearned` seeds the next one.

- Escalation is evaluated **before** the terminal branches in `handleNickServ`, which is the actual fix for #2528.
- It is gated on: not authenticated, not SASL'd, not already escalated, still on the bare form, account and password both set, and the account differing from the current nick case-insensitively. The account form resolves the same target otherwise.
- It never escalates out of the bad-password branch. That is precisely what Anope 1.8 returns for a two-argument attempt, so escalating there would loop.
- The form that authenticates is learned in `setAuthenticated()`. A *failed* escalation is deliberately not remembered.
- A remembered account form is forgotten once it is itself rejected, so a later nick grouping or services upgrade heals on the next connect with no user action.
- The learned form is dropped when `Auth` changes, since which form works is a property of the account being authenticated as.

Trigger strings, one per services package, read from source:

| Notice | Services |
|---|---|
| `isn't registered` | Anope |
| `is not a registered nickname` | Atheme |
| `account does not exist` | Ergo |
| `insufficient parameters` | Atheme with `nickserv::no_nick_ownership` |
| `invalid parameters` | Ergo |
| `help identify` | Anope, IRCServices |
| `syntax: identify` | Atheme, Anope |

When an escalated attempt is rejected on credentials, the surfaced error now says so rather than flatly asserting bad credentials, since on legacy services that reply is ambiguous.

## No new setting

Deliberately no `identify_format` option, matching the ecosystem. Quassel hardcodes the bare form in C++; HexChat's login-method dropdown selects the transport, never the argument form, and [hexchat#576](https://github.com/hexchat/hexchat/issues/576) requested the account-qualified form and was refused; ZNC's nickserv module defaults to `NICKSERV IDENTIFY {password}`. [phergie#12](https://github.com/phergie/phergie-irc-plugin-react-nickserv/issues/12) is the same failure from the other direction ("all IDENTIFY commands fail on Rizon") and was resolved by hardcoding bare rather than adding a setting, despite the issue title asking for configurability.

A user cannot answer "which services package does this tracker run?", and a wrong value is worse than none.

## Drive-by fixes in the same path

- **`handleLoggedIn` (RPL_LOGGEDIN 900) was dead code.** It used `m.Nick()`, but a numeric's source is the server name and `ParseNUH` returns a bare hostname as `Name` without an error, so `isOurCurrentNick` was never true. Now reads `Params[0]` and `Params[2]`. Confirmed live: `:irc1.myanonamouse.net 900 <nick> <nick>!<user>@<host> <account> :You are now logged in as <account>`.
- **NickServ passwords were being logged in plaintext.** `internal/logger/sanitize.go` matched `NickServ IDENTIFY <pw>`, but the command is sent as a single trailing parameter, so the logged line reads `--> PRIVMSG NickServ :IDENTIFY <pw>` and the colon meant the pattern never matched. Now covers both spellings and both argument counts. Tokens are delimited by whitespace or an unescaped quote, with backslash escapes consumed as a pair, so a credential containing a backslash (legal in an IRC nick, and escaped again by JSON-encoded log lines) is not split with its tail left behind.
- `handleNickServ` indexed `msg.Params[1]` without a length check.
- The NOTICE match table detected nothing on Atheme. Added `invalid password for` and `is not a registered nickname`.
- The old fallback did not guard against an empty `Auth.Account`; it is removed along with the fallback.

Fixes #2528

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* `go test ./...` passes, plus `go test -race ./internal/irc/` clean.
* New `internal/irc/nickserv_identify_test.go` covers: the notice matcher against the verbatim replies of each services package, including the must-not-escalate cases (success and bad password); every state guard; the forward-only lifecycle and its re-arm on disconnect; the #2528 regression; ladder termination; the Anope 1.8 ambiguous-error path; stickiness across reconnect and the unlearn/invalidate paths; the wire form per ladder state; and the 900 handler.
* Four new sanitizer cases in `internal/logger/sanitize_test.go` covering the form actually put on the wire. The plaintext-password leak was reproduced before the fix.
* Live protocol probes (`HELP IDENTIFY` only, no credentials sent) against Rizon, MyAnonaMouse, p2p-network, Scratch Network, Nebulance, Libera and DigitalIRC to establish the syntax each services package advertises.
* End-to-end on MyAnonaMouse with a real account: bare IDENTIFY from a grouped nick authenticates and returns `900` plus `MODE +r`; from an ungrouped nick it returns `Nick <bot> isn't registered.`, reproducing #2528.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL (n/a, the learned form is in-memory handler state by design)
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Yes. Claude Code (Opus 5) was used throughout.

Research: surveying the NickServ IDENTIFY argument handling across Atheme, Anope 1.8/2.x, Ergo and legacy services packages by reading their source; running the live protocol probes; surveying how other IRC clients and bouncers expose NickServ auth; and the git archaeology on autobrr's own history. Findings were cross-checked against primary sources, and the load-bearing ones (the Rizon and MAM probes, the Anope 1.8 parser, the dead 900 handler, the sanitizer leak) were reproduced and verified directly rather than taken on trust.

Implementation: the handler changes, the sanitizer fix and the tests are AI-written, reviewed and directed by me. Design decisions (bare-first rather than the reporter's proposed unconditional account form, no user-facing setting, in-memory rather than persisted stickiness) were made by me based on that research.