### PR TITLE
fix(filter): use rolling relative time windows for download limits

### DIFF
--- a/internal/database/filter.go
+++ b/internal/database/filter.go
@@ -36,19 +36,19 @@ func NewFilterRepo(log zerolog.Logger, db *DB) *FilterRepo {
 
 const (
 	filterDownloadsSQLite = `SELECT
-	COUNT(DISTINCT CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', strftime('%Y-%m-%dT%H:00:00', datetime('now','localtime'))) AS INTEGER) THEN release_id END) as "hour_count",
-	COUNT(DISTINCT CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'start of day')) AS INTEGER) THEN release_id END) as "day_count",
-	COUNT(DISTINCT CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'weekday 0', '-7 days', 'start of day')) AS INTEGER) THEN release_id END) as "week_count",
-	COUNT(DISTINCT CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', 'start of month')) AS INTEGER) THEN release_id END) as "month_count",
+	COUNT(DISTINCT CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', '-1 hour')) AS INTEGER) THEN release_id END) as "hour_count",
+	COUNT(DISTINCT CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', '-1 day')) AS INTEGER) THEN release_id END) as "day_count",
+	COUNT(DISTINCT CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', '-7 days')) AS INTEGER) THEN release_id END) as "week_count",
+	COUNT(DISTINCT CASE WHEN CAST(strftime('%s', datetime(timestamp, 'localtime')) AS INTEGER) >= CAST(strftime('%s', datetime('now', 'localtime', '-30 days')) AS INTEGER) THEN release_id END) as "month_count",
 	COUNT(DISTINCT release_id) as "total_count"
 FROM release_action_status
 WHERE status IN ('PUSH_APPROVED', 'PENDING') AND filter_id = ?;`
 
 	filterDownloadsPG = `SELECT
-    COUNT(DISTINCT CASE WHEN timestamp >= date_trunc('hour', CURRENT_TIMESTAMP) THEN release_id END) as "hour_count",
-    COUNT(DISTINCT CASE WHEN timestamp >= date_trunc('day', CURRENT_DATE) THEN release_id END) as "day_count",
-    COUNT(DISTINCT CASE WHEN timestamp >= date_trunc('week', CURRENT_DATE) THEN release_id END) as "week_count",
-    COUNT(DISTINCT CASE WHEN timestamp >= date_trunc('month', CURRENT_DATE) THEN release_id END) as "month_count",
+    COUNT(DISTINCT CASE WHEN timestamp >= NOW() - INTERVAL '1 hour' THEN release_id END) as "hour_count",
+    COUNT(DISTINCT CASE WHEN timestamp >= NOW() - INTERVAL '1 day' THEN release_id END) as "day_count",
+    COUNT(DISTINCT CASE WHEN timestamp >= NOW() - INTERVAL '7 days' THEN release_id END) as "week_count",
+    COUNT(DISTINCT CASE WHEN timestamp >= NOW() - INTERVAL '30 days' THEN release_id END) as "month_count",
     COUNT(DISTINCT release_id) as "total_count"
 FROM release_action_status
 WHERE status IN ('PUSH_APPROVED', 'PENDING') AND filter_id = $1;`

--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -1052,6 +1052,64 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			_ = releaseRepo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
 		})
 
+		t.Run(fmt.Sprintf("GetFilterDownloads_Rolling_Windows [%s]", dbType), func(t *testing.T) {
+			mockFilter := getMockFilter()
+			err := repo.Store(t.Context(), mockFilter)
+			assert.NoError(t, err)
+
+			mockClient := getMockDownloadClient()
+			err = downloadClientRepo.Store(t.Context(), &mockClient)
+			assert.NoError(t, err)
+
+			mockAction := getMockAction()
+			mockAction.FilterID = mockFilter.ID
+			mockAction.ClientID = mockClient.ID
+			err = actionRepo.Store(t.Context(), mockAction)
+			assert.NoError(t, err)
+
+			now := time.Now()
+			offsets := []time.Duration{
+				-30 * time.Minute,
+				-2 * time.Hour,
+				-2 * 24 * time.Hour,
+				-10 * 24 * time.Hour,
+				-35 * 24 * time.Hour,
+			}
+
+			for i, offset := range offsets {
+				mockRelease := getMockRelease()
+				mockRelease.FilterID = mockFilter.ID
+				mockRelease.TorrentName = fmt.Sprintf("Torrent %d", i)
+				err = releaseRepo.Store(t.Context(), mockRelease)
+				assert.NoError(t, err)
+
+				ras := getMockReleaseActionStatus()
+				ras.ActionID = int64(mockAction.ID)
+				ras.FilterID = int64(mockFilter.ID)
+				ras.ReleaseID = mockRelease.ID
+				ras.Timestamp = now.Add(offset)
+
+				err = releaseRepo.StoreReleaseActionStatus(t.Context(), ras)
+				assert.NoError(t, err)
+			}
+
+			err = repo.GetFilterDownloadCount(t.Context(), mockFilter)
+			assert.NoError(t, err)
+			assert.NotNil(t, mockFilter.Downloads)
+			assert.Equal(t, &domain.FilterDownloads{
+				HourCount:  1,
+				DayCount:   2,
+				WeekCount:  3,
+				MonthCount: 4,
+				TotalCount: 5,
+			}, mockFilter.Downloads)
+
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: mockAction.ID})
+			_ = repo.Delete(t.Context(), mockFilter.ID)
+			_ = downloadClientRepo.Delete(t.Context(), mockClient.ID)
+			_ = releaseRepo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+		})
+
 		t.Run(fmt.Sprintf("GetFilterDownloads_No_Releases [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockFilter := getMockFilter()


### PR DESCRIPTION
# Description

Updates filter download rate limits (`Hour`, `Day`, `Week`, `Month`) to calculate download counts using relative rolling time windows instead of fixed calendar clock boundaries.

Previously, limits were evaluated against fixed clock boundaries (e.g., start of the hour `12:00:00`, start of day, etc.). This caused issues where a release pushed at 11:58 was ignored when another release arrived at 12:02 under a "1 download per hour" limit, because 11:58 fell before the 12:00 clock reset.

With relative rolling windows:
- **Hour**: Releases within the past 1 hour (`>= now - 1 hour`).
- **Day**: Releases within the past 24 hours (`>= now - 1 day`).
- **Week**: Releases within the past 7 days (`>= now - 7 days`).
- **Month**: Releases within the past 30 days (`>= now - 30 days`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Ran `go test ./cmd/... ./internal/... ./pkg/...` (all passed).
- Added `GetFilterDownloads_Rolling_Windows` integration test in `internal/database/filter_test.go` verifying rate limits for releases offset at 30m, 2h, 2d, 10d, and 35d.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally

## AI disclosure

This PR was authored with assistance from Google Antigravity (Gemini). AI was used for research, updating the SQLite/PostgreSQL SQL queries, and writing unit test cases in `filter_test.go`.