### PR TITLE
fix(auth): preserve return url and clean up session on expiry

### DIFF
--- a/web/src/api/QueryClient.tsx
+++ b/web/src/api/QueryClient.tsx
@@ -6,28 +6,29 @@
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { toast } from "@components/hot-toast";
 import Toast from "@components/notifications/Toast";
+import { APIClient } from "@api/APIClient";
 import { AuthContext } from "@utils/Context";
-import { getRouteApi, redirect } from "@tanstack/react-router";
 
 const MAX_RETRIES = 6;
 
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error, query) => {
-      const loginRoute = getRouteApi("/login");
       console.error(`Caught error for query '${query.queryKey}': `, error);
 
       if (error.message === "Cookie expired or invalid.") {
-        AuthContext.reset();
-        redirect({
-          to: loginRoute.id,
-          search: {
-            // Use the current location to power a redirect after login
-            // (Do not use `router.state.resolvedLocation` as it can
-            // potentially lag behind the actual current location)
-            redirect: location.href
-          },
-        });
+        // several queries can fail at once; only the first one acts
+        if (AuthContext.get().isLoggedIn) {
+          // best effort: destroys the server-side session and clears the
+          // cookie in case the session is still alive on the server
+          APIClient.auth.logout().catch(() => {
+            // the session was already dead server-side
+          });
+          // navigation to /login happens in AuthenticatedLayout, which
+          // reacts to the reset while the location still points at the
+          // page to return to; navigating from here too would race it
+          AuthContext.reset();
+        }
         return;
       } else {
         toast.custom((t) => <Toast type="error" body={ error?.message } t={ t }/>);

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -340,12 +340,7 @@ export const AuthRoute = createRoute({
 function AuthenticatedLayout() {
   const isLoggedIn = AuthContext.useSelector((s) => s.isLoggedIn);
   if (!isLoggedIn) {
-    const redirect = (
-      location.pathname.length > 1
-        ? { redirect: location.pathname }
-        : undefined
-    );
-    return <Navigate to="/login" search={redirect} />;
+    return <Navigate to="/login" search={{ redirect: location.pathname + location.search }} />;
   }
 
   return (


### PR DESCRIPTION
# Description

Fixes the session-expiry flow in the web UI. Flagged by the automated QA run on #2561 as pre-existing findings unrelated to that PR, split out here.

When a request fails with the session-expired 403 mid-session, the previous behavior had three problems:

- The `QueryClient` error handler called TanStack Router's `redirect()` imperatively from the QueryCache `onError` callback. `redirect()` only takes effect when thrown from router hooks (`beforeLoad`/`loader`), so this was dead code - the return-URL logic it appeared to implement never ran.
- Navigation to the login page actually happened through `AuthenticatedLayout`'s fallback, which passed only `location.pathname` as the return URL (dropping the query string) and omitted it entirely on the dashboard.
- Nothing cleaned up the session: no logout request, so a server-side session that was still alive stayed alive and the cookie lingered in the browser.

**Changes**

- `web/src/api/QueryClient.tsx`: on the session-expired error, fire a best-effort `POST /api/auth/logout` (destroys the server-side session and clears the cookie when the session is still valid; harmless no-op when it is truly dead), then reset the auth context. Guarded so that when several queries fail at once, only the first acts. The inert `redirect()` call is removed; navigation is deliberately left to `AuthenticatedLayout` so there is exactly one navigator and no race between them.
- `web/src/routes.tsx`: `AuthenticatedLayout`'s login redirect now carries `location.pathname + location.search` and is always present, so the return URL survives query params (e.g. a filtered releases view) and works from the dashboard too.

An earlier iteration navigated from the query handler itself; adversarial review showed that races the layout fallback (with opposite winners in dev and production builds, since the module-load timing differs) and that handler-captured absolute URLs break route matching after login. The single-navigator design avoids both by construction.

One behavior note for reviewers: `HttpClient` treats any 403 while logged in as session expiry (pre-existing). With the logout call, such a 403 now also ends the server-side session. For autobrr's API a 403 only ever means the session is invalid, so this is the intended full reset - just worth knowing if a reverse proxy in front of autobrr ever emits a stray 403.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Manually, end to end via browser automation against a local instance: forced the session-expired 403 mid-session from both the dashboard and a filtered releases view (`/releases?action_status=PUSH_APPROVED`). Verified the logout request fires exactly once, the session cookie is gone afterwards, the login URL carries the full return location (`/login?redirect=%2Freleases%3Faction_status%3DPUSH_APPROVED`), and signing back in lands on the exact original page including query params.
* Verified concurrent failures (several polling queries hitting 403 in the same tick) trigger a single logout and a single navigation.
* `pnpm --dir web lint` and `pnpm --dir web build` pass.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL (no schema changes)