### PR TITLE
fix(irc): show full channel history in webui

### DIFF
--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -779,7 +779,7 @@ interface EventsProps {
 
 export const Events = ({ network, channel }: EventsProps) => {
   const [settings] = SettingsContext.use();
-  const { events: logs } = useIrcChannelWithHistory(network.id, channel, 100, true);
+  const { events: logs } = useIrcChannelWithHistory(network.id, channel, 1000, true);
 
   const [isFullscreen, toggleFullscreen] = useToggle(false);
 


### PR DESCRIPTION
# Description

The backend keeps up to 1000 messages per IRC channel (`MaxChannelMessages` in `internal/irc/channel.go`), and the history endpoint returns the full buffer. The WebUI Events view, however, passed `limit: 100` to `useIrcChannelWithHistory`, which trims the fetched history client-side, so users only ever saw the last 100 messages.

This bumps the limit to 1000 so the Events view shows the full channel history the backend keeps.

Fixes #2570

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Frontend-only change: `pnpm --dir web build` passes and the changed file lints clean (`eslint src/screens/settings/Irc.tsx`)
* Verified the new limit matches the backend buffer size (`MaxChannelMessages = 1000`); the history API already returns the full buffer, the cap was purely client-side trimming

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally (no Go code touched)
- [x] I have linked any related issue and updated docs if needed