### PR TITLE
refactor(filters): store indexer connections

### DIFF
--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -1358,6 +1358,8 @@ func (r *FilterRepo) ToggleEnabled(ctx context.Context, filterID int, enabled bo
 	return nil
 }
 
+// StoreIndexerConnections syncs the filter_indexer connections for the filter
+// to the given indexers, deleting stale connections and inserting missing ones.
 func (r *FilterRepo) StoreIndexerConnections(ctx context.Context, filterID int, indexers []domain.Indexer) error {
 	tx, err := r.db.Handler.BeginTx(ctx, nil)
 	if err != nil {
@@ -1366,9 +1368,18 @@ func (r *FilterRepo) StoreIndexerConnections(ctx context.Context, filterID int, 
 
 	defer tx.Rollback()
 
+	indexerIDs := make([]int64, 0, len(indexers))
+	for _, indexer := range indexers {
+		indexerIDs = append(indexerIDs, indexer.ID)
+	}
+
 	deleteQueryBuilder := r.db.squirrel.
 		Delete("filter_indexer").
 		Where(sq.Eq{"filter_id": filterID})
+
+	if len(indexerIDs) > 0 {
+		deleteQueryBuilder = deleteQueryBuilder.Where(sq.NotEq{"indexer_id": indexerIDs})
+	}
 
 	deleteQuery, deleteArgs, err := deleteQueryBuilder.ToSql()
 	if err != nil {
@@ -1380,29 +1391,25 @@ func (r *FilterRepo) StoreIndexerConnections(ctx context.Context, filterID int, 
 		return errors.Wrap(err, "error executing query")
 	}
 
-	if len(indexers) == 0 {
-		if err := tx.Commit(); err != nil {
-			return errors.Wrap(err, "error store indexers for filter: %d", filterID)
+	if len(indexerIDs) > 0 {
+		queryBuilder := r.db.squirrel.
+			Insert("filter_indexer").
+			Columns("filter_id", "indexer_id")
+
+		for _, indexerID := range indexerIDs {
+			queryBuilder = queryBuilder.Values(filterID, indexerID)
 		}
 
-		return nil
-	}
+		queryBuilder = queryBuilder.Suffix("ON CONFLICT DO NOTHING")
 
-	queryBuilder := r.db.squirrel.
-		Insert("filter_indexer").
-		Columns("filter_id", "indexer_id")
+		query, args, err := queryBuilder.ToSql()
+		if err != nil {
+			return errors.Wrap(err, "error building query")
+		}
 
-	for _, indexer := range indexers {
-		queryBuilder = queryBuilder.Values(filterID, indexer.ID)
-	}
-
-	query, args, err := queryBuilder.ToSql()
-	if err != nil {
-		return errors.Wrap(err, "error building query")
-	}
-
-	if _, err = tx.ExecContext(ctx, query, args...); err != nil {
-		return errors.Wrap(err, "error executing query")
+		if _, err = tx.ExecContext(ctx, query, args...); err != nil {
+			return errors.Wrap(err, "error executing query")
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -55,6 +55,7 @@ type actionService interface {
 
 type indexerService interface {
 	FindByFilterID(ctx context.Context, filterID int) ([]domain.Indexer, error)
+	List(ctx context.Context) ([]domain.Indexer, error)
 }
 
 type indexerAPIService interface {
@@ -243,6 +244,11 @@ func (s *Service) Update(ctx context.Context, filter *domain.Filter) error {
 		return err
 	}
 
+	if err := s.validateIndexers(ctx, filter.Indexers); err != nil {
+		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("invalid indexers for filter")
+		return err
+	}
+
 	// update
 	err = s.repo.Update(ctx, filter)
 	if err != nil {
@@ -283,6 +289,33 @@ func (s *Service) Update(ctx context.Context, filter *domain.Filter) error {
 	return nil
 }
 
+// validateIndexers rejects indexers that do not exist. The database cannot be
+// relied on for this: SQLite runs without foreign key enforcement for legacy
+// reasons, so unknown ids would otherwise be stored as orphaned connections.
+func (s *Service) validateIndexers(ctx context.Context, indexers []domain.Indexer) error {
+	if len(indexers) == 0 {
+		return nil
+	}
+
+	existing, err := s.indexerSvc.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	existingIDs := make(map[int64]struct{}, len(existing))
+	for _, indexer := range existing {
+		existingIDs[indexer.ID] = struct{}{}
+	}
+
+	for _, indexer := range indexers {
+		if _, ok := existingIDs[indexer.ID]; !ok {
+			return errors.Wrap(domain.ErrIndexerNotFound, "indexer with id %d does not exist", indexer.ID)
+		}
+	}
+
+	return nil
+}
+
 func (s *Service) UpdatePartial(ctx context.Context, filter domain.FilterUpdate) error {
 	// cleanup
 	if filter.Shows != nil {
@@ -291,6 +324,13 @@ func (s *Service) UpdatePartial(ctx context.Context, filter domain.FilterUpdate)
 		clean = strings.ReplaceAll(clean, ",,", ",")
 
 		filter.Shows = &clean
+	}
+
+	if filter.Indexers != nil {
+		if err := s.validateIndexers(ctx, filter.Indexers); err != nil {
+			s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("invalid indexers for filter")
+			return err
+		}
 	}
 
 	// update

--- a/internal/filter/service_test.go
+++ b/internal/filter/service_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package filter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/autobrr/autobrr/internal/domain"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+type indexerSvcStub struct {
+	indexers []domain.Indexer
+}
+
+func (s *indexerSvcStub) FindByFilterID(_ context.Context, _ int) ([]domain.Indexer, error) {
+	return s.indexers, nil
+}
+
+func (s *indexerSvcStub) List(_ context.Context) ([]domain.Indexer, error) {
+	return s.indexers, nil
+}
+
+func TestService_validateIndexers(t *testing.T) {
+	svc := &Service{
+		log:        zerolog.Nop(),
+		indexerSvc: &indexerSvcStub{indexers: []domain.Indexer{{ID: 1}, {ID: 2}}},
+	}
+
+	t.Run("accepts existing indexers", func(t *testing.T) {
+		assert.NoError(t, svc.validateIndexers(t.Context(), []domain.Indexer{{ID: 1}, {ID: 2}}))
+	})
+
+	t.Run("accepts empty selection", func(t *testing.T) {
+		assert.NoError(t, svc.validateIndexers(t.Context(), nil))
+	})
+
+	t.Run("rejects unknown indexer", func(t *testing.T) {
+		err := svc.validateIndexers(t.Context(), []domain.Indexer{{ID: 1}, {ID: 99}})
+		assert.ErrorIs(t, err, domain.ErrIndexerNotFound)
+	})
+}
+
+// The repo fields are nil, so reaching any persistence call would panic. A
+// clean ErrIndexerNotFound proves validation runs before anything is stored.
+func TestService_Update_ValidatesIndexersBeforePersisting(t *testing.T) {
+	svc := &Service{
+		log:        zerolog.Nop(),
+		indexerSvc: &indexerSvcStub{indexers: []domain.Indexer{{ID: 1}}},
+	}
+
+	err := svc.Update(t.Context(), &domain.Filter{
+		ID:       1,
+		Name:     "filter",
+		Indexers: []domain.Indexer{{ID: 99}},
+	})
+	assert.ErrorIs(t, err, domain.ErrIndexerNotFound)
+}
+
+func TestService_UpdatePartial_ValidatesIndexersBeforePersisting(t *testing.T) {
+	svc := &Service{
+		log:        zerolog.Nop(),
+		indexerSvc: &indexerSvcStub{indexers: []domain.Indexer{{ID: 1}}},
+	}
+
+	err := svc.UpdatePartial(t.Context(), domain.FilterUpdate{
+		ID:       1,
+		Indexers: []domain.Indexer{{ID: 99}},
+	})
+	assert.ErrorIs(t, err, domain.ErrIndexerNotFound)
+}

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -172,6 +172,11 @@ func (h filterHandler) update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Update(r.Context(), data); err != nil {
+		if errors.Is(err, domain.ErrIndexerNotFound) {
+			h.encoder.StatusError(w, http.StatusBadRequest, err)
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -194,6 +199,11 @@ func (h filterHandler) updatePartial(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.UpdatePartial(r.Context(), data); err != nil {
+		if errors.Is(err, domain.ErrIndexerNotFound) {
+			h.encoder.StatusError(w, http.StatusBadRequest, err)
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}


### PR DESCRIPTION
# Description

`StoreIndexerConnections` wiped every `filter_indexer` row for the filter and reinserted the full set on each save. It now syncs instead: stale connections are deleted, and the new set is inserted with `ON CONFLICT DO NOTHING`, so connections that are still wanted are never touched and duplicate input IDs can't abort the transaction. An empty set still clears all connections.

Same pattern as the `list_filter` handling in #2568. No functional change intended.

## Type of change

- [x] Refactor / maintenance (no functional change)

## How has this been tested?

* `TestFilterRepo_StoreIndexerConnections` passes against both SQLite and Postgres (docker compose `test_postgres`), exercising the `NOT IN` delete and `ON CONFLICT` insert on both engines
* `go fmt`, `go vet`, and the non-integration test suite pass locally

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed