### PR TITLE
fix(lists): error on update when list has never been refreshed

### DIFF
--- a/internal/database/list.go
+++ b/internal/database/list.go
@@ -81,9 +81,11 @@ func (r *ListRepo) List(ctx context.Context) ([]*domain.List, error) {
 		list.ClientID = clientID.V
 		list.URL = url.V
 		list.APIKey = apiKey.V
+
 		list.LastRefreshTime = lastRefreshTime.V
 		list.LastRefreshData = lastRefreshData.V
 		list.LastRefreshStatus = domain.ListRefreshStatus(lastRefreshStatus.V)
+
 		list.Filters = make([]domain.ListFilter, 0)
 
 		lists = append(lists, &list)
@@ -134,10 +136,11 @@ func (r *ListRepo) FindByID(ctx context.Context, listID int64) (*domain.List, er
 
 	var list domain.List
 
-	var url, apiKey sql.Null[string]
+	var url, apiKey, lastRefreshStatus, lastRefreshData sql.Null[string]
+	var lastRefreshTime sql.Null[time.Time]
 	var clientID sql.Null[int]
 
-	err = row.Scan(&list.ID, &list.Name, &list.Enabled, &list.Type, &clientID, &url, pq.Array(&list.Headers), &apiKey, &list.MatchRelease, pq.Array(&list.TagsInclude), pq.Array(&list.TagsExclude), &list.IncludeUnmonitored, &list.IncludeAlternateTitles, &list.IncludeYear, &list.SkipCleanSanitize, &list.LastRefreshTime, &list.LastRefreshStatus, &list.LastRefreshData, &list.CreatedAt, &list.UpdatedAt)
+	err = row.Scan(&list.ID, &list.Name, &list.Enabled, &list.Type, &clientID, &url, pq.Array(&list.Headers), &apiKey, &list.MatchRelease, pq.Array(&list.TagsInclude), pq.Array(&list.TagsExclude), &list.IncludeUnmonitored, &list.IncludeAlternateTitles, &list.IncludeYear, &list.SkipCleanSanitize, &lastRefreshTime, &lastRefreshStatus, &lastRefreshData, &list.CreatedAt, &list.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -145,6 +148,10 @@ func (r *ListRepo) FindByID(ctx context.Context, listID int64) (*domain.List, er
 	list.ClientID = clientID.V
 	list.URL = url.V
 	list.APIKey = apiKey.V
+
+	list.LastRefreshTime = lastRefreshTime.V
+	list.LastRefreshData = lastRefreshData.V
+	list.LastRefreshStatus = domain.ListRefreshStatus(lastRefreshStatus.V)
 
 	return &list, nil
 }

--- a/internal/database/list.go
+++ b/internal/database/list.go
@@ -465,3 +465,44 @@ func (r *ListRepo) GetListFilters(ctx context.Context, listID int64) ([]domain.L
 
 	return filters, nil
 }
+
+// GetAllListFilters returns the filters connected to each list, keyed by list id.
+func (r *ListRepo) GetAllListFilters(ctx context.Context) (map[int64][]domain.ListFilter, error) {
+	qb := r.db.squirrel.Select(
+		"lf.list_id",
+		"f.id",
+		"f.name",
+	).
+		From("list_filter lf").
+		Join(
+			"filter f ON f.id = lf.filter_id",
+		).
+		OrderBy(
+			"f.name ASC",
+		)
+
+	query, args, err := qb.ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := r.db.Handler.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	filters := make(map[int64][]domain.ListFilter)
+	for rows.Next() {
+		var listID int64
+		var filter domain.ListFilter
+		if err := rows.Scan(&listID, &filter.ID, &filter.Name); err != nil {
+			return nil, err
+		}
+
+		filters[listID] = append(filters[listID], filter)
+	}
+
+	return filters, nil
+}

--- a/internal/database/list.go
+++ b/internal/database/list.go
@@ -198,11 +198,6 @@ func (r *ListRepo) Store(ctx context.Context, list *domain.List) error {
 			list.SkipCleanSanitize,
 		).Suffix("RETURNING id").RunWith(tx)
 
-	//query, args, err := qb.ToSql()
-	//if err != nil {
-	//	return err
-	//}
-
 	if err := qb.QueryRowContext(ctx).Scan(&list.ID); err != nil {
 		return err
 	}
@@ -254,14 +249,6 @@ func (r *ListRepo) Update(ctx context.Context, list *domain.List) error {
 		return err
 	}
 
-	if err := r.StoreListFilterConnection(ctx, tx, list); err != nil {
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return errors.Wrap(err, "error updating filter actions")
-	}
-
 	rowsAffected, err := results.RowsAffected()
 	if err != nil {
 		return err
@@ -269,6 +256,14 @@ func (r *ListRepo) Update(ctx context.Context, list *domain.List) error {
 
 	if rowsAffected == 0 {
 		return domain.ErrUpdateFailed
+	}
+
+	if err := r.StoreListFilterConnection(ctx, tx, list); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "error updating list and filters")
 	}
 
 	return nil
@@ -345,7 +340,7 @@ func (r *ListRepo) Delete(ctx context.Context, listID int64) error {
 	}
 
 	if err := tx.Commit(); err != nil {
-		return errors.Wrap(err, "error storing list and filters")
+		return errors.Wrap(err, "error deleting list and filter connections")
 	}
 
 	return nil
@@ -379,10 +374,20 @@ func (r *ListRepo) ToggleEnabled(ctx context.Context, listID int64, enabled bool
 	return nil
 }
 
+// StoreListFilterConnection syncs the list_filter connections for the list to
+// list.Filters, deleting stale connections and inserting missing ones.
 func (r *ListRepo) StoreListFilterConnection(ctx context.Context, tx *Tx, list *domain.List) error {
-	qb := r.db.squirrel.Delete("list_filter").Where(sq.Eq{"list_id": list.ID})
+	filterIDs := make([]int, 0, len(list.Filters))
+	for _, filter := range list.Filters {
+		filterIDs = append(filterIDs, filter.ID)
+	}
 
-	query, args, err := qb.ToSql()
+	deleteQb := r.db.squirrel.Delete("list_filter").Where(sq.Eq{"list_id": list.ID})
+	if len(filterIDs) > 0 {
+		deleteQb = deleteQb.Where(sq.NotEq{"filter_id": filterIDs})
+	}
+
+	query, args, err := deleteQb.ToSql()
 	if err != nil {
 		return err
 	}
@@ -397,41 +402,25 @@ func (r *ListRepo) StoreListFilterConnection(ctx context.Context, tx *Tx, list *
 		return err
 	}
 
-	r.log.Trace().Int64("rows_affected", rowsAffected).Msg("deleted list filters")
+	r.log.Trace().Int64("rows_affected", rowsAffected).Msg("deleted stale list filter connections")
 
-	//if rowsAffected == 0 {
-	//	return domain.ErrUpdateFailed
-	//}
+	if len(filterIDs) == 0 {
+		return nil
+	}
 
-	for _, filter := range list.Filters {
-		qb := r.db.squirrel.Insert("list_filter").
-			Columns(
-				"list_id",
-				"filter_id",
-			).
-			Values(
-				list.ID,
-				filter.ID,
-			)
+	insertQb := r.db.squirrel.Insert("list_filter").Columns("list_id", "filter_id")
+	for _, filterID := range filterIDs {
+		insertQb = insertQb.Values(list.ID, filterID)
+	}
+	insertQb = insertQb.Suffix("ON CONFLICT DO NOTHING")
 
-		query, args, err := qb.ToSql()
-		if err != nil {
-			return err
-		}
+	query, args, err = insertQb.ToSql()
+	if err != nil {
+		return err
+	}
 
-		results, err := tx.ExecContext(ctx, query, args...)
-		if err != nil {
-			return err
-		}
-
-		rowsAffected, err := results.RowsAffected()
-		if err != nil {
-			return err
-		}
-
-		if rowsAffected == 0 {
-			return domain.ErrUpdateFailed
-		}
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/list/service.go
+++ b/internal/list/service.go
@@ -129,7 +129,12 @@ func (s *Service) Update(ctx context.Context, list *domain.List) error {
 
 	existingList, err := s.FindByID(ctx, list.ID)
 	if err != nil {
-		s.log.Error().Err(err).Int64("list_id", list.ID).Msg("could not find list by id")
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			s.log.Error().Err(err).Int64("list_id", list.ID).Msg("could not find list by id")
+		} else {
+			s.log.Error().Err(err).Int64("list_id", list.ID).Msg("could not get list by id")
+		}
+
 		return err
 	}
 

--- a/internal/list/service.go
+++ b/internal/list/service.go
@@ -25,6 +25,7 @@ type listRepo interface {
 	ToggleEnabled(ctx context.Context, listID int64, enabled bool) error
 	Delete(ctx context.Context, listID int64) error
 	GetListFilters(ctx context.Context, listID int64) ([]domain.ListFilter, error)
+	GetAllListFilters(ctx context.Context) (map[int64][]domain.ListFilter, error)
 }
 
 type clientService interface {
@@ -68,14 +69,15 @@ func (s *Service) List(ctx context.Context) ([]*domain.List, error) {
 		return nil, err
 	}
 
-	// attach filters
-	for _, list := range data {
-		filters, err := s.repo.GetListFilters(ctx, list.ID)
-		if err != nil {
-			return nil, err
-		}
+	filters, err := s.repo.GetAllListFilters(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-		list.Filters = filters
+	for _, list := range data {
+		if listFilters, ok := filters[list.ID]; ok {
+			list.Filters = listFilters
+		}
 	}
 
 	return data, nil


### PR DESCRIPTION
# Description

Editing a list that had never completed a refresh always failed. Reported on Discord, no GitHub issue.

`Service.Update` fetches the existing record via `FindByID` to restore the API key when the client sends the redacted placeholder. `ListRepo.FindByID` scanned the nullable `last_refresh_time`, `last_refresh_status`, and `last_refresh_data` columns directly into non-nullable Go types, so a list whose refresh columns were still NULL errored before the update ever ran:

```
sql: Scan error on column index 15, name "last_refresh_time": unsupported Scan, storing driver.Value type <nil> into type *time.Time
```

The same path broke manually refreshing a single never-run list (`RefreshList` also goes through `FindByID`). `List()` already handled these columns with `sql.Null` wrappers; `FindByID` now does the same. `Service.Update` also logs record-not-found and lookup failures distinctly.

While in the area, two refactors of the list persistence code (no functional change intended):

- `StoreListFilterConnection` now syncs the `list_filter` junction instead of wiping and reinserting every connection: stale rows are deleted, the new set goes in as a single multi-row `INSERT ... ON CONFLICT DO NOTHING`, and rows that are still wanted are never touched. `Update` checks `RowsAffected` before commit so updating a nonexistent ID rolls back instead of committing the connection changes, dead `rowsAffected` checks and commented-out code are removed, and two copy-pasted error messages are corrected.
- `Service.List` no longer runs one `GetListFilters` query per list. A new `GetAllListFilters` repo method fetches all connections in one query, and the service attaches them via map lookup: two queries total instead of 1+N. Per-list name ordering and the `[]` JSON shape for lists without filters are preserved.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor / maintenance (no functional change)

## How has this been tested?

* `go fmt`, `go vet`, and the full non-integration test suite pass locally
* NULL-scan repro against SQLite: the old scan pattern reproduces the exact error above on a row with NULL refresh columns, the `sql.Null` pattern reads it cleanly
* The junction sync was exercised against an in-memory SQLite with the production `list_filter` schema: initial store, adding, removing, full replace, duplicate input IDs, no-op resave, and clearing all connections all produce the correct final set
* The batched filter query was verified the same way: correct per-list grouping, name ordering preserved, orphaned junction rows dropped by the join

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed