### PR TITLE
fix(ci): update existing docs indexer PR instead of opening duplicates

### DIFF
--- a/.github/workflows/update-indexers.yml
+++ b/.github/workflows/update-indexers.yml
@@ -56,45 +56,49 @@ jobs:
         echo "Checking generated files..."
         ls -l ../${{ env.DOCS_PATH }}/snippets/indexers.mdx ../${{ env.DOCS_PATH }}/snippets/freeleech.mdx || true
 
-    - name: Create Pull Request
+    - name: Create or update pull request
       run: |
+        set -euo pipefail
         cd ${{ env.DOCS_PATH }}
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        
-        echo "Current git status:"
-        git status
-        
-        # Create a new branch
-        BRANCH_NAME="update-indexers-$(date +%Y%m%d-%H%M%S)"
-        echo "Creating branch: $BRANCH_NAME"
-        git checkout -b $BRANCH_NAME
-        
-        echo "Changes to be added:"
-        git status snippets/indexers.mdx snippets/freeleech.mdx
-        
-        # Add and commit changes
+
+        BRANCH="automation/update-indexers"
+        TITLE="docs: update indexers and freeleech support lists"
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        git switch -C "$BRANCH"
         git add snippets/indexers.mdx snippets/freeleech.mdx
-        
-        echo "Git status after adding files:"
-        git status
-        
-        # Check if there are staged changes
+
         if git diff --cached --quiet; then
-          echo "No changes detected in the files"
+          echo "Generated tables match main; nothing to do."
+          exit 0
+        fi
+
+        # Reuse the fixed branch across runs; skip the push when its tip already
+        # carries this exact content, so the daily cron doesn't rewrite the branch
+        # (new commit + CI + notifications) without an actual change.
+        if git fetch origin "$BRANCH" 2>/dev/null; then
+          if git diff --quiet FETCH_HEAD -- snippets/indexers.mdx snippets/freeleech.mdx; then
+            echo "Branch $BRANCH is already up to date."
+          else
+            git commit -m "$TITLE"
+            git push --force origin "$BRANCH"
+          fi
         else
-          echo "Changes detected, creating commit and PR"
-          git commit -m "docs: update indexers and freeleech support lists"
-          
-          echo "Pushing changes..."
-          git push origin $BRANCH_NAME
-          
-          echo "Creating PR..."
+          git commit -m "$TITLE"
+          git push origin "$BRANCH"
+        fi
+
+        existing="$(gh pr list --repo ${{ env.DOCS_REPO }} --head "$BRANCH" --state open --json number --jq '.[0].number // empty' || true)"
+        if [ -n "$existing" ]; then
+          echo "Existing PR #$existing updated via branch push."
+        else
           gh pr create \
             --repo ${{ env.DOCS_REPO }} \
             --base main \
-            --head $BRANCH_NAME \
-            --title "docs: update indexers and freeleech support lists" \
+            --head "$BRANCH" \
+            --title "$TITLE" \
             --body "Automated update of the indexers and freeleech support lists from definitions" \
             --label "documentation"
         fi


### PR DESCRIPTION
# Description

The daily Update Indexers List workflow opens a brand-new PR on autobrr/autobrr.com every time it runs, because it pushes to a timestamped branch (`update-indexers-<date>-<time>`) and always calls `gh pr create`. The docs repo keeps accumulating duplicate open PRs.

This changes the workflow to use the same create-or-update pattern as `update-toolchain.yml`:

- Push to a fixed branch (`automation/update-indexers`) instead of a timestamped one
- Only run `gh pr create` when no open PR exists for that branch; otherwise the branch push refreshes the existing PR
- Skip the push entirely when the branch tip already carries the exact same generated content, so the daily cron doesn't produce a no-op commit (plus CI runs and notifications) on the open PR

Only the workflow is touched; `scripts/update-indexers.py` just generates the snippet files and is unchanged.

Note: the previously opened duplicate PRs on autobrr.com need to be closed manually once.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* YAML validated locally; the shell logic mirrors the proven step in `update-toolchain.yml`
* Walked through the edge cases: no changes vs main (early exit), merged and deleted branch (early exit next run), closed-but-unmerged PR (new PR from the existing branch), stale branch content (force push)
* Will verify live via `workflow_dispatch` after merge, since the PR creation only runs against the docs repo with the `DOCS_TOKEN` secret

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have linked any related issue and updated docs if needed