### PR TITLE
fix(indexers): TBy remove invite command

### DIFF
--- a/internal/indexer/definitions/torrentbytes.yaml
+++ b/internal/indexer/definitions/torrentbytes.yaml
@@ -47,7 +47,7 @@ irc:
     - name: invite_command
       type: secret
       default: "erica letmeinannounce USERNAME IRCKEY"
-      required: true
+      required: false
       label: Invite command
       help: Invite auth with Erica, please replace USERNAME and IRCKEY.
 

--- a/internal/indexer/definitions/torrentbytes.yaml
+++ b/internal/indexer/definitions/torrentbytes.yaml
@@ -44,12 +44,12 @@ irc:
       label: NickServ Password
       help: NickServ password
 
-    - name: invite_command
-      type: secret
-      default: "erica letmeinannounce USERNAME IRCKEY"
-      required: false
-      label: Invite command
-      help: Invite auth with Erica, please replace USERNAME and IRCKEY.
+#    - name: invite_command
+#      type: secret
+#      default: "erica letmeinannounce USERNAME IRCKEY"
+#      required: true
+#      label: Invite command
+#      help: Invite auth with Erica, please replace USERNAME and IRCKEY.
 
   channels:
     - name: "#torrentbytes-announce"


### PR DESCRIPTION
# Description

It is not required to provide the invite command. In fact, it has not been working for a long time and the response is always `<erica> irc key or username is wrong!`. You just need to be identified with NickServ.

I believe due to this, AutoBrr still thinks it is not in the channel. This should fix the issue `join not confirmed`, even though it clearly is in the channel and can see the announces and it actually works.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Not tested

## Screenshots (for UI changes)

<img width="828" height="105" alt="image" src="https://github.com/user-attachments/assets/6a3c0b37-c507-434b-9d3c-0f866418f0ef" />

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

No AI was used.

