### PR TITLE
feat(filters): batch external filter lookup

### DIFF
--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -741,8 +741,27 @@ func (r *FilterRepo) findByIndexerIdentifier(ctx context.Context, indexer string
 }
 
 func (r *FilterRepo) FindExternalFiltersByID(ctx context.Context, filterId int) ([]domain.FilterExternal, error) {
+	externalFilters, err := r.findExternalFilters(ctx, []int{filterId})
+	if err != nil {
+		return nil, err
+	}
+
+	return externalFilters[filterId], nil
+}
+
+// FindExternalFiltersByFilterIDs returns external filters for the given filters grouped by filter id.
+func (r *FilterRepo) FindExternalFiltersByFilterIDs(ctx context.Context, filterIDs []int) (map[int][]domain.FilterExternal, error) {
+	return r.findExternalFilters(ctx, filterIDs)
+}
+
+func (r *FilterRepo) findExternalFilters(ctx context.Context, filterIDs []int) (map[int][]domain.FilterExternal, error) {
+	if len(filterIDs) == 0 {
+		return map[int][]domain.FilterExternal{}, nil
+	}
+
 	queryBuilder := r.db.squirrel.
 		Select(
+			"fe.filter_id",
 			"fe.id",
 			"fe.name",
 			"fe.idx",
@@ -762,8 +781,8 @@ func (r *FilterRepo) FindExternalFiltersByID(ctx context.Context, filterId int) 
 			"fe.on_error",
 		).
 		From("filter_external fe").
-		Where(sq.Eq{"fe.filter_id": filterId}).
-		OrderBy("fe.idx DESC")
+		Where(sq.Eq{"fe.filter_id": filterIDs}).
+		OrderBy("fe.filter_id", "fe.idx DESC")
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
@@ -772,16 +791,14 @@ func (r *FilterRepo) FindExternalFiltersByID(ctx context.Context, filterId int) 
 
 	rows, err := r.db.Handler.QueryContext(ctx, query, args...)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, domain.ErrRecordNotFound
-		}
 		return nil, errors.Wrap(err, "error executing query")
 	}
 	defer rows.Close()
 
-	var externalFilters []domain.FilterExternal
+	externalFilters := make(map[int][]domain.FilterExternal)
 
 	for rows.Next() {
+		var filterID int
 		var external domain.FilterExternal
 
 		// filter external
@@ -789,6 +806,7 @@ func (r *FilterRepo) FindExternalFiltersByID(ctx context.Context, filterId int) 
 		var extWebhookStatus, extWebhookRetryAttempts, extWebhookDelaySeconds, extExecStatus sql.NullInt32
 
 		if err := rows.Scan(
+			&filterID,
 			&external.ID,
 			&external.Name,
 			&external.Index,
@@ -823,7 +841,11 @@ func (r *FilterRepo) FindExternalFiltersByID(ctx context.Context, filterId int) 
 		external.WebhookRetryAttempts = int(extWebhookRetryAttempts.Int32)
 		external.WebhookRetryDelaySeconds = int(extWebhookDelaySeconds.Int32)
 
-		externalFilters = append(externalFilters, external)
+		externalFilters[filterID] = append(externalFilters[filterID], external)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "error scanning rows")
 	}
 
 	return externalFilters, nil

--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -589,6 +589,71 @@ func TestFilterRepo_FindExternalFiltersByID(t *testing.T) {
 	}
 }
 
+func TestFilterRepo_FindExternalFiltersByFilterIDs(t *testing.T) {
+	for dbType, db := range testDBs {
+		log := setupLoggerForTest()
+		repo := NewFilterRepo(log, db)
+
+		t.Run(fmt.Sprintf("FindExternalFiltersByFilterIDs_Groups_By_Filter [%s]", dbType), func(t *testing.T) {
+			// Setup
+			firstFilter := getMockFilter()
+			err := repo.Store(t.Context(), firstFilter)
+			assert.NoError(t, err)
+
+			secondFilter := getMockFilter()
+			err = repo.Store(t.Context(), secondFilter)
+			assert.NoError(t, err)
+
+			first := getMockFilterExternal()
+			first.Index = 1
+			second := getMockFilterExternal()
+			second.Name = "ExternalFilterTwo"
+			second.Index = 2
+
+			err = repo.StoreFilterExternal(t.Context(), firstFilter.ID, []domain.FilterExternal{first, second})
+			assert.NoError(t, err)
+
+			err = repo.StoreFilterExternal(t.Context(), secondFilter.ID, []domain.FilterExternal{first})
+			assert.NoError(t, err)
+
+			// Execute
+			externalFilters, err := repo.FindExternalFiltersByFilterIDs(t.Context(), []int{firstFilter.ID, secondFilter.ID})
+
+			// Verify
+			assert.NoError(t, err)
+			assert.Len(t, externalFilters, 2)
+			assert.Len(t, externalFilters[firstFilter.ID], 2)
+			assert.Len(t, externalFilters[secondFilter.ID], 1)
+
+			// idx DESC is preserved within each filter
+			assert.Equal(t, 2, externalFilters[firstFilter.ID][0].Index)
+			assert.Equal(t, 1, externalFilters[firstFilter.ID][1].Index)
+
+			// matches what the per-filter lookup returns
+			single, err := repo.FindExternalFiltersByID(t.Context(), firstFilter.ID)
+			assert.NoError(t, err)
+			assert.Equal(t, single, externalFilters[firstFilter.ID])
+
+			// Cleanup
+			_ = repo.Delete(t.Context(), firstFilter.ID)
+			_ = repo.Delete(t.Context(), secondFilter.ID)
+		})
+
+		t.Run(fmt.Sprintf("FindExternalFiltersByFilterIDs_Empty_Input [%s]", dbType), func(t *testing.T) {
+			externalFilters, err := repo.FindExternalFiltersByFilterIDs(t.Context(), []int{})
+			assert.NoError(t, err)
+			assert.Empty(t, externalFilters)
+		})
+
+		t.Run(fmt.Sprintf("FindExternalFiltersByFilterIDs_Unknown_ID [%s]", dbType), func(t *testing.T) {
+			externalFilters, err := repo.FindExternalFiltersByFilterIDs(t.Context(), []int{-1})
+			assert.NoError(t, err)
+			assert.Empty(t, externalFilters)
+			assert.Nil(t, externalFilters[-1])
+		})
+	}
+}
+
 func TestFilterRepo_StoreIndexerConnection(t *testing.T) {
 	for dbType, db := range testDBs {
 		log := setupLoggerForTest()

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -31,6 +31,7 @@ type filterRepo interface {
 	FindByID(ctx context.Context, filterID int) (*domain.Filter, error)
 	FindByIndexerIdentifier(ctx context.Context, indexer string) ([]*domain.Filter, error)
 	FindExternalFiltersByID(ctx context.Context, filterId int) ([]domain.FilterExternal, error)
+	FindExternalFiltersByFilterIDs(ctx context.Context, filterIDs []int) (map[int][]domain.FilterExternal, error)
 	Store(ctx context.Context, filter *domain.Filter) error
 	Update(ctx context.Context, filter *domain.Filter) error
 	UpdatePartial(ctx context.Context, filter domain.FilterUpdate) error
@@ -195,12 +196,18 @@ func (s *Service) FindByIndexerIdentifier(ctx context.Context, indexer string) (
 
 	// we do not load actions here since we do not need it at this stage
 	// only load those after a filter has matched
+	filterIDs := make([]int, 0, len(filters))
 	for _, filter := range filters {
-		externalFilters, err := s.repo.FindExternalFiltersByID(ctx, filter.ID)
-		if err != nil {
-			s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not find external filters")
-		}
-		filter.External = externalFilters
+		filterIDs = append(filterIDs, filter.ID)
+	}
+
+	externalFilters, err := s.repo.FindExternalFiltersByFilterIDs(ctx, filterIDs)
+	if err != nil {
+		s.log.Error().Err(err).Str("indexer", indexer).Msg("could not find external filters")
+	}
+
+	for _, filter := range filters {
+		filter.External = externalFilters[filter.ID]
 	}
 
 	return filters, nil


### PR DESCRIPTION
# Description

`FindByIndexerIdentifier` loaded external filters with one query per filter, in a loop, before any filter had been matched:

```go
for _, filter := range filters {
    externalFilters, err := s.repo.FindExternalFiltersByID(ctx, filter.ID)
    ...
}
```

Every announce hits this path, and the loop runs over *all* enabled filters on the indexer, not just matching ones. An indexer with 30 attached filters therefore issued 31 queries (1 wide filter query + 30 external-filter lookups) before it could even decide whether anything matched. Most installs have no external filters configured at all, so those queries return nothing.

This replaces the loop with a single batched lookup:

- New `FilterRepo.FindExternalFiltersByFilterIDs(ctx, []int) (map[int][]domain.FilterExternal, error)`, which selects `fe.filter_id` alongside the existing columns, uses `sq.Eq{"fe.filter_id": filterIDs}` for the `IN` list, and orders by `fe.filter_id, fe.idx DESC` so per-filter ordering is unchanged.
- `FindExternalFiltersByID` now delegates to the same helper and indexes the resulting map, so there is one row-scanning block instead of two near-identical copies. Its behaviour is unchanged, including returning `nil, nil` for an unknown filter id.
- `FindByIndexerIdentifier` collects the ids and makes one call. Empty input short-circuits without touching the database.

Net effect: `F - 1` fewer round trips per announce, where `F` is the number of enabled filters on the indexer. On SQLite this matters more than the raw query count suggests, since `SetMaxOpenConns(1)` means every one of those round trips is serialised against every other announce in flight.

Two small fixes in the code being touched:

- Added the missing `rows.Err()` check after the scan loop. Previously an error part-way through iteration was swallowed, and the caller silently received a truncated set of external filters rather than an error.
- Dropped an unreachable `errors.Is(err, sql.ErrNoRows)` branch. `QueryContext` does not return `ErrNoRows`, so that `domain.ErrRecordNotFound` path could never be taken.

Error handling is otherwise deliberately unchanged: as before, a failed lookup is logged and processing continues with no external filters attached (previously per filter, now once for the batch — same outcome).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor / maintenance (no functional change)

Primarily a performance change; there is no checkbox for that. The bug-fix box covers the `rows.Err()` issue described above.

## How has this been tested?

* New `TestFilterRepo_FindExternalFiltersByFilterIDs` covering grouping across two filters, `idx DESC` ordering preserved within each filter, equivalence with the single-id method, empty input, and an unknown id.
* Full `TestFilterRepo` integration suite passes against **both SQLite and PostgreSQL** (`go test -tags=integration ./internal/database/`).
* Standard suite green: `go test $(go list ./... | grep -v test/integration)`.
* `go build ./...`, `go vet`, and `gofmt` all clean.

Note for reviewers running the full integration suite: `TestReleaseCleanupJobRepo_UpdateLastRun` fails on Postgres for anyone not in UTC (it compares a local-time value against a UTC one). That is pre-existing and unrelated — verified by stashing this change and re-running on a clean tree.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed