### PR TITLE
chore(dependabot): exclude CodeQL from cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       github:
         patterns:
           - "*"
+    # codeql-action moves its floating v4 tag the moment each release publishes,
+    # so the default cooldown makes Dependabot pin v4 to the previous concrete
+    # version. Exclude it so @v4 is compared against the actual latest release.
+    cooldown:
+      exclude: ["github/codeql-action"]
 
   - package-ecosystem: gomod
     directory: /


### PR DESCRIPTION
# Description

Since Dependabot's default 3-day package cooldown (July 2026), it keeps opening PRs that rewrite our floating `github/codeql-action@v4` ref to a pinned previous version (#2558, #2574). codeql-action moves the `v4` tag the same minute each release publishes, so the newest release is always inside the cooldown window and Dependabot resolves "latest eligible" to the release before it - proposing what is effectively a downgrade, with a bump PR treadmill to follow.

Exclude codeql-action from cooldown so `@v4` is compared against the actual latest release again. All other actions keep the default cooldown, and a future v5 major will still be surfaced normally.

## Type of change

- [x] Refactor / maintenance (no functional change)

## How has this been tested?

* Verified the mechanism against dependabot-core's github_actions update checker and the codeql-action tags (`v4` is re-tagged within seconds of each release)
* Config shape checked against the Dependabot options reference: all `cooldown` sub-keys are optional and `exclude` takes plain dependency-name strings

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have linked any related issue and updated docs if needed