### PR TITLE
fix(docs): parse v2 definitions in indexer docs generator

### DIFF
--- a/.github/workflows/update-indexers.yml
+++ b/.github/workflows/update-indexers.yml
@@ -36,6 +36,9 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Install Python dependencies
+      run: pip install pyyaml
+
     - name: Update indexers list
       run: |
         # Verify source paths exist before running script

--- a/scripts/update-indexers.py
+++ b/scripts/update-indexers.py
@@ -3,59 +3,131 @@
 # Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+"""Generate the indexer and freeleech tables for the autobrr.com docs.
+
+Indexer definitions (v2) parse announces per IRC channel: every channel carries
+its own set of line patterns, and the release fields come from the named capture
+groups in those patterns plus the optional mappings that translate a captured
+value into other fields. Freeleech support is therefore derived from the groups
+and mappings of every channel of a definition, not from a definition-level vars
+list like it was in v1.
+"""
+
+import argparse
 import os
 import re
-from typing import Dict
+import sys
+from typing import Any, Dict, List, Set, Tuple
+
+import yaml
 
 # Paths relative to GitHub Actions workspace
 DEFINITIONS_DIR = "../autobrr/internal/indexer/definitions"
 INDEXERS_OUTPUT = "../autobrr.com/snippets/indexers.mdx"
 FREELEECH_OUTPUT = "../autobrr.com/snippets/freeleech.mdx"
 
-def parse_yaml_file(file_path: str) -> Dict:
-    """Parse YAML files"""
-    result = {}
-    with open(file_path, 'r', encoding='utf-8') as f:
-        content = f.read()
-        
-        # Extract fields using regex
-        name_match = re.search(r'name:\s*(.*)', content)
-        desc_match = re.search(r'description:\s*(.*)', content)
-        
-        supports_match = re.search(r'supports:\s*\n((?:\s*-\s*[^\n]+\n)*)', content)
-        supports = []
-        if supports_match:
-            supports = re.findall(r'-\s*(\w+)', supports_match.group(1))
-        
-        # Look for freeleech in multiple places:
-        # 1. In vars section
-        has_freeleech = bool(re.search(r'vars:.*?-\s*freeleech\s*$', content, re.MULTILINE | re.DOTALL))
-        has_freeleech_percent = bool(re.search(r'vars:.*?-\s*freeleechPercent\s*$', content, re.MULTILINE | re.DOTALL))
+NAMED_GROUP_RE = re.compile(r"\(\?P<([A-Za-z_][A-Za-z0-9_]*)>")
 
-        # 2. In mappings section - check what the fields map to
-        mappings_freeleech = bool(re.search(r'mappings:.*?(?:freeleech|freeleechPercent):\s*(?!.*?percent|.*?\d+%)', content, re.MULTILINE | re.DOTALL))
-        mappings_freeleech_percent = bool(re.search(r'mappings:.*?(?:freeleech|freeleechPercent):\s*(?:.*?percent|.*?\d+%)', content, re.MULTILINE | re.DOTALL))
 
-        has_freeleech = has_freeleech or mappings_freeleech
-        has_freeleech_percent = has_freeleech_percent or mappings_freeleech_percent
+def captured_vars(parse: Dict[str, Any]) -> Set[str]:
+    """Return the fields the line patterns of a channel capture."""
+    captured: Set[str] = set()
 
-        # 3. If mappings section contains downloadVolumeFactor, treat as supporting both
-        mappings_section = re.search(r'mappings:.*', content, re.DOTALL)
-        if mappings_section and 'downloadVolumeFactor' in mappings_section.group(0):
-            has_freeleech = True
-            has_freeleech_percent = True
-        
-        result = {
-            'name': name_match.group(1).strip() if name_match else '',
-            'description': desc_match.group(1).strip() if desc_match else '',
-            'supports': supports,
-            'freeleech': has_freeleech,
-            'freeleechPercent': has_freeleech_percent
-        }
-    return result
+    for line in parse.get("lines") or []:
+        if not isinstance(line, dict) or line.get("ignore"):
+            continue
+
+        # an explicit vars list keeps the legacy positional mapping and takes
+        # precedence over named groups, same as IndexerIRCParseLine.ParseLine
+        explicit = line.get("vars")
+        if explicit:
+            captured.update(v for v in explicit if isinstance(v, str))
+            continue
+
+        captured.update(NAMED_GROUP_RE.findall(line.get("pattern") or ""))
+
+    return captured
+
+
+def mapped_vars(parse: Dict[str, Any]) -> Tuple[Set[str], List[float]]:
+    """Return the fields a channel maps captured values to, and the download volume factors among them."""
+    mapped: Set[str] = set()
+    factors: List[float] = []
+
+    for values in (parse.get("mappings") or {}).values():
+        for targets in (values or {}).values():
+            if not isinstance(targets, dict):
+                continue
+
+            mapped.update(targets)
+
+            factor = targets.get("downloadVolumeFactor")
+            try:
+                factors.append(float(factor))
+            except (TypeError, ValueError):
+                continue
+
+    return mapped, factors
+
+
+def parse_freeleech(parse: Dict[str, Any]) -> Tuple[bool, bool]:
+    """Return whether a channel announces freeleech and freeleech percent."""
+    captured = captured_vars(parse)
+    mapped, factors = mapped_vars(parse)
+    produced = captured | mapped
+
+    # a factor below 1 is inverted into a freeleech percent by Release.MapVars, so
+    # a mapping that reaches 0 (fully free) fills in both fields, not just freeleech
+    discounted = any(0 <= f < 1 for f in factors)
+
+    freeleech = "freeleech" in produced or discounted
+    freeleech_percent = "freeleechPercent" in produced or discounted
+
+    # captured directly instead of mapped, so any value can be announced
+    if "downloadVolumeFactor" in captured:
+        freeleech = freeleech_percent = True
+
+    return freeleech, freeleech_percent
+
+
+def parse_definition(file_path: str) -> Dict[str, Any]:
+    """Read an indexer definition and reduce it to the fields the docs tables need."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        definition = yaml.safe_load(f)
+
+    if not isinstance(definition, dict):
+        raise ValueError("definition is not a mapping")
+
+    supports = [s.lower() for s in definition.get("supports") or [] if isinstance(s, str)]
+
+    freeleech = False
+    freeleech_percent = False
+
+    for channel in ((definition.get("irc") or {}).get("channels") or []):
+        parse = (channel or {}).get("parse")
+        if not parse:
+            continue
+
+        channel_freeleech, channel_freeleech_percent = parse_freeleech(parse)
+        freeleech = freeleech or channel_freeleech
+        freeleech_percent = freeleech_percent or channel_freeleech_percent
+
+    return {
+        "name": str(definition.get("name") or "").strip(),
+        "description": str(definition.get("description") or "").strip(),
+        "supports": supports,
+        "freeleech": freeleech,
+        "freeleechPercent": freeleech_percent,
+    }
+
 
 def get_feature_checkmark(value: bool) -> str:
     return "✓" if value else "✗"
+
+
+def escape_cell(value: str) -> str:
+    return value.replace("|", "\\|")
+
 
 def generate_indexers_markdown(indexers: list) -> str:
     """Generate markdown for indexers table."""
@@ -63,63 +135,81 @@ def generate_indexers_markdown(indexers: list) -> str:
     markdown += "<summary>Click to view supported indexers</summary>\n\n"
     markdown += "| Indexer | Description | IRC | RSS |\n"
     markdown += "|---------|-------------|-----|-----|\n"
-    
+
     for indexer in indexers:
-        name = indexer.get('name', '')
-        description = indexer.get('description', '')
-        irc_support = get_feature_checkmark('irc' in [f.lower() for f in indexer.get('supports', [])])
-        rss_support = get_feature_checkmark('rss' in [f.lower() for f in indexer.get('supports', [])])
-        
+        name = escape_cell(indexer.get("name", ""))
+        description = escape_cell(indexer.get("description", ""))
+        irc_support = get_feature_checkmark("irc" in indexer.get("supports", []))
+        rss_support = get_feature_checkmark("rss" in indexer.get("supports", []))
+
         markdown += f"| {name} | {description} | {irc_support} | {rss_support} |\n"
-    
+
     markdown += "\n</details>"
     return markdown
+
 
 def generate_freeleech_markdown(indexers: list) -> str:
     """Generate markdown for freeleech table."""
     markdown = "| Indexer | Freeleech | Freeleech Percent |\n"
     markdown += "|---------|-----------|------------------|\n"
-    
+
     for indexer in indexers:
-        # Skip if neither freeleech feature is supported
-        if not (indexer.get('freeleech', False) or indexer.get('freeleechPercent', False)):
+        if not (indexer.get("freeleech", False) or indexer.get("freeleechPercent", False)):
             continue
-            
-        name = indexer.get('name', '')
-        freeleech = get_feature_checkmark(indexer.get('freeleech', False))
-        freeleech_percent = get_feature_checkmark(indexer.get('freeleechPercent', False))
-        
+
+        name = escape_cell(indexer.get("name", ""))
+        freeleech = get_feature_checkmark(indexer.get("freeleech", False))
+        freeleech_percent = get_feature_checkmark(indexer.get("freeleechPercent", False))
+
         markdown += f"| {name} | {freeleech} | {freeleech_percent} |\n"
-    
+
     return markdown
+
 
 def main():
     """Generate markdown documents"""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--definitions", default=DEFINITIONS_DIR, help="directory with indexer definitions")
+    parser.add_argument("--indexers-output", default=INDEXERS_OUTPUT, help="path of the generated indexers table")
+    parser.add_argument("--freeleech-output", default=FREELEECH_OUTPUT, help="path of the generated freeleech table")
+    args = parser.parse_args()
+
     indexers = []
-    
-    # Read the YAML files
-    for filename in os.listdir(DEFINITIONS_DIR):
-        if filename.endswith('.yaml'):
-            file_path = os.path.join(DEFINITIONS_DIR, filename)
-            indexer = parse_yaml_file(file_path)
-            if indexer:
-                indexers.append(indexer)
-    
+    failed = []
+
+    for filename in sorted(os.listdir(args.definitions)):
+        if not filename.endswith(".yaml"):
+            continue
+
+        file_path = os.path.join(args.definitions, filename)
+        try:
+            indexers.append(parse_definition(file_path))
+        except (OSError, ValueError, yaml.YAMLError) as e:
+            failed.append(f"{filename}: {e}")
+
+    if failed:
+        print("Could not parse indexer definitions:", file=sys.stderr)
+        for failure in failed:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
     # Sort indexers by name, but put generic ones last
     def sort_key(indexer):
-        name = indexer.get('name', '').lower()
-        return (name.startswith('generic'), name)
-    
+        name = indexer.get("name", "").lower()
+        return (name.startswith("generic"), name)
+
     indexers.sort(key=sort_key)
-    
-    # Generate and write files
+
     for output_file, content in [
-        (INDEXERS_OUTPUT, generate_indexers_markdown(indexers)),
-        (FREELEECH_OUTPUT, generate_freeleech_markdown(indexers))
+        (args.indexers_output, generate_indexers_markdown(indexers)),
+        (args.freeleech_output, generate_freeleech_markdown(indexers)),
     ]:
         os.makedirs(os.path.dirname(output_file), exist_ok=True)
-        with open(output_file, 'w', encoding='utf-8') as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             f.write(content)
 
+    return 0
+
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
# Description

The docs generator `scripts/update-indexers.py` still reads definitions the v1 way: it regex-scrapes the raw YAML for a definition-level `vars:` list containing `freeleech`/`freeleechPercent`, and treats the whole file after `mappings:` as one blob. Since the v2 format landed in #2502, release fields come from named capture groups in the line patterns of each IRC channel, plus the per-channel `mappings:` block that translates a captured value into other fields. None of the current 114 definitions has a `vars:` list any more.

The result is that the generated freeleech table has quietly collapsed. Running the old script against today's definitions produces **8 rows**, down from the 50 on autobrr.com - 42 indexers lost their freeleech entry, and the daily workflow has been regenerating this since the v2 migration.

This rewrites the parsing to match the v2 format:

- Parse with PyYAML instead of regex over raw text.
- Walk `irc.channels[].parse` **per channel** and union the result, so freeleech announced on only one of several channels is still picked up.
- Read named capture groups (`(?P<freeleech>`, `(?P<freeleechPercent>`) from each line's `pattern`. Lines with `ignore: true` are skipped, and a line-level `vars:` list still takes precedence over named groups, mirroring `IndexerIRCParseLine.ParseLine`.
- Read `parse.mappings` with its real shape (`source -> value -> {target: value}`). A `freeleech`/`freeleechPercent` target counts directly, and `downloadVolumeFactor` values are inspected: any factor below 1 is inverted into a freeleech percent by `Release.MapVars`, so it marks both columns. This covers the enum-style trackers (`leechTypeEnum`, `freeleechEnum`, `fl`) that the old blob regex could not read.
- `uploadVolumeFactor` is deliberately ignored - it is double upload, not freeleech.

Along the way the script now fails loudly (exit 1, every bad file listed on stderr) instead of silently writing a truncated table, escapes `|` in table cells, and takes `--definitions` / `--indexers-output` / `--freeleech-output` flags so it can be run locally against a checkout.

The workflow gets a `pip install pyyaml` step.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Ran the old and the new script against the current 114 definitions. Old: 8 freeleech rows. New: 50.
* Diffed the new output against the tables published on autobrr.com (last generated 2026-06-29, before the v2 migration). Everything is byte-identical except three intentional corrections:
    * `freeleech.mdx`: BeyondHD `✗ ✓` -> `✓ ✓`. Its `freeleechEnum` maps `Capped FL` and `100% FL` to `downloadVolumeFactor: 0`, which the old regex never saw.
    * `indexers.mdx`: DasUnerwartete added (new since the last docs run).
    * `indexers.mdx`: Nexum's description no longer carries the literal YAML quotes (`"Nexum is a FRENCH..."`), since PyYAML unquotes it.
* Verified the mapping-driven trackers by hand against their definitions: UltraBits (factors `{0, 1}`) and the other `leechTypeEnum` trackers (factors down to `0.25`) all resolve to `✓ ✓`, MyAnonamouse (`releaseTags: VIP -> freeleech`) to `✓ ✗`.
* Exercised synthetic definitions covering a multi-channel definition with freeleech on only the second channel, a positional `vars:` list, a `freeleech` group on an `ignore: true` line, a directly captured `downloadVolumeFactor`, a mapping that only reaches full freeleech, and malformed YAML (exits 1, writes nothing).

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have linked any related issue and updated docs if needed