### PR TITLE
fix(releases): cleanup with Pending state

### DIFF
--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -496,21 +496,6 @@ func ValidReleasePushStatus(s string) bool {
 	}
 }
 
-// ValidDeletableReleasePushStatus checks if a status is valid for deletion operations.
-// Excludes PENDING status as it's not applicable for completed release deletions.
-func ValidDeletableReleasePushStatus(s string) bool {
-	switch s {
-	case string(ReleasePushStatusApproved):
-		return true
-	case string(ReleasePushStatusRejected):
-		return true
-	case string(ReleasePushStatusErr):
-		return true
-	default:
-		return false
-	}
-}
-
 // ReleaseCleanupStatus represents the status of a cleanup job execution
 type ReleaseCleanupStatus string
 
@@ -558,10 +543,9 @@ func (j *ReleaseCleanupJob) Validate() error {
 
 	// Validate statuses if provided
 	if j.Statuses != "" {
-		statuses := strings.Split(j.Statuses, ",")
-		for _, status := range statuses {
+		for status := range strings.SplitSeq(j.Statuses, ",") {
 			status = strings.TrimSpace(status)
-			if status != "" && !ValidDeletableReleasePushStatus(status) {
+			if status != "" && !ValidReleasePushStatus(status) {
 				return errors.New("invalid status: %s", status)
 			}
 		}

--- a/internal/release/cleanup.go
+++ b/internal/release/cleanup.go
@@ -67,6 +67,20 @@ func (j *CleanupJob) Run() {
 		}
 	}
 
+	// A configured status filter that yields no valid statuses must not fall
+	// through to an unfiltered delete - that would drop the status predicate
+	// and the approved-release protection entirely.
+	if j.job.Statuses != "" && len(statuses) == 0 {
+		j.log.Error().Str("statuses", j.job.Statuses).Msg("no valid statuses in configured filter, aborting cleanup")
+
+		j.job.LastRunStatus = domain.ReleaseCleanupStatusError
+		j.job.LastRunData = "no valid statuses in configured filter: " + j.job.Statuses
+		if err := j.releaseRepo.UpdateCleanupJobLastRun(ctx, j.job); err != nil {
+			j.log.Error().Err(err).Msg("error updating cleanup job status")
+		}
+		return
+	}
+
 	// Build delete request
 	req := &domain.DeleteReleaseRequest{
 		OlderThan:       j.job.OlderThan,

--- a/internal/release/cleanup.go
+++ b/internal/release/cleanup.go
@@ -58,7 +58,7 @@ func (j *CleanupJob) Run() {
 		for s := range strings.SplitSeq(j.job.Statuses, ",") {
 			trimmed := strings.TrimSpace(s)
 			if trimmed != "" {
-				if domain.ValidDeletableReleasePushStatus(trimmed) {
+				if domain.ValidReleasePushStatus(trimmed) {
 					statuses = append(statuses, trimmed)
 				} else {
 					j.log.Warn().Str("status", trimmed).Msg("invalid release status ignored")

--- a/internal/release/cleanup_test.go
+++ b/internal/release/cleanup_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package release
+
+import (
+	"context"
+	"testing"
+
+	"github.com/autobrr/autobrr/internal/domain"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCleanupRepo struct {
+	deleteCalled bool
+	deleteReq    *domain.DeleteReleaseRequest
+	updatedJob   *domain.ReleaseCleanupJob
+}
+
+func (m *mockCleanupRepo) UpdateCleanupJobLastRun(_ context.Context, job *domain.ReleaseCleanupJob) error {
+	m.updatedJob = job
+	return nil
+}
+
+func (m *mockCleanupRepo) Delete(_ context.Context, req *domain.DeleteReleaseRequest) error {
+	m.deleteCalled = true
+	m.deleteReq = req
+	return nil
+}
+
+func TestCleanupJobRun_AllStatusesInvalid_AbortsWithoutDelete(t *testing.T) {
+	repo := &mockCleanupRepo{}
+	job := &domain.ReleaseCleanupJob{Name: "test", OlderThan: 24, Statuses: "LEGACY_UNKNOWN"}
+
+	NewCleanupJob(zerolog.Nop(), repo, job).Run()
+
+	assert.False(t, repo.deleteCalled)
+	assert.Equal(t, domain.ReleaseCleanupStatusError, job.LastRunStatus)
+	assert.Contains(t, job.LastRunData, "no valid statuses")
+}
+
+func TestCleanupJobRun_MixedStatuses_DeletesWithValidOnly(t *testing.T) {
+	repo := &mockCleanupRepo{}
+	job := &domain.ReleaseCleanupJob{Name: "test", OlderThan: 24, Statuses: "PENDING, LEGACY_UNKNOWN"}
+
+	NewCleanupJob(zerolog.Nop(), repo, job).Run()
+
+	assert.True(t, repo.deleteCalled)
+	assert.Equal(t, []string{"PENDING"}, repo.deleteReq.ReleaseStatuses)
+	assert.Equal(t, domain.ReleaseCleanupStatusSuccess, job.LastRunStatus)
+}
+
+func TestCleanupJobRun_NoStatusFilter_Deletes(t *testing.T) {
+	repo := &mockCleanupRepo{}
+	job := &domain.ReleaseCleanupJob{Name: "test", OlderThan: 24}
+
+	NewCleanupJob(zerolog.Nop(), repo, job).Run()
+
+	assert.True(t, repo.deleteCalled)
+	assert.Empty(t, repo.deleteReq.ReleaseStatuses)
+	assert.Equal(t, domain.ReleaseCleanupStatusSuccess, job.LastRunStatus)
+}


### PR DESCRIPTION
# Description

The release cleanup job rejected `PENDING` as a status filter: `ReleaseCleanupJob.Validate()` returned "invalid status" when saving a job that included it, and even if such a job existed, `CleanupJob.Run()` silently dropped the status with an "invalid release status ignored" warning. Releases stuck in the Pending state could therefore never be cleaned up by a status-filtered job.

The cause was `ValidDeletableReleasePushStatus`, a stricter copy of `ValidReleasePushStatus` that excluded `PENDING`. There is no reason a user should be prevented from deleting pending releases, so this removes the function and uses `ValidReleasePushStatus` in both the job validation and the cleanup run. The validation loop also switches to `strings.SplitSeq` to match the surrounding code.

This also adds a guard in `CleanupJob.Run()`: if a job has a configured status filter but none of its values are valid (e.g. the persisted data predates a status rename), the run now records an ERROR and aborts instead of falling through to an unfiltered delete, which would have dropped both the status predicate and the approved-release protection.

Reported on Discord.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* `go build ./...` and `go test ./internal/domain/... ./internal/release/...` pass locally
* New unit tests in `internal/release/cleanup_test.go` cover the all-invalid abort, mixed valid/invalid filtering, and the unfiltered-job path
* Created a cleanup job with the `PENDING` status filter and verified it now validates and deletes pending releases, instead of being rejected on save

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed