### PR TITLE
fix(feeds): resolve magnet links from torznab magneturl

### DIFF
--- a/internal/feed/rss.go
+++ b/internal/feed/rss.go
@@ -178,6 +178,17 @@ func (j *RSSJob) processItem(item *gofeed.Item) *domain.Release {
 		rls.DownloadURL = sanitize.URLEncoding(item.Link)
 	}
 
+	// a magnet can not be fetched over http, so it never belongs in DownloadURL,
+	// whatever the feed is configured as. It also has no hostname, which would send
+	// it through the relative url handling below and mangle it.
+	if strings.HasPrefix(rls.DownloadURL, domain.MagnetURIPrefix) {
+		if rls.MagnetURI == "" {
+			rls.MagnetURI = rls.DownloadURL
+		}
+
+		rls.DownloadURL = ""
+	}
+
 	if rls.DownloadURL != "" {
 		// handle no baseurl with only relative url
 		// grab url from feed url and create full url

--- a/internal/feed/rss_test.go
+++ b/internal/feed/rss_test.go
@@ -568,6 +568,70 @@ func TestRSSJob_processItem(t *testing.T) {
 	}
 }
 
+func TestRSSJob_processItemMagnet(t *testing.T) {
+	t.Parallel()
+
+	const (
+		magnetURI = "magnet:?xt=urn:btih:deadbeef"
+		detailURL = "https://fake-feed.com/details.php?id=00000"
+	)
+
+	magnetEnclosure := []*gofeed.Enclosure{{URL: magnetURI, Length: "1", Type: "application/x-bittorrent"}}
+
+	tests := []struct {
+		name            string
+		downloadType    domain.FeedDownloadType
+		item            *gofeed.Item
+		wantDownloadURL string
+		wantMagnetURI   string
+	}{
+		{
+			name:            "magnet type keeps the detail link as fallback",
+			downloadType:    domain.FeedDownloadTypeMagnet,
+			item:            &gofeed.Item{Link: detailURL, Enclosures: magnetEnclosure},
+			wantDownloadURL: detailURL,
+			wantMagnetURI:   magnetURI,
+		},
+		{
+			name:          "magnet in the link is not mangled into a relative url",
+			downloadType:  domain.FeedDownloadTypeMagnet,
+			item:          &gofeed.Item{Link: magnetURI},
+			wantMagnetURI: magnetURI,
+		},
+		{
+			name:          "magnet in the link is rescued without the magnet download type",
+			item:          &gofeed.Item{Link: magnetURI},
+			wantMagnetURI: magnetURI,
+		},
+		{
+			name:          "magnet in the enclosure is rescued without the magnet download type",
+			item:          &gofeed.Item{Enclosures: magnetEnclosure},
+			wantMagnetURI: magnetURI,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := &RSSJob{
+				Log: zerolog.Nop(),
+				URL: "https://fake-feed.com/rss",
+				Feed: &domain.Feed{
+					Indexer:  domain.IndexerMinimal{Name: "Mock Feed", Identifier: "mock-feed"},
+					Settings: &domain.FeedSettingsJSON{DownloadType: tt.downloadType},
+				},
+			}
+
+			tt.item.Title = "Some.Release.Title.2022.09.22.720p.WEB.h264-GROUP"
+
+			got := j.processItem(tt.item)
+			assert.NotNil(t, got)
+
+			assert.Equal(t, tt.wantDownloadURL, got.DownloadURL, "download url")
+			assert.Equal(t, tt.wantMagnetURI, got.MagnetURI, "magnet uri")
+		})
+	}
+}
+
 func Test_isMaxAge(t *testing.T) {
 	t.Parallel()
 	type args struct {

--- a/internal/feed/torznab.go
+++ b/internal/feed/torznab.go
@@ -143,18 +143,31 @@ func (j *TorznabJob) processItems(items []torznab.FeedItem) ([]*domain.Release, 
 
 		rls.TorrentName = item.Title
 		rls.DownloadURL = item.Link
-		if j.Feed.Settings != nil && j.Feed.Settings.DownloadType == domain.FeedDownloadTypeMagnet && strings.HasPrefix(item.Link, domain.MagnetURIPrefix) {
-			rls.MagnetURI = item.Link
-			rls.DownloadURL = ""
-		}
 
 		if item.Enclosure != nil && item.Enclosure.Type == "application/x-bittorrent" {
 			rls.DownloadURL = item.Enclosure.URL
+		}
 
-			if j.Feed.Settings != nil && j.Feed.Settings.DownloadType == domain.FeedDownloadTypeMagnet && strings.HasPrefix(item.Enclosure.URL, domain.MagnetURIPrefix) {
-				rls.MagnetURI = item.Enclosure.URL
-				rls.DownloadURL = ""
+		if j.Feed.Settings != nil && j.Feed.Settings.DownloadType == domain.FeedDownloadTypeMagnet {
+			// Jackett and Prowlarr publish the magnet in the magneturl attr but put their
+			// own proxy url in the link, which only redirects to it. Mirror a non-magnet
+			// url into MagnetURI for ResolveMagnetURI to follow, and leave it in
+			// DownloadURL as the fallback for when it never resolves.
+			if strings.HasPrefix(item.MagnetURI, domain.MagnetURIPrefix) {
+				rls.MagnetURI = item.MagnetURI
+			} else {
+				rls.MagnetURI = rls.DownloadURL
 			}
+		}
+
+		// a magnet can not be fetched over http, so it never belongs in DownloadURL,
+		// whatever the feed is configured as
+		if strings.HasPrefix(rls.DownloadURL, domain.MagnetURIPrefix) {
+			if rls.MagnetURI == "" {
+				rls.MagnetURI = rls.DownloadURL
+			}
+
+			rls.DownloadURL = ""
 		}
 
 		rls.ParseString(item.Title)

--- a/internal/feed/torznab_test.go
+++ b/internal/feed/torznab_test.go
@@ -15,6 +15,90 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTorznabJob_processItems(t *testing.T) {
+	const (
+		magnetURI  = "magnet:?xt=urn:btih:deadbeef"
+		proxyURL   = "http://jackett:9117/dl/mock/?jackett_apikey=key&file=Some.Release"
+		torrentURL = "https://fake-feed.com/download/00000.torrent"
+	)
+
+	torrentEnclosure := &torznab.Enclosure{URL: torrentURL, Type: "application/x-bittorrent"}
+	magnetEnclosure := &torznab.Enclosure{URL: magnetURI, Type: "application/x-bittorrent"}
+
+	tests := []struct {
+		name            string
+		settings        *domain.FeedSettingsJSON
+		item            torznab.FeedItem
+		wantDownloadURL string
+		wantMagnetURI   string
+	}{
+		{
+			name:            "no feed settings keeps the torrent url",
+			item:            torznab.FeedItem{Link: torrentURL, Enclosure: torrentEnclosure},
+			wantDownloadURL: torrentURL,
+		},
+		{
+			name:            "torrent type ignores the magneturl attr",
+			settings:        &domain.FeedSettingsJSON{DownloadType: domain.FeedDownloadTypeTorrent},
+			item:            torznab.FeedItem{Link: torrentURL, Enclosure: torrentEnclosure, MagnetURI: magnetURI},
+			wantDownloadURL: torrentURL,
+		},
+		{
+			name:          "magnet in the link",
+			settings:      &domain.FeedSettingsJSON{DownloadType: domain.FeedDownloadTypeMagnet},
+			item:          torznab.FeedItem{Link: magnetURI},
+			wantMagnetURI: magnetURI,
+		},
+		{
+			name:          "magnet in the enclosure",
+			settings:      &domain.FeedSettingsJSON{DownloadType: domain.FeedDownloadTypeMagnet},
+			item:          torznab.FeedItem{Link: proxyURL, Enclosure: magnetEnclosure},
+			wantMagnetURI: magnetURI,
+		},
+		{
+			name:            "magneturl attr wins over the proxy link",
+			settings:        &domain.FeedSettingsJSON{DownloadType: domain.FeedDownloadTypeMagnet},
+			item:            torznab.FeedItem{Link: proxyURL, MagnetURI: magnetURI},
+			wantDownloadURL: proxyURL,
+			wantMagnetURI:   magnetURI,
+		},
+		{
+			name:            "proxy link is kept for ResolveMagnetURI to follow",
+			settings:        &domain.FeedSettingsJSON{DownloadType: domain.FeedDownloadTypeMagnet},
+			item:            torznab.FeedItem{Link: proxyURL},
+			wantDownloadURL: proxyURL,
+			wantMagnetURI:   proxyURL,
+		},
+		{
+			name:          "magnet never stays in the download url",
+			settings:      &domain.FeedSettingsJSON{DownloadType: domain.FeedDownloadTypeTorrent},
+			item:          torznab.FeedItem{Link: proxyURL, Enclosure: magnetEnclosure},
+			wantMagnetURI: magnetURI,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := &TorznabJob{
+				Log: zerolog.New(io.Discard),
+				Feed: &domain.Feed{
+					Indexer:  domain.IndexerMinimal{Name: "Mock Feed", Identifier: "mock-feed"},
+					Settings: tt.settings,
+				},
+			}
+
+			tt.item.Title = "Some.Release.Title.2022.09.22.720p.WEB.h264-GROUP"
+
+			releases, err := j.processItems([]torznab.FeedItem{tt.item})
+			assert.NoError(t, err)
+			assert.Len(t, releases, 1)
+
+			assert.Equal(t, tt.wantDownloadURL, releases[0].DownloadURL, "download url")
+			assert.Equal(t, tt.wantMagnetURI, releases[0].MagnetURI, "magnet uri")
+		})
+	}
+}
+
 func TestTorznabJob_RunE(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		queryType := r.URL.Query().Get("t")

--- a/internal/releasedownload/download_service.go
+++ b/internal/releasedownload/download_service.go
@@ -367,10 +367,15 @@ func (s *DownloadService) ResolveMagnetURI(ctx context.Context, r *domain.Releas
 		return errors.Wrap(err, "could not read response body")
 	}
 
-	magnet := string(body)
-	if magnet != "" {
-		r.MagnetURI = magnet
+	magnet := strings.TrimSpace(string(body))
+	if !strings.HasPrefix(magnet, domain.MagnetURIPrefix) {
+		// the url did not lead to a magnet after all, drop it so HasMagnetUri stays
+		// false and the release falls back to downloading from DownloadURL
+		r.MagnetURI = ""
+		return nil
 	}
+
+	r.MagnetURI = magnet
 
 	return nil
 }

--- a/internal/releasedownload/download_service_test.go
+++ b/internal/releasedownload/download_service_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2021-2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package releasedownload
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/autobrr/internal/domain"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockIndexerRepo struct{}
+
+func (m *mockIndexerRepo) FindByID(_ context.Context, id int) (*domain.Indexer, error) {
+	return &domain.Indexer{ID: int64(id), Identifier: "mock-feed"}, nil
+}
+
+type mockProxyService struct{}
+
+func (m *mockProxyService) FindByID(_ context.Context, id int64) (*domain.Proxy, error) {
+	return &domain.Proxy{ID: id}, nil
+}
+
+func TestDownloadService_ResolveMagnetURI(t *testing.T) {
+	const magnetURI = "magnet:?xt=urn:btih:deadbeef"
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		// magnetURI on the release before resolving, %s is replaced with the test server url
+		before string
+		want   string
+	}{
+		{
+			name:   "empty is left alone",
+			before: "",
+			want:   "",
+		},
+		{
+			name:   "magnet is left alone",
+			before: magnetURI,
+			want:   magnetURI,
+		},
+		{
+			name: "redirect to a magnet is followed",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, magnetURI, http.StatusFound)
+			},
+			before: "%s/dl/mock",
+			want:   magnetURI,
+		},
+		{
+			name: "magnet in the body is used",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				io.WriteString(w, magnetURI+"\n")
+			},
+			before: "%s/dl/mock",
+			want:   magnetURI,
+		},
+		{
+			name: "a response that is not a magnet is discarded",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				io.WriteString(w, "d8:announce20:https://fake-feed.come")
+			},
+			before: "%s/dl/mock",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			magnet := tt.before
+
+			if tt.handler != nil {
+				srv := httptest.NewServer(tt.handler)
+				defer srv.Close()
+
+				magnet = strings.Replace(tt.before, "%s", srv.URL, 1)
+			}
+
+			svc := NewDownloadService(zerolog.New(io.Discard), &mockIndexerRepo{}, &mockProxyService{})
+
+			rls := domain.NewRelease(domain.IndexerMinimal{ID: 1, Name: "Mock Feed", Identifier: "mock-feed"})
+			rls.MagnetURI = magnet
+
+			err := svc.ResolveMagnetURI(t.Context(), rls)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, rls.MagnetURI)
+		})
+	}
+}

--- a/pkg/torznab/feed.go
+++ b/pkg/torznab/feed.go
@@ -65,6 +65,7 @@ type FeedItem struct {
 	Comments        string           `xml:"comments"`
 	Size            uint64           `xml:"size"`
 	Link            string           `xml:"link"`
+	MagnetURI       string           `xml:"magneturl,omitempty"`
 	Enclosure       *Enclosure       `xml:"enclosure,omitempty"`
 	Category        []int            `xml:"category,omitempty"`
 	Categories      Categories
@@ -222,6 +223,10 @@ func (f *FeedItem) parseAttributes() {
 			}
 		case "genre":
 			f.Genres = strings.Split(attr.Value, ",")
+		case "magneturl":
+			if f.MagnetURI == "" {
+				f.MagnetURI = attr.Value
+			}
 		}
 	}
 

--- a/pkg/torznab/feed_test.go
+++ b/pkg/torznab/feed_test.go
@@ -41,3 +41,39 @@ func TestFeedItem_parseAttributes(t *testing.T) {
 		})
 	}
 }
+
+func TestFeedItem_parseAttributesMagnetURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		item       FeedItem
+		attributes Attributes
+		want       string
+	}{
+		{
+			name:       "magneturl attr is picked up",
+			attributes: Attributes{{Name: "magneturl", Value: "magnet:?xt=urn:btih:deadbeef"}},
+			want:       "magnet:?xt=urn:btih:deadbeef",
+		},
+		{
+			name:       "missing attr leaves it empty",
+			attributes: Attributes{{Name: "seeders", Value: "10"}},
+			want:       "",
+		},
+		{
+			name:       "element takes precedence over attr",
+			item:       FeedItem{MagnetURI: "magnet:?xt=urn:btih:fromelement"},
+			attributes: Attributes{{Name: "magneturl", Value: "magnet:?xt=urn:btih:fromattr"}},
+			want:       "magnet:?xt=urn:btih:fromelement",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.item
+			f.Attributes = tt.attributes
+			f.parseAttributes()
+
+			assert.Equal(t, tt.want, f.MagnetURI)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Torznab feeds set to `Download Type: Magnet` could end up with an empty `MagnetURI` on the release, so `{{.MagnetURI}}` rendered empty in macros and download client actions tried to fetch the link as a `.torrent`. Two separate causes.

**1. The torznab `magneturl` attribute was never parsed.** Jackett and Prowlarr publish the magnet as `<torznab:attr name="magneturl" value="magnet:?..." />`. `pkg/torznab` had no field for it and `parseAttributes` had no case, so the value was decoded into `Attributes` and then dropped. The RSS path already reads the equivalent (`item.Custom["magnetURI"]` and the `torrent` extension's `magnetURI`); torznab had no counterpart.

**2. #2439 stopped indirection links from reaching `MagnetURI`.** Before it, `rls.MagnetURI = item.Link` ran unconditionally for magnet feeds. That mattered, because Jackett and Prowlarr usually put their own proxy url in `<link>` (Jackett: `http://jackett:9117/dl/<indexer>/?jackett_apikey=...`) which only 302-redirects to the magnet rather than being one. Seeding `MagnetURI` with that link let `DownloadService.ResolveMagnetURI` follow it, and `sharedhttp.MagnetRoundTripper` already turns a redirect that lands on the `magnet:` scheme into a 200 whose body is the magnet, so the round trip worked.

The `strings.HasPrefix(item.Link, domain.MagnetURIPrefix)` guard added in #2439 meant an http link no longer matched, so `MagnetURI` stayed empty, `ResolveMagnetURI` returned early on `r.MagnetURI == ""`, and the release went down the torrent download path with `HasMagnetUri()` false. The guard is correct for what it fixed (a magnet in the enclosure landing in `DownloadURL`, #2429). The regression is that nothing replaced the indirection case.

## The rule this settles on

> A literal `magnet:?` never stays in `DownloadURL`. An http url that only *redirects* to a magnet does stay, because it is still a valid download url and a usable fallback.

That single rule is what the changes below enforce.

**`pkg/torznab/feed.go`** - `MagnetURI` added to `FeedItem` as `xml:"magneturl,omitempty"` so a `<magneturl>` element is picked up too, plus a `magneturl` case in `parseAttributes` guarded with `if f.MagnetURI == ""` so an element wins over the attribute.

**`internal/feed/torznab.go`** - the enclosure now resolves `DownloadURL` first. One `MAGNET`-gated block then prefers `item.MagnetURI`, and otherwise mirrors the resolved download url into `MagnetURI` for `ResolveMagnetURI` to follow, leaving it in `DownloadURL` as the fallback for when it never resolves. Below that, an ungated block moves a literal magnet out of `DownloadURL`.

Preferring `magneturl` stays gated on `DownloadType == MAGNET` on purpose: Jackett and Prowlarr publish that attribute for nearly every public tracker, so honouring it unconditionally would silently flip `Torrent` feeds over to magnets. The literal-magnet rescue is ungated, since fetching a `magnet:` over http can only ever fail. That also covers users who never set the download type, which is the shape of #2429.

**`internal/releasedownload/download_service.go`** - `ResolveMagnetURI` trims the response body and only accepts it when it actually starts with `magnet:?`, clearing `MagnetURI` otherwise so `HasMagnetUri()` stays false and the release falls back to downloading from `DownloadURL`. Previously any non-empty body was assigned, so an endpoint that answered with a `.torrent` left binary junk in the field, which then showed up verbatim in `{{.MagnetURI}}`. Trimming also drops the trailing newline some indexers send.

**`internal/feed/rss.go`** - the same ungated rescue, placed before the relative-url base join. RSS had the worse version of this: `url.Parse("magnet:?...")` has no hostname, so a magnet in `<link>` on a feed without the magnet download type was joined against the feed host and came out as `https://feed.example.com/magnet:?xt=...`.

This came out of reviewing #2333, which proposed assigning the magnet to `DownloadURL` instead. That is the wrong lever: `DownloadURL == ""` for magnets is the invariant `HasMagnetUri()` and `downloadTorrentFile` rely on.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* New `TestTorznabJob_processItems` covering 7 cases: no feed settings, torrent type ignoring the `magneturl` attr, magnet in the link, magnet in the enclosure, the attr winning over the proxy link, the proxy link being kept for resolution, and a magnet rescued from a torrent-type feed.
* New `TestDownloadService_ResolveMagnetURI` driving a real `httptest` server: empty input, an already-resolved magnet, a **302 to `magnet:` being followed**, a magnet in the body, and a non-magnet response being discarded. The redirect case exercises the full indirection round trip through `MagnetRoundTripper`.
* New `TestRSSJob_processItemMagnet` covering the detail link surviving as a fallback, the magnet in `<link>` no longer being mangled, and the rescue firing without the magnet download type.
* New `TestFeedItem_parseAttributesMagnetURL` covering the attribute, its absence, and element precedence.
* The pre-existing `TestRSSJob_processItem/magnet` passes unchanged.
* Standard suite green: `go test $(go list ./... | grep -v test/integration)`. `go build ./...` and `gofmt` clean.

Not covered automatically: a live Jackett or Prowlarr instance. Worth a manual pass against one before merging.

## Known gap, not addressed here

`MagnetURI` has no database column and `Service.Retry` re-reads the release from the database, so retrying a *literal*-magnet release from the UI still fails with `download_file: url can't be empty`. This PR fixes retry for the indirection case, since the url survives in `download_url`. Closing it properly needs a `magnet_uri` column plus SQLite and PostgreSQL migrations, which belongs in its own PR.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed

No schema change, so the migration checkbox does not apply.