### PR TITLE
feat(clients): add Sportarr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ qBittorrent, Deluge, r(u)Torrent, and Transmission. You don't need to use the *a
 - **Transmission**
 - **Porla**
 - **aria2**
-- **Sonarr, Radarr, Lidarr, Whisparr, Readarr:** Pushes releases directly for early swarm participation, rather than relying on RSS feeds.
+- **Sonarr, Radarr, Lidarr, Whisparr, Readarr, Sportarr:** Pushes releases directly for early swarm participation, rather than relying on RSS feeds.
 - **SABnzbd (Usenet):** Integrates smoothly for Usenet downloads.
 - **Watch Folder:** Monitors specified folders for new files.
 - **Exec Custom Scripts:** Execute tailored scripts for advanced automation.

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -90,6 +90,9 @@ func (s *Service) RunAction(ctx context.Context, action *domain.Action, release 
 	case domain.ActionTypeReadarr:
 		rejections, err = s.readarr(ctx, action, release)
 
+	case domain.ActionTypeSportarr:
+		rejections, err = s.sportarr(ctx, action, release)
+
 	case domain.ActionTypeSabnzbd:
 		rejections, err = s.sabnzbd(ctx, action, release)
 

--- a/internal/action/sportarr.go
+++ b/internal/action/sportarr.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package action
+
+import (
+	"context"
+	"time"
+
+	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/autobrr/autobrr/pkg/arr/sportarr"
+	"github.com/autobrr/autobrr/pkg/errors"
+
+	"github.com/rs/zerolog"
+)
+
+func (s *Service) sportarr(ctx context.Context, action *domain.Action, release *domain.Release) ([]string, error) {
+	l := zerolog.Ctx(ctx)
+
+	l.Trace().Msg("running Sportarr action")
+
+	client, err := s.clientSvc.GetClient(ctx, action.ClientID)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get client with id %d", action.ClientID)
+	}
+	action.Client = client
+
+	if !client.Enabled {
+		return nil, errors.New("client %s %s not enabled", client.Type, client.Name)
+	}
+
+	arrClient, ok := client.Client.(*sportarr.Client)
+	if !ok {
+		return nil, errors.New("invalid client type")
+	}
+
+	r := sportarr.ReleasePushRequest{
+		Title:            release.TorrentName,
+		InfoUrl:          release.InfoURL,
+		DownloadUrl:      release.DownloadURL,
+		MagnetUrl:        release.MagnetURI,
+		Size:             release.Size,
+		Indexer:          release.Indexer.GetExternalIdentifier(),
+		DownloadProtocol: release.Protocol.String(),
+		Protocol:         release.Protocol.String(),
+		PublishDate:      time.Now().Format(time.RFC3339),
+	}
+
+	indexerFlags := sportarr.BuildIndexerFlags(sportarr.ReleaseMeta{
+		FreeleechPercent: release.FreeleechPercent,
+		Origin:           release.Origin,
+	})
+	r.IndexerFlags = int(indexerFlags)
+
+	rejections, err := arrClient.Push(ctx, r)
+	if err != nil {
+		return nil, errors.Wrap(err, "sportarr: failed to push release: %v", r)
+	}
+
+	if rejections != nil {
+		l.Debug().Str("indexer", r.Indexer).Str("host", client.Host).Strs("rejections", rejections).Msg("client rejected the release")
+
+		return rejections, nil
+	}
+
+	l.Info().Str("indexer", r.Indexer).Str("host", client.Host).Msg("release successfully added to client")
+
+	return nil, nil
+}

--- a/internal/domain/action.go
+++ b/internal/domain/action.go
@@ -174,6 +174,7 @@ const (
 	ActionTypeWhisparr     ActionType = "WHISPARR"
 	ActionTypeWhisparrV3   ActionType = "WHISPARR_V3"
 	ActionTypeReadarr      ActionType = "READARR"
+	ActionTypeSportarr     ActionType = "SPORTARR"
 	ActionTypeSabnzbd      ActionType = "SABNZBD"
 	ActionTypeNzbget       ActionType = "NZBGET"
 )

--- a/internal/domain/client.go
+++ b/internal/domain/client.go
@@ -190,6 +190,7 @@ const (
 	DownloadClientTypeWhisparr     DownloadClientType = "WHISPARR"
 	DownloadClientTypeWhisparrV3   DownloadClientType = "WHISPARR_V3"
 	DownloadClientTypeReadarr      DownloadClientType = "READARR"
+	DownloadClientTypeSportarr     DownloadClientType = "SPORTARR"
 	DownloadClientTypeSabnzbd      DownloadClientType = "SABNZBD"
 	DownloadClientTypeNzbget       DownloadClientType = "NZBGET"
 )

--- a/internal/domain/list.go
+++ b/internal/domain/list.go
@@ -22,6 +22,7 @@ const (
 	ListTypeReadarr    ListType = "READARR"
 	ListTypeWhisparr   ListType = "WHISPARR"
 	ListTypeWhisparrV3 ListType = "WHISPARR_V3"
+	ListTypeSportarr   ListType = "SPORTARR"
 	ListTypeMDBList    ListType = "MDBLIST"
 	ListTypeMetacritic ListType = "METACRITIC"
 	ListTypePlaintext  ListType = "PLAINTEXT"
@@ -108,7 +109,7 @@ func (l *List) Validate() error {
 }
 
 func (l *List) ListTypeArr() bool {
-	return l.Type == ListTypeRadarr || l.Type == ListTypeSonarr || l.Type == ListTypeLidarr || l.Type == ListTypeReadarr || l.Type == ListTypeWhisparr || l.Type == ListTypeWhisparrV3
+	return l.Type == ListTypeRadarr || l.Type == ListTypeSonarr || l.Type == ListTypeLidarr || l.Type == ListTypeReadarr || l.Type == ListTypeWhisparr || l.Type == ListTypeWhisparrV3 || l.Type == ListTypeSportarr
 }
 
 func (l *List) ListTypeList() bool {

--- a/internal/download_client/connection.go
+++ b/internal/download_client/connection.go
@@ -16,6 +16,7 @@ import (
 	"github.com/autobrr/autobrr/pkg/arr/radarr"
 	"github.com/autobrr/autobrr/pkg/arr/readarr"
 	"github.com/autobrr/autobrr/pkg/arr/sonarr"
+	"github.com/autobrr/autobrr/pkg/arr/sportarr"
 	"github.com/autobrr/autobrr/pkg/arr/whisparr"
 	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/autobrr/autobrr/pkg/nzbget"
@@ -65,6 +66,9 @@ func (s *Service) testConnection(ctx context.Context, client domain.DownloadClie
 
 	case domain.DownloadClientTypeReadarr:
 		return s.testReadarrConnection(ctx, client)
+
+	case domain.DownloadClientTypeSportarr:
+		return s.testSportarrConnection(ctx, client)
 
 	case domain.DownloadClientTypeSabnzbd:
 		return s.testSabnzbdConnection(ctx, client)
@@ -258,6 +262,34 @@ func (s *Service) testRadarrConnection(ctx context.Context, client domain.Downlo
 	}
 
 	s.log.Debug().Msg("test client connection for Radarr: success")
+
+	return nil
+}
+
+func (s *Service) testSportarrConnection(ctx context.Context, client domain.DownloadClient) error {
+	r := sportarr.New(sportarr.Config{
+		Hostname:      client.Host,
+		APIKey:        client.Settings.APIKey,
+		BasicAuth:     client.Settings.Auth.Enabled,
+		Username:      client.Settings.Auth.Username,
+		Password:      client.Settings.Auth.Password,
+		TLSSkipVerify: client.TLSSkipVerify,
+		Log:           s.log,
+	})
+
+	status, err := r.Test(ctx)
+	if err != nil {
+		return errors.Wrap(err, "sportarr: connection test failed: %v", client.Host)
+	}
+
+	// The native release/push route ships with 4.0.1024; older versions
+	// answer system/status fine but 404 the push, so fail the test early
+	// with an actionable message instead of failing on the first release.
+	if !status.SupportsNativeAPI() {
+		return errors.New("sportarr: version %s is too old, autobrr needs Sportarr %s or newer", status.Version, sportarr.MinimumVersion)
+	}
+
+	s.log.Debug().Str("version", status.Version).Msg("test client connection for Sportarr: success")
 
 	return nil
 }

--- a/internal/download_client/service.go
+++ b/internal/download_client/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/autobrr/autobrr/pkg/arr/radarr"
 	"github.com/autobrr/autobrr/pkg/arr/readarr"
 	"github.com/autobrr/autobrr/pkg/arr/sonarr"
+	"github.com/autobrr/autobrr/pkg/arr/sportarr"
 	"github.com/autobrr/autobrr/pkg/arr/whisparr"
 	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/autobrr/autobrr/pkg/nzbget"
@@ -141,6 +142,24 @@ func (s *Service) GetArrTags(ctx context.Context, id int32) ([]*domain.ArrTag, e
 		tags, err := arrClient.GetTags(ctx)
 		if err != nil {
 			s.log.Error().Err(err).Int32("client_id", id).Msg("could not get tags from whisparr")
+			return data, nil
+		}
+
+		for _, tag := range tags {
+			emt := &domain.ArrTag{
+				ID:    tag.ID,
+				Label: tag.Label,
+			}
+			data = append(data, emt)
+		}
+
+		return data, nil
+
+	case domain.DownloadClientTypeSportarr:
+		arrClient := client.Client.(*sportarr.Client)
+		tags, err := arrClient.GetTags(ctx)
+		if err != nil {
+			s.log.Error().Err(err).Int32("client_id", id).Msg("could not get tags from sportarr")
 			return data, nil
 		}
 
@@ -454,6 +473,17 @@ func (s *Service) GetClient(ctx context.Context, clientId int32) (*domain.Downlo
 			APIKey:        client.Settings.APIKey,
 			Version:       whisparrVersion(client.Type),
 			Log:           s.log.With().Str("type", "Whisparr").Str("client", client.Name).Logger(),
+			BasicAuth:     client.Settings.Auth.Enabled,
+			Username:      client.Settings.Auth.Username,
+			Password:      client.Settings.Auth.Password,
+			TLSSkipVerify: client.TLSSkipVerify,
+		})
+
+	case domain.DownloadClientTypeSportarr:
+		client.Client = sportarr.New(sportarr.Config{
+			Hostname:      client.Host,
+			APIKey:        client.Settings.APIKey,
+			Log:           s.log.With().Str("type", "Sportarr").Str("client", client.Name).Logger(),
 			BasicAuth:     client.Settings.Auth.Enabled,
 			Username:      client.Settings.Auth.Username,
 			Password:      client.Settings.Auth.Password,

--- a/internal/list/process_arr_sportarr.go
+++ b/internal/list/process_arr_sportarr.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package list
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/autobrr/autobrr/pkg/arr"
+	"github.com/autobrr/autobrr/pkg/arr/sportarr"
+	"github.com/autobrr/autobrr/pkg/errors"
+
+	"github.com/rs/zerolog"
+)
+
+func (s *Service) sportarr(ctx context.Context, list *domain.List) error {
+	l := s.log.With().Str("list", list.Name).Str("type", "sportarr").Int("client", list.ClientID).Logger()
+
+	l.Debug().Msg("gathering titles")
+
+	titles, err := s.processSportarr(ctx, list, &l)
+	if err != nil {
+		return err
+	}
+
+	l.Debug().Int("count", len(titles)).Msg("got filter titles")
+
+	if len(titles) == 0 {
+		l.Debug().Str("list", list.Name).Msg("no titles found to update")
+		return nil
+	}
+
+	joinedTitles := strings.Join(titles, ",")
+
+	l.Trace().Str("titles", joinedTitles).Int("count", len(titles)).Msg("found titles")
+
+	filterUpdate := domain.FilterUpdate{Shows: &joinedTitles}
+
+	if list.MatchRelease {
+		filterUpdate.Shows = &nullString
+		filterUpdate.MatchReleases = &joinedTitles
+	}
+
+	for _, filter := range list.Filters {
+		l.Debug().Int("filter_id", filter.ID).Msg("updating filter")
+
+		filterUpdate.ID = filter.ID
+
+		if err := s.filterSvc.UpdatePartial(ctx, filterUpdate); err != nil {
+			return errors.Wrap(err, "error updating filter: %v", filter.ID)
+		}
+
+		l.Debug().Int("filter_id", filter.ID).Msg("successfully updated filter")
+	}
+
+	return nil
+}
+
+func (s *Service) processSportarr(ctx context.Context, list *domain.List, logger *zerolog.Logger) ([]string, error) {
+	downloadClient, err := s.downloadClientSvc.GetClient(ctx, int32(list.ClientID))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get client with id %d", list.ClientID)
+	}
+
+	if !downloadClient.Enabled {
+		return nil, errors.New("client %s %s not enabled", downloadClient.Type, downloadClient.Name)
+	}
+
+	client, ok := downloadClient.Client.(*sportarr.Client)
+	if !ok {
+		return nil, errors.New("client %s %s is not a sportarr client", downloadClient.Type, downloadClient.Name)
+	}
+
+	var tags []*arr.Tag
+	if len(list.TagsExclude) > 0 || len(list.TagsInclude) > 0 {
+		t, err := client.GetTags(ctx)
+		if err != nil {
+			logger.Debug().Msg("could not get tags")
+		}
+		tags = t
+	}
+
+	leagues, err := client.GetAllLeagues(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debug().Int("count", len(leagues)).Msg("found leagues to process")
+
+	titleSet := make(map[string]struct{})
+	var processedTitles int
+
+	for _, league := range leagues {
+		if !list.ShouldProcessItem(league.Monitored) {
+			continue
+		}
+
+		if len(list.TagsInclude) > 0 {
+			if len(league.Tags) == 0 {
+				continue
+			}
+			if !containsTag(tags, league.Tags, list.TagsInclude) {
+				continue
+			}
+		}
+
+		if len(list.TagsExclude) > 0 {
+			if containsTag(tags, league.Tags, list.TagsExclude) {
+				continue
+			}
+		}
+
+		processedTitles++
+
+		titles := processTitle(league.Name, list.MatchRelease)
+		for _, title := range titles {
+			titleSet[title] = struct{}{}
+		}
+	}
+
+	uniqueTitles := make([]string, 0, len(titleSet))
+	for title := range titleSet {
+		uniqueTitles = append(uniqueTitles, title)
+	}
+
+	sort.Strings(uniqueTitles)
+	logger.Debug().Int("total", len(leagues)).Int("processed", processedTitles).Int("created", len(uniqueTitles)).Msg("processed items")
+
+	return uniqueTitles, nil
+}

--- a/internal/list/service.go
+++ b/internal/list/service.go
@@ -236,6 +236,9 @@ func (s *Service) refreshList(ctx context.Context, listItem *domain.List) error 
 	case domain.ListTypeLidarr:
 		err = s.lidarr(ctx, listItem)
 
+	case domain.ListTypeSportarr:
+		err = s.sportarr(ctx, listItem)
+
 	case domain.ListTypeMDBList:
 		err = s.mdblist(ctx, listItem)
 

--- a/pkg/arr/sportarr/client.go
+++ b/pkg/arr/sportarr/client.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sportarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/autobrr/autobrr/pkg/errors"
+	"github.com/autobrr/autobrr/pkg/sharedhttp"
+)
+
+func (c *Client) get(ctx context.Context, endpoint string) (int, []byte, error) {
+	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
+	u.Path = path.Join(u.Path, "/api/", endpoint)
+	reqUrl := u.String()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl, http.NoBody)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not build request")
+	}
+
+	if c.config.BasicAuth {
+		req.SetBasicAuth(c.config.Username, c.config.Password)
+	}
+
+	c.setHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "sportarr.http.Do(req): %+v", req)
+	}
+
+	defer sharedhttp.DrainAndClose(resp)
+
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
+
+	var buf bytes.Buffer
+	if _, err = io.Copy(&buf, resp.Body); err != nil {
+		return resp.StatusCode, nil, errors.Wrap(err, "sportarr.io.Copy")
+	}
+
+	return resp.StatusCode, buf.Bytes(), nil
+}
+
+func (c *Client) getJSON(ctx context.Context, endpoint string, params url.Values, data any) error {
+	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
+	u.Path = path.Join(u.Path, "/api/", endpoint)
+	reqUrl := u.String()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl, http.NoBody)
+	if err != nil {
+		return errors.Wrap(err, "could not build request")
+	}
+
+	if c.config.BasicAuth {
+		req.SetBasicAuth(c.config.Username, c.config.Password)
+	}
+
+	c.setHeaders(req)
+
+	req.URL.RawQuery = params.Encode()
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "sportarr.http.Do(req): %+v", req)
+	}
+
+	defer sharedhttp.DrainAndClose(resp)
+
+	if resp.Body == nil {
+		return errors.New("response body is nil")
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return errors.New("unauthorized: bad credentials")
+	} else if resp.StatusCode != http.StatusOK {
+		return errors.New("sportarr: bad request: %s (status: %s)", endpoint, resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return errors.Wrap(err, "could not unmarshal data")
+	}
+
+	return nil
+}
+
+func (c *Client) postBody(ctx context.Context, endpoint string, data any) (int, []byte, error) {
+	u, err := url.Parse(c.config.Hostname)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not parse url: %s", c.config.Hostname)
+	}
+
+	u.Path = path.Join(u.Path, "/api/", endpoint)
+	reqUrl := u.String()
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not marshal data: %+v", data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqUrl, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "could not build request")
+	}
+
+	if c.config.BasicAuth {
+		req.SetBasicAuth(c.config.Username, c.config.Password)
+	}
+
+	c.setHeaders(req)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, errors.Wrap(err, "sportarr.http.Do(req): %+v", req)
+	}
+
+	defer sharedhttp.DrainAndClose(resp)
+
+	if resp.Body == nil {
+		return resp.StatusCode, nil, errors.New("response body is nil")
+	}
+
+	var buf bytes.Buffer
+	if _, err = io.Copy(&buf, resp.Body); err != nil {
+		return resp.StatusCode, nil, errors.Wrap(err, "sportarr.io.Copy")
+	}
+
+	if resp.StatusCode == http.StatusBadRequest {
+		return resp.StatusCode, buf.Bytes(), nil
+	} else if resp.StatusCode < 200 || resp.StatusCode > 401 {
+		return resp.StatusCode, buf.Bytes(), errors.New("sportarr: bad request: %v (status: %s): %s", resp.Request.RequestURI, resp.Status, buf.String())
+	}
+
+	return resp.StatusCode, buf.Bytes(), nil
+}
+
+func (c *Client) setHeaders(req *http.Request) {
+	if req.Body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	req.Header.Set("User-Agent", "autobrr")
+
+	req.Header.Set("X-Api-Key", c.config.APIKey)
+}

--- a/pkg/arr/sportarr/sportarr.go
+++ b/pkg/arr/sportarr/sportarr.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/autobrr/autobrr/pkg/arr"
 	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/autobrr/autobrr/pkg/sharedhttp"
 
+	goversion "github.com/hashicorp/go-version"
 	"github.com/rs/zerolog"
 )
 
@@ -157,49 +157,15 @@ func (c *Client) GetTags(ctx context.Context) ([]*arr.Tag, error) {
 // application API this client talks to (/api/release/push).
 const MinimumVersion = "4.0.1024"
 
+var minimumVersion = goversion.Must(goversion.NewVersion(MinimumVersion))
+
 // SupportsNativeAPI reports whether the version from system/status is at
 // least MinimumVersion. Unparseable versions return false.
 func (r SystemStatusResponse) SupportsNativeAPI() bool {
-	return compareVersions(r.Version, MinimumVersion) >= 0
-}
-
-// compareVersions compares dotted numeric versions segment by segment,
-// treating missing or non-numeric segments as 0.
-func compareVersions(a, b string) int {
-	as := strings.Split(a, ".")
-	bs := strings.Split(b, ".")
-
-	segments := len(as)
-	if len(bs) > segments {
-		segments = len(bs)
+	v, err := goversion.NewVersion(r.Version)
+	if err != nil {
+		return false
 	}
 
-	for i := 0; i < segments; i++ {
-		av, bv := 0, 0
-		if i < len(as) {
-			av = atoiSafe(as[i])
-		}
-		if i < len(bs) {
-			bv = atoiSafe(bs[i])
-		}
-		if av != bv {
-			if av > bv {
-				return 1
-			}
-			return -1
-		}
-	}
-
-	return 0
-}
-
-func atoiSafe(s string) int {
-	v := 0
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return v
-		}
-		v = v*10 + int(r-'0')
-	}
-	return v
+	return v.GreaterThanOrEqual(minimumVersion)
 }

--- a/pkg/arr/sportarr/sportarr.go
+++ b/pkg/arr/sportarr/sportarr.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sportarr
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/autobrr/autobrr/pkg/arr"
+	"github.com/autobrr/autobrr/pkg/errors"
+	"github.com/autobrr/autobrr/pkg/sharedhttp"
+
+	"github.com/rs/zerolog"
+)
+
+type Config struct {
+	Hostname string
+	APIKey   string
+
+	// basic auth username and password
+	BasicAuth bool
+	Username  string
+	Password  string
+
+	TLSSkipVerify bool
+
+	Log zerolog.Logger
+}
+
+type ClientInterface interface {
+	Test(ctx context.Context) (*SystemStatusResponse, error)
+	Push(ctx context.Context, release ReleasePushRequest) ([]string, error)
+}
+
+type Client struct {
+	config Config
+	http   *http.Client
+
+	log zerolog.Logger
+}
+
+// New create new sportarr Client
+func New(config Config) *Client {
+	transport := sharedhttp.Transport
+	if config.TLSSkipVerify {
+		transport = sharedhttp.TransportTLSInsecure
+	}
+
+	httpClient := &http.Client{
+		Timeout:   time.Second * 120,
+		Transport: transport,
+	}
+
+	return &Client{
+		config: config,
+		http:   httpClient,
+		log:    config.Log,
+	}
+}
+
+// logger prefers the request-scoped logger from ctx, which carries trace_id
+// and other correlation fields, over the static client logger.
+func (c *Client) logger(ctx context.Context) *zerolog.Logger {
+	if l := zerolog.Ctx(ctx); l.GetLevel() != zerolog.Disabled {
+		return l
+	}
+	return &c.log
+}
+
+func (c *Client) Test(ctx context.Context) (*SystemStatusResponse, error) {
+	status, res, err := c.get(ctx, "system/status")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not make Test")
+	}
+
+	if status == http.StatusUnauthorized {
+		return nil, errors.New("unauthorized: bad credentials")
+	}
+
+	c.logger(ctx).Trace().Int("status", status).Str("response", string(res)).Msg("sportarr system/status response")
+
+	response := SystemStatusResponse{}
+	if err = json.Unmarshal(res, &response); err != nil {
+		return nil, errors.Wrap(err, "could not unmarshal data")
+	}
+
+	return &response, nil
+}
+
+func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string, error) {
+	status, res, err := c.postBody(ctx, "release/push", release)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not push release to sportarr")
+	}
+
+	c.logger(ctx).Trace().Int("status", status).Str("response", string(res)).Msg("sportarr release/push response")
+
+	if status == http.StatusBadRequest {
+		badRequestResponses := make([]*BadRequestResponse, 0)
+
+		if err = json.Unmarshal(res, &badRequestResponses); err != nil {
+			return nil, errors.Wrap(err, "could not unmarshal data")
+		}
+
+		rejections := []string{}
+		for _, response := range badRequestResponses {
+			rejections = append(rejections, response.String())
+		}
+
+		return rejections, nil
+	}
+
+	pushResponse := make([]ReleasePushResponse, 0)
+	if err = json.Unmarshal(res, &pushResponse); err != nil {
+		return nil, errors.Wrap(err, "could not unmarshal data")
+	}
+
+	if len(pushResponse) == 0 {
+		return nil, errors.New("sportarr release/push returned an empty response")
+	}
+
+	// log and return if rejected
+	if pushResponse[0].Rejected {
+		c.logger(ctx).Debug().Strs("rejections", pushResponse[0].Rejections).Msg("sportarr release/push rejected")
+		return pushResponse[0].Rejections, nil
+	}
+
+	// successful push
+	return nil, nil
+}
+
+func (c *Client) GetAllLeagues(ctx context.Context) ([]League, error) {
+	data := make([]League, 0)
+	err := c.getJSON(ctx, "leagues", nil, &data)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get leagues")
+	}
+
+	return data, nil
+}
+
+func (c *Client) GetTags(ctx context.Context) ([]*arr.Tag, error) {
+	data := make([]*arr.Tag, 0)
+	err := c.getJSON(ctx, "tag", nil, &data)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get tags")
+	}
+
+	return data, nil
+}
+
+// MinimumVersion is the first Sportarr release that serves the native
+// application API this client talks to (/api/release/push).
+const MinimumVersion = "4.0.1024"
+
+// SupportsNativeAPI reports whether the version from system/status is at
+// least MinimumVersion. Unparseable versions return false.
+func (r SystemStatusResponse) SupportsNativeAPI() bool {
+	return compareVersions(r.Version, MinimumVersion) >= 0
+}
+
+// compareVersions compares dotted numeric versions segment by segment,
+// treating missing or non-numeric segments as 0.
+func compareVersions(a, b string) int {
+	as := strings.Split(a, ".")
+	bs := strings.Split(b, ".")
+
+	segments := len(as)
+	if len(bs) > segments {
+		segments = len(bs)
+	}
+
+	for i := 0; i < segments; i++ {
+		av, bv := 0, 0
+		if i < len(as) {
+			av = atoiSafe(as[i])
+		}
+		if i < len(bs) {
+			bv = atoiSafe(bs[i])
+		}
+		if av != bv {
+			if av > bv {
+				return 1
+			}
+			return -1
+		}
+	}
+
+	return 0
+}
+
+func atoiSafe(s string) int {
+	v := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return v
+		}
+		v = v*10 + int(r-'0')
+	}
+	return v
+}

--- a/pkg/arr/sportarr/sportarr_test.go
+++ b/pkg/arr/sportarr/sportarr_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build integration
+
+package sportarr
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_client_Push(t *testing.T) {
+	// disable logger
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	log.SetOutput(io.Discard)
+
+	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	key := "mock-key"
+
+	mux.HandleFunc("/api/release/push", func(w http.ResponseWriter, r *http.Request) {
+		// request validation logic
+		apiKey := r.Header.Get("X-Api-Key")
+		if apiKey != "" {
+			if apiKey != key {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write(nil)
+				return
+			}
+		}
+
+		// read json response
+		jsonPayload, _ := os.ReadFile("testdata/release_push_response.json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonPayload)
+	})
+
+	type fields struct {
+		config Config
+	}
+	type args struct {
+		release ReleasePushRequest
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		rejections []string
+		err        error
+		wantErr    bool
+	}{
+		{
+			name: "push",
+			fields: fields{
+				config: Config{
+					Hostname:  ts.URL,
+					APIKey:    "",
+					BasicAuth: false,
+					Username:  "",
+					Password:  "",
+				},
+			},
+			args: args{release: ReleasePushRequest{
+				Title:            "Formula.1.2026x10.Belgium.Race.SkyF1HD.1080p",
+				DownloadUrl:      "https://www.test.org/rss/download/0000001/00000000000000000000/Formula.1.2026x10.Belgium.Race.SkyF1HD.1080p.torrent",
+				Size:             0,
+				Indexer:          "test",
+				DownloadProtocol: "torrent",
+				Protocol:         "torrent",
+				PublishDate:      "2026-07-19T15:00:00Z",
+			}},
+			rejections: []string{"No matching event found"},
+		},
+		{
+			name: "push_error",
+			fields: fields{
+				config: Config{
+					Hostname:  ts.URL,
+					APIKey:    key,
+					BasicAuth: false,
+					Username:  "",
+					Password:  "",
+				},
+			},
+			args: args{release: ReleasePushRequest{
+				Title:            "Formula.1.2026x10.Belgium.Race.SkyF1HD.1080p",
+				DownloadUrl:      "https://www.test.org/rss/download/0000001/00000000000000000000/Formula.1.2026x10.Belgium.Race.SkyF1HD.1080p.torrent",
+				Size:             0,
+				Indexer:          "test",
+				DownloadProtocol: "torrent",
+				Protocol:         "torrent",
+				PublishDate:      "2026-07-19T15:00:00Z",
+			}},
+			rejections: []string{"No matching event found"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New(tt.fields.config)
+
+			rejections, err := c.Push(context.Background(), tt.args.release)
+			assert.Equal(t, tt.rejections, rejections)
+			if tt.wantErr && assert.Error(t, err) {
+				assert.Equal(t, tt.err, err)
+			}
+		})
+	}
+}
+
+func Test_client_Test(t *testing.T) {
+	// disable logger
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	log.SetOutput(io.Discard)
+
+	key := "mock-key"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKey := r.Header.Get("X-Api-Key")
+		if apiKey != "" {
+			if apiKey != key {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write(nil)
+				return
+			}
+		}
+		jsonPayload, _ := os.ReadFile("testdata/system_status_response.json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonPayload)
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name        string
+		cfg         Config
+		want        *SystemStatusResponse
+		expectedErr string
+		wantErr     bool
+	}{
+		{
+			name: "fetch",
+			cfg: Config{
+				Hostname:  srv.URL,
+				APIKey:    key,
+				BasicAuth: false,
+				Username:  "",
+				Password:  "",
+			},
+			want:        &SystemStatusResponse{Version: "4.0.1024.1104"},
+			expectedErr: "",
+			wantErr:     false,
+		},
+		{
+			name: "fetch_unauthorized",
+			cfg: Config{
+				Hostname:  srv.URL,
+				APIKey:    "bad-mock-key",
+				BasicAuth: false,
+				Username:  "",
+				Password:  "",
+			},
+			want:        nil,
+			expectedErr: "unauthorized: bad credentials",
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New(tt.cfg)
+
+			got, err := c.Test(context.Background())
+			if tt.wantErr && assert.Error(t, err) {
+				assert.EqualErrorf(t, err, tt.expectedErr, "Error should be: %v, got: %v", tt.expectedErr, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_SystemStatusResponse_SupportsNativeAPI(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{version: "4.0.1024.1104", want: true},
+		{version: "4.1.0", want: true},
+		{version: "5.0.0", want: true},
+		{version: "4.0.1024", want: true},
+		{version: "4.0.1023.1103", want: false},
+		{version: "4.0.999", want: false},
+		{version: "", want: false},
+		{version: "garbage", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			r := SystemStatusResponse{Version: tt.version}
+			assert.Equal(t, tt.want, r.SupportsNativeAPI())
+		})
+	}
+}

--- a/pkg/arr/sportarr/testdata/release_push_response.json
+++ b/pkg/arr/sportarr/testdata/release_push_response.json
@@ -1,0 +1,18 @@
+[
+  {
+    "title": "Formula.1.2026x10.Belgium.Race.SkyF1HD.1080p",
+    "infoUrl": null,
+    "downloadUrl": "https://www.test.org/rss/download/0000001/00000000000000000000/Formula.1.2026x10.Belgium.Race.SkyF1HD.1080p.torrent",
+    "size": 0,
+    "indexer": "test",
+    "downloadProtocol": "torrent",
+    "protocol": "torrent",
+    "publishDate": "2026-07-19T15:00:00.0000000Z",
+    "approved": false,
+    "rejected": true,
+    "temporarilyRejected": false,
+    "rejections": [
+      "No matching event found"
+    ]
+  }
+]

--- a/pkg/arr/sportarr/testdata/system_status_response.json
+++ b/pkg/arr/sportarr/testdata/system_status_response.json
@@ -1,0 +1,4 @@
+{
+  "version": "4.0.1024.1104",
+  "appName": "Sportarr"
+}

--- a/pkg/arr/sportarr/types.go
+++ b/pkg/arr/sportarr/types.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sportarr
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ReleasePushRequest struct {
+	Title            string `json:"title"`
+	InfoUrl          string `json:"infoUrl,omitempty"`
+	DownloadUrl      string `json:"downloadUrl,omitempty"`
+	MagnetUrl        string `json:"magnetUrl,omitempty"`
+	Size             uint64 `json:"size"`
+	Indexer          string `json:"indexer"`
+	DownloadProtocol string `json:"downloadProtocol"`
+	Protocol         string `json:"protocol"`
+	PublishDate      string `json:"publishDate"`
+	IndexerFlags     int    `json:"indexerFlags,omitempty"`
+}
+
+type ReleasePushResponse struct {
+	Approved     bool     `json:"approved"`
+	Rejected     bool     `json:"rejected"`
+	TempRejected bool     `json:"temporarilyRejected"`
+	Rejections   []string `json:"rejections"`
+}
+
+type BadRequestResponse struct {
+	PropertyName   string `json:"propertyName"`
+	ErrorMessage   string `json:"errorMessage"`
+	ErrorCode      string `json:"errorCode"`
+	AttemptedValue string `json:"attemptedValue"`
+	Severity       string `json:"severity"`
+}
+
+func (r *BadRequestResponse) String() string {
+	return fmt.Sprintf("[%s: %s] %s: %s - got value: %s", r.Severity, r.ErrorCode, r.PropertyName, r.ErrorMessage, r.AttemptedValue)
+}
+
+type SystemStatusResponse struct {
+	Version string `json:"version"`
+}
+
+// League is a Sportarr library entry, the equivalent of a Sonarr series:
+// events (games, races, cards) belong to a league the way episodes belong
+// to a series.
+type League struct {
+	ID        int64  `json:"id"`
+	Name      string `json:"name,omitempty"`
+	Sport     string `json:"sport,omitempty"`
+	Monitored bool   `json:"monitored"`
+	Tags      []int  `json:"tags,omitempty"`
+}
+
+type IndexerFlags int
+
+const (
+	IndexerFlagFreeleech    IndexerFlags = 1
+	IndexerFlagHalfleech    IndexerFlags = 2
+	IndexerFlagDoubleUpload IndexerFlags = 4
+	IndexerFlagInternal     IndexerFlags = 8
+	IndexerFlagScene        IndexerFlags = 16
+	IndexerFlagFreeleech75  IndexerFlags = 32
+	IndexerFlagFreeleech25  IndexerFlags = 64
+	IndexerFlagNuked        IndexerFlags = 128
+	IndexerFlagSubtitles    IndexerFlags = 256
+)
+
+type ReleaseMeta struct {
+	FreeleechPercent int
+	Origin           string // "scene" or "internal"
+	Nuked            bool
+	HasSubtitles     bool
+	DoubleUpload     bool
+}
+
+// BuildIndexerFlags maps release metadata onto the flag bitmask Sportarr's
+// release/push endpoint understands (the same mask Sonarr uses).
+func BuildIndexerFlags(m ReleaseMeta) IndexerFlags {
+	var flags IndexerFlags
+	switch m.FreeleechPercent {
+	case 100:
+		flags |= IndexerFlagFreeleech
+	case 75:
+		flags |= IndexerFlagFreeleech75
+	case 50:
+		flags |= IndexerFlagHalfleech
+	case 25:
+		flags |= IndexerFlagFreeleech25
+	}
+	switch strings.ToLower(strings.TrimSpace(m.Origin)) {
+	case "internal":
+		flags |= IndexerFlagInternal
+	case "scene":
+		flags |= IndexerFlagScene
+	}
+	if m.Nuked {
+		flags |= IndexerFlagNuked
+	}
+	if m.HasSubtitles {
+		flags |= IndexerFlagSubtitles
+	}
+	if m.DoubleUpload {
+		flags |= IndexerFlagDoubleUpload
+	}
+	return flags
+}

--- a/web/src/domain/constants.ts
+++ b/web/src/domain/constants.ts
@@ -331,6 +331,11 @@ export const DownloadClientTypeOptions: RadioFieldsetOption[] = [
     value: "READARR"
   },
   {
+    label: "Sportarr",
+    description: "Send to Sportarr and let it decide",
+    value: "SPORTARR"
+  },
+  {
     label: "SABnzbd",
     description: "Add nzbs directly to SABnzbd",
     value: "SABNZBD",
@@ -411,6 +416,11 @@ export const getDownloadClientTypeOptions = (t: TFunction): RadioFieldsetOption[
     value: "READARR"
   },
   {
+    label: t("options:downloadClient.SPORTARR.label"),
+    description: t("options:downloadClient.SPORTARR.description"),
+    value: "SPORTARR"
+  },
+  {
     label: t("options:downloadClient.SABNZBD.label"),
     description: t("options:downloadClient.SABNZBD.description"),
     value: "SABNZBD",
@@ -442,6 +452,7 @@ export const ActionTypeOptions: RadioFieldsetOption[] = [
   { label: "Whisparr (v2)", description: "Send to Whisparr and let it decide", value: "WHISPARR" },
   { label: "Whisparr (v3)", description: "Send to Whisparr and let it decide", value: "WHISPARR_V3" },
   { label: "Readarr", description: "Send to Readarr and let it decide", value: "READARR" },
+  { label: "Sportarr", description: "Send to Sportarr and let it decide", value: "SPORTARR" },
   { label: "SABnzbd", description: "Add to SABnzbd", value: "SABNZBD" },
   { label: "NZBGet", description: "Add to NZBGet", value: "NZBGET" }
 ];
@@ -464,6 +475,7 @@ export const getActionTypeOptions = (t: TFunction): RadioFieldsetOption[] => [
   { label: t("options:actionType.WHISPARR.label"), description: t("options:actionType.WHISPARR.description"), value: "WHISPARR" },
   { label: t("options:actionType.WHISPARR_V3.label"), description: t("options:actionType.WHISPARR_V3.description"), value: "WHISPARR_V3" },
   { label: t("options:actionType.READARR.label"), description: t("options:actionType.READARR.description"), value: "READARR" },
+  { label: t("options:actionType.SPORTARR.label"), description: t("options:actionType.SPORTARR.description"), value: "SPORTARR" },
   { label: t("options:actionType.SABNZBD.label"), description: t("options:actionType.SABNZBD.description"), value: "SABNZBD" },
   { label: t("options:actionType.NZBGET.label"), description: t("options:actionType.NZBGET.description"), value: "NZBGET" }
 ];
@@ -486,6 +498,7 @@ export const ActionTypeNameMap: Record<ActionType, string> = {
   "WHISPARR": "Whisparr (v2)",
   "WHISPARR_V3": "Whisparr (v3)",
   "READARR": "Readarr",
+  "SPORTARR": "Sportarr",
   "SABNZBD": "SABnzbd",
   "NZBGET": "NZBGet"
 } as const;
@@ -508,6 +521,7 @@ export const getActionTypeNameMap = (t: TFunction): Record<ActionType, string> =
   "WHISPARR": t("options:actionType.WHISPARR.label"),
   "WHISPARR_V3": t("options:actionType.WHISPARR_V3.label"),
   "READARR": t("options:actionType.READARR.label"),
+  "SPORTARR": t("options:actionType.SPORTARR.label"),
   "SABNZBD": t("options:actionType.SABNZBD.label"),
   "NZBGET": t("options:actionType.NZBGET.label")
 });
@@ -526,6 +540,7 @@ export const DOWNLOAD_CLIENTS = [
   "WHISPARR",
   "WHISPARR_V3",
   "READARR",
+  "SPORTARR",
   "SABNZBD",
   "NZBGET"
 ];
@@ -609,6 +624,10 @@ export const ListTypeOptions: OptionBasicTyped<ListType>[] = [
     value: "WHISPARR_V3"
   },
   {
+    label: "Sportarr",
+    value: "SPORTARR"
+  },
+  {
     label: "MDBList",
     value: "MDBLIST"
   },
@@ -639,6 +658,7 @@ export const ListTypeNameMap: Record<ListType, string> = {
   "RADARR": "Radarr",
   "LIDARR": "Lidarr",
   "READARR": "Readarr",
+  "SPORTARR": "Sportarr",
   "WHISPARR": "Whisparr (v2)",
   "WHISPARR_V3": "Whisparr (v3)",
   "MDBLIST": "MDBList",

--- a/web/src/forms/settings/DownloadClientForms.tsx
+++ b/web/src/forms/settings/DownloadClientForms.tsx
@@ -492,6 +492,7 @@ export const componentMap: componentMapType = {
   WHISPARR: <FormFieldsArr />,
   WHISPARR_V3: <FormFieldsArr />,
   READARR: <FormFieldsArr />,
+  SPORTARR: <FormFieldsArr />,
   SABNZBD: <FormFieldsSabnzbd />,
   NZBGET: <FormFieldsNzbget />
 };
@@ -679,6 +680,7 @@ export const rulesComponentMap: componentMapType = {
   WHISPARR: <FormFieldsRulesArr />,
   WHISPARR_V3: <FormFieldsRulesArr />,
   READARR: <FormFieldsRulesArr />,
+  SPORTARR: <FormFieldsRulesArr />,
 };
 
 interface formButtonsProps {

--- a/web/src/forms/settings/ListForms.tsx
+++ b/web/src/forms/settings/ListForms.tsx
@@ -515,6 +515,8 @@ const ListTypeForm = (props: ListTypeFormProps) => {
     case "WHISPARR":
     case "WHISPARR_V3":
       return <ListTypeArr {...props} />;
+    case "SPORTARR":
+      return <ListTypeArr {...props} />;
     case "TRAKT":
       return <ListTypeTrakt />;
     case "STEAM":
@@ -548,6 +550,7 @@ const FilterOptionCheckBoxes = (props: ListTypeFormProps) => {
     case "LIDARR":
     case "WHISPARR":
     case "READARR":
+    case "SPORTARR":
       return (
         <fieldset>
           <legend className="sr-only">{t("forms.list.settingsLegend")}</legend>
@@ -598,7 +601,7 @@ function ListTypeArr({ listType, clients }: ListTypeFormProps) {
         clientType={listType}
       />
 
-      {values.client_id > 0 && (values.type === "RADARR" || values.type === "SONARR" || values.type === "WHISPARR" || values.type === "WHISPARR_V3") && (
+      {values.client_id > 0 && (values.type === "RADARR" || values.type === "SONARR" || values.type === "WHISPARR" || values.type === "WHISPARR_V3" || values.type === "SPORTARR") && (
         <>
           <ListArrTagsMultiSelectField name="tags_included" label={t("forms.list.tagsIncluded")} options={arrTagsQuery.data?.map(f => ({
             value: f.label,

--- a/web/src/i18n/locales/en/options.json
+++ b/web/src/i18n/locales/en/options.json
@@ -59,6 +59,10 @@
       "label": "Readarr",
       "description": "Send to Readarr and let it decide"
     },
+    "SPORTARR": {
+      "label": "Sportarr",
+      "description": "Send to Sportarr and let it decide"
+    },
     "SABNZBD": {
       "label": "SABnzbd",
       "description": "Add nzbs directly to SABnzbd"
@@ -136,6 +140,10 @@
     "READARR": {
       "label": "Readarr",
       "description": "Send to Readarr and let it decide"
+    },
+    "SPORTARR": {
+      "label": "Sportarr",
+      "description": "Send to Sportarr and let it decide"
     },
     "SABNZBD": {
       "label": "SABnzbd",

--- a/web/src/i18n/locales/en/settings.json
+++ b/web/src/i18n/locales/en/settings.json
@@ -435,7 +435,7 @@
       "settingsLegend": "Settings",
       "source": "Source",
       "sourceList": "Source list",
-      "arrSourceDescription": "Update filters from titles in Radarr, Sonarr, Lidarr, Readarr, or Whisparr.",
+      "arrSourceDescription": "Update filters from titles in Radarr, Sonarr, Lidarr, Readarr, Whisparr, or Sportarr.",
       "traktSourceDescription": "Use a Trakt list or one of the default autobrr hosted lists.",
       "anilistSourceDescription": "Use an AniList list from one of the default autobrr hosted lists.",
       "plaintextSourceDescription": "Use a plain text list with one item per line.",

--- a/web/src/screens/filters/sections/Actions.tsx
+++ b/web/src/screens/filters/sections/Actions.tsx
@@ -174,6 +174,7 @@ const TypeForm = (props: ClientActionProps) => {
   case "WHISPARR":
   case "WHISPARR_V3":
   case "READARR":
+  case "SPORTARR":
     return <Arr {...props} />;
   // nzb
   case "SABNZBD":

--- a/web/src/types/Download.d.ts
+++ b/web/src/types/Download.d.ts
@@ -17,6 +17,7 @@ type DownloadClientType =
   "WHISPARR" |
   "WHISPARR_V3" |
   "READARR" |
+  "SPORTARR" |
   "SABNZBD" |
   "NZBGET";
 

--- a/web/src/types/List.d.ts
+++ b/web/src/types/List.d.ts
@@ -53,6 +53,7 @@ type ListType =
   | "READARR"
   | "WHISPARR"
   | "WHISPARR_V3"
+  | "SPORTARR"
   | "MDBLIST"
   | "TRAKT"
   | "METACRITIC"


### PR DESCRIPTION
# Description

Adds Sportarr (https://github.com/Sportarr/Sportarr) as a download client, filter action, and list source, following the pattern of the other arr integrations. Sportarr is a sports PVR where leagues are the library items and events are the episodes, so lists build filter titles from monitored league names.

The client talks Sportarr's native application API (documented in the Sportarr repo under docs/APPLICATION_API.md): release/push for the grab decision engine, system/status for connection tests, and tag/leagues reads for list building. I maintain Sportarr, so the API side of this is versioned and supported on our end. The push route ships with Sportarr 4.0.1024, and the connection test checks the reported version and fails with an actionable message on older installs instead of failing on the first release.

Discussion: https://github.com/autobrr/autobrr/discussions/2302

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

* `go test ./...` passes, plus the package's integration-tagged tests (`go test ./pkg/arr/sportarr/... -tags=integration`)
* `pnpm --dir web lint` and `pnpm --dir web build` clean
* End to end against a real Sportarr instance through the autobrr binary: the download client test rejects Sportarr 4.0.1023 with the version message and passes on 4.0.1024, and a pushed release runs through Sportarr's decision engine with rejection reasons round-tripping back into autobrr

## Screenshots (for UI changes)

The new entries reuse the existing arr form components unchanged; happy to attach screenshots if wanted.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed

(No database schema changes.)

## AI disclosure

I used an AI coding assistant (Claude Code) to help draft the implementation and the tests. The design came from reading how your Sonarr and Whisparr integrations are structured and mirroring that exactly, so the Sportarr client, action, and list processor read as siblings of those. I reviewed everything, ran go fmt, the Go suite, and the web lint and build, and verified the whole flow end to end against a real Sportarr instance through the autobrr binary before opening this.