### PR TITLE
fix(ci): docs update trigger never fired on tag builds

### DIFF
--- a/.github/workflows/trigger_docs_update.yml
+++ b/.github/workflows/trigger_docs_update.yml
@@ -11,9 +11,11 @@ jobs:
   trigger_docs_update:
     runs-on: ubuntu-latest
     # only run if the 'build' workflow was successful and was triggered by a tag push
+    # (head_branch is the bare tag name for tag-triggered runs, e.g. "v1.83.0")
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'refs/tags/v')
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
     steps:
       - name: Trigger docs workflow
         run: |


### PR DESCRIPTION
# Description

The docs-update trigger never fired on tag builds. For tag builds, `workflow_run.head_branch` contains the bare tag name (for example `v1.83.0`), not `refs/tags/v*`. The old condition always evaluated false. The workflow skipped every run, and it never sent the repository_dispatch to autobrr.com. Changelog PRs were made manually with workflow_dispatch.

This PR corrects the condition. It also adds an `event == 'push'` guard. The guard stops PR branches that start with `v` from a match.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* I inspected the run history with the GitHub API. All runs of this workflow have the conclusion `skipped`.
* I inspected the tag build for `v1.81.0`. Its `head_branch` value is `v1.81.0`, so the new condition matches it.
* Full test: cut a release from a branch that contains this fix. Then make sure that this workflow runs, and that a release-notes PR appears in autobrr.com.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I ran `go fmt` and the test suite passes locally (N/A — no Go changes)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL (N/A)
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Was any AI used in this PR? Roughly how much of the code was AI-written, and what model/tool?

Yes. Claude Code (Fable 5) diagnosed the fault and wrote the full change, directed and reviewed by @s0up4200.
