### PR TITLE
fix(irc): accept join confirmation received before the join workflow starts

### DIFF
--- a/internal/irc/channel_state_machine.go
+++ b/internal/irc/channel_state_machine.go
@@ -81,6 +81,7 @@ var validChannelTransitions = map[ChannelState][]ChannelState{
 	ChannelStateIdle: {
 		ChannelStateJoining,
 		ChannelStateAwaitingInvite,
+		ChannelStateMonitoring,
 		ChannelStateError,
 		ChannelStateKicked,
 		ChannelStateParted,
@@ -251,6 +252,10 @@ func (sm *ChannelStateMachine) onStateEntry(state ChannelState) {
 }
 
 func (sm *ChannelStateMachine) Start() {
+	if sm.CurrentState() == ChannelStateMonitoring {
+		return
+	}
+
 	if !sm.channel.IsEnabled() {
 		sm.log.Debug().Msg("channel disabled, skipping join workflow")
 		sm.transition(ChannelStateDisabled)

--- a/internal/irc/recovery_test.go
+++ b/internal/irc/recovery_test.go
@@ -45,6 +45,7 @@ func waitFor(cond func() bool, timeout time.Duration) bool {
 // states are no longer terminal: a retry or a successful join can leave them.
 func TestChannelStateTransitions_Recoverable(t *testing.T) {
 	cases := []struct{ from, to ChannelState }{
+		{ChannelStateIdle, ChannelStateMonitoring},
 		{ChannelStateError, ChannelStateJoining},
 		{ChannelStateError, ChannelStateAwaitingInvite},
 		{ChannelStateError, ChannelStateMonitoring},
@@ -71,6 +72,27 @@ func TestOnInviteRecoversFromError(t *testing.T) {
 
 	if !waitFor(func() bool { return sse.hasStateEvent("#announce", "Joining") }, time.Second) {
 		t.Fatalf("OnInvite from Error did not restart the join workflow, state=%s", sm.CurrentState())
+	}
+}
+
+// TestForceJoinBeforeStart covers servers (e.g. InspIRCd trackers) that
+// force-join the bot on connect: the join confirms while the channel is still
+// Idle, and the later Start() must not re-send a JOIN the server would
+// silently drop.
+func TestForceJoinBeforeStart(t *testing.T) {
+	h, _ := newTestHandler()
+	sm := newIdleSM(h, "#announce", "")
+
+	sm.OnJoinSuccess()
+
+	if !waitForState(sm, ChannelStateMonitoring, time.Second) {
+		t.Fatalf("force-join while Idle did not confirm the channel, state=%s", sm.CurrentState())
+	}
+
+	sm.Start()
+
+	if got := sm.CurrentState(); got != ChannelStateMonitoring {
+		t.Fatalf("Start() after a force-join disturbed the channel, state=%s", got)
 	}
 }
 


### PR DESCRIPTION
# Description

Some servers force-join the bot into the announce channel immediately on connect (seen on Norbits, InspIRCd). The join confirmation (`RPL_ENDOFNAMES`) then arrives while the channel state machine is still `Idle`, and `Idle -> Monitoring` was not a valid transition. The confirmation was rejected, the state machine sent its own `JOIN` for a channel it was already in, and the server dropped the duplicate silently. No second confirmation came, so the 45s timer failed the channel into the error/backoff loop until it gave up. The UI showed "join not confirmed" while announces flowed the whole time.

The fix adds the missing `Idle -> Monitoring` edge, the same recovery edge that `Error`, `Kicked`, and `InviteFailed` already have. `Start()` now also returns early when the channel is already `Monitoring`. Before, that path was a no-op that logged an "invalid state transition" error on every reconnect where the force-join won the race.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Diagnosed on a live instance with TRACE logs: the raw IRC exchange shows the server-initiated `JOIN` and `366` before the join workflow ran, the rejected `Idle -> Monitoring` transition, and the silent drop of the duplicate `JOIN`.
* New test `TestForceJoinBeforeStart` covers the sequence: confirmation while `Idle`, then `Start()` must not disturb the channel.
* New row in `TestChannelStateTransitions_Recoverable` pins the `Idle -> Monitoring` edge.
* Full `internal/irc` test suite passes.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Was any AI used in this PR? Roughly how much of the code was AI-written, and what model/tool?

Yes. The diagnosis and all of the code were written with Claude Code (Fable 5), directed and reviewed by me.
