### PR TITLE
fix(indexers): feed refresh scheduling and indexer secret setting

### DIFF
--- a/cmd/autobrr/main.go
+++ b/cmd/autobrr/main.go
@@ -170,7 +170,7 @@ func main() {
 		downloadService       = releasedownload.NewDownloadService(log, indexerRepo, proxyService)
 		downloadClientService = download_client.NewService(log, downloadClientRepo)
 		actionService         = action.NewService(log, actionRepo, downloadClientService, downloadService, bus)
-		indexerService        = indexer.NewService(log, cfg.Config, bus, indexerRepo, releaseRepo, indexerAPIService, schedulingService)
+		indexerService        = indexer.NewService(log, cfg.Config, bus, indexerRepo, releaseRepo, indexerAPIService)
 		filterService         = filter.NewService(log, filterRepo, actionService, releaseRepo, indexerAPIService, indexerService, downloadService, notificationService)
 		releaseService        = release.NewService(log, releaseRepo, actionService, filterService, indexerService, schedulingService, bus)
 		ircService            = irc.NewService(log, serverEvents, ircRepo, releaseService, indexerService, notificationService, proxyService)

--- a/internal/database/feed.go
+++ b/internal/database/feed.go
@@ -39,6 +39,7 @@ func (r *FeedRepo) FindOne(ctx context.Context, params domain.FindOneParams) (*d
 			"i.name",
 			"i.use_proxy",
 			"i.proxy_id",
+			"i.enabled",
 			"f.name",
 			"f.type",
 			"f.enabled",
@@ -88,10 +89,10 @@ func (r *FeedRepo) FindOne(ctx context.Context, params domain.FindOneParams) (*d
 	var indexerIdentifier, indexerIdentifierExternal, indexerName sql.NullString
 	var lastRun sql.NullTime
 	var capabilitiesJSONString sql.NullString
-	var indexerUseProxy sql.NullBool
+	var indexerUseProxy, indexerEnabled sql.NullBool
 	var categoriesText []string
 
-	if err := row.Scan(&f.ID, &indexerID, &indexerIdentifier, &indexerIdentifierExternal, &indexerName, &indexerUseProxy, &indexerProxyID, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &lastRun, &settings, &f.CreatedAt, &f.UpdatedAt, &f.IndexerID); err != nil {
+	if err := row.Scan(&f.ID, &indexerID, &indexerIdentifier, &indexerIdentifierExternal, &indexerName, &indexerUseProxy, &indexerProxyID, &indexerEnabled, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &lastRun, &settings, &f.CreatedAt, &f.UpdatedAt, &f.IndexerID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, domain.ErrRecordNotFound
 		}
@@ -114,6 +115,7 @@ func (r *FeedRepo) FindOne(ctx context.Context, params domain.FindOneParams) (*d
 		f.Indexer.Name = indexerName.String
 		f.UseProxy = indexerUseProxy.Bool
 		f.ProxyID = indexerProxyID.Int64
+		f.IndexerEnabled = indexerEnabled.Bool
 	}
 
 	f.LastRun = lastRun.Time
@@ -152,6 +154,7 @@ func (r *FeedRepo) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
 			"i.name",
 			"i.use_proxy",
 			"i.proxy_id",
+			"i.enabled",
 			"f.name",
 			"f.type",
 			"f.enabled",
@@ -190,9 +193,10 @@ func (r *FeedRepo) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
 	var proxyID sql.NullInt64
 	var lastRun sql.NullTime
 	var capabilitiesJSONString sql.NullString
+	var indexerEnabled sql.NullBool
 	var categoriesText []string
 
-	if err := row.Scan(&f.ID, &f.Indexer.ID, &f.Indexer.Identifier, &f.Indexer.IdentifierExternal, &f.Indexer.Name, &f.UseProxy, &proxyID, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &lastRun, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
+	if err := row.Scan(&f.ID, &f.Indexer.ID, &f.Indexer.Identifier, &f.Indexer.IdentifierExternal, &f.Indexer.Name, &f.UseProxy, &proxyID, &indexerEnabled, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &lastRun, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, domain.ErrRecordNotFound
 		}
@@ -209,6 +213,7 @@ func (r *FeedRepo) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
 	}
 
 	f.ProxyID = proxyID.Int64
+	f.IndexerEnabled = indexerEnabled.Bool
 	f.LastRun = lastRun.Time
 	f.ApiKey = apiKey.String
 	f.Cookie = cookie.String
@@ -244,6 +249,7 @@ func (r *FeedRepo) Find(ctx context.Context) ([]domain.Feed, error) {
 			"i.name",
 			"i.use_proxy",
 			"i.proxy_id",
+			"i.enabled",
 			"f.name",
 			"f.type",
 			"f.enabled",
@@ -286,9 +292,10 @@ func (r *FeedRepo) Find(ctx context.Context) ([]domain.Feed, error) {
 		var lastRun sql.NullTime
 		var capabilitiesJSONString sql.NullString
 		var proxyID sql.NullInt64
+		var indexerEnabled sql.NullBool
 		var categoriesText []string
 
-		if err := rows.Scan(&f.ID, &f.Indexer.ID, &f.Indexer.Identifier, &f.Indexer.IdentifierExternal, &f.Indexer.Name, &f.UseProxy, &proxyID, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &lastRun, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
+		if err := rows.Scan(&f.ID, &f.Indexer.ID, &f.Indexer.Identifier, &f.Indexer.IdentifierExternal, &f.Indexer.Name, &f.UseProxy, &proxyID, &indexerEnabled, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &lastRun, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
 			return nil, errors.Wrap(err, "error scanning row")
 		}
 
@@ -301,6 +308,7 @@ func (r *FeedRepo) Find(ctx context.Context) ([]domain.Feed, error) {
 		}
 
 		f.ProxyID = proxyID.Int64
+		f.IndexerEnabled = indexerEnabled.Bool
 		f.LastRun = lastRun.Time
 		f.ApiKey = apiKey.String
 		f.Cookie = cookie.String

--- a/internal/database/feed.go
+++ b/internal/database/feed.go
@@ -52,6 +52,7 @@ func (r *FeedRepo) FindOne(ctx context.Context, params domain.FindOneParams) (*d
 			"f.cookie",
 			"f.user_agent",
 			"f.tls_skip_verify",
+			"f.last_run",
 			"f.settings",
 			"f.created_at",
 			"f.updated_at",
@@ -85,11 +86,12 @@ func (r *FeedRepo) FindOne(ctx context.Context, params domain.FindOneParams) (*d
 	var apiKey, cookie, userAgent, settings sql.NullString
 	var indexerID, indexerProxyID sql.NullInt64
 	var indexerIdentifier, indexerIdentifierExternal, indexerName sql.NullString
+	var lastRun sql.NullTime
 	var capabilitiesJSONString sql.NullString
 	var indexerUseProxy sql.NullBool
 	var categoriesText []string
 
-	if err := row.Scan(&f.ID, &indexerID, &indexerIdentifier, &indexerIdentifierExternal, &indexerName, &indexerUseProxy, &indexerProxyID, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &settings, &f.CreatedAt, &f.UpdatedAt, &f.IndexerID); err != nil {
+	if err := row.Scan(&f.ID, &indexerID, &indexerIdentifier, &indexerIdentifierExternal, &indexerName, &indexerUseProxy, &indexerProxyID, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &lastRun, &settings, &f.CreatedAt, &f.UpdatedAt, &f.IndexerID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, domain.ErrRecordNotFound
 		}
@@ -114,6 +116,7 @@ func (r *FeedRepo) FindOne(ctx context.Context, params domain.FindOneParams) (*d
 		f.ProxyID = indexerProxyID.Int64
 	}
 
+	f.LastRun = lastRun.Time
 	f.ApiKey = apiKey.String
 	f.Cookie = cookie.String
 	f.UserAgent = userAgent.String
@@ -162,6 +165,7 @@ func (r *FeedRepo) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
 			"f.cookie",
 			"f.user_agent",
 			"f.tls_skip_verify",
+			"f.last_run",
 			"f.settings",
 			"f.created_at",
 			"f.updated_at",
@@ -184,10 +188,11 @@ func (r *FeedRepo) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
 
 	var apiKey, cookie, userAgent, settings sql.NullString
 	var proxyID sql.NullInt64
+	var lastRun sql.NullTime
 	var capabilitiesJSONString sql.NullString
 	var categoriesText []string
 
-	if err := row.Scan(&f.ID, &f.Indexer.ID, &f.Indexer.Identifier, &f.Indexer.IdentifierExternal, &f.Indexer.Name, &f.UseProxy, &proxyID, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
+	if err := row.Scan(&f.ID, &f.Indexer.ID, &f.Indexer.Identifier, &f.Indexer.IdentifierExternal, &f.Indexer.Name, &f.UseProxy, &proxyID, &f.Name, &f.Type, &f.Enabled, &f.URL, &f.Interval, &f.Timeout, &f.MaxAge, pq.Array(&categoriesText), &capabilitiesJSONString, &apiKey, &cookie, &userAgent, &f.TLSSkipVerify, &lastRun, &settings, &f.CreatedAt, &f.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, domain.ErrRecordNotFound
 		}
@@ -204,6 +209,7 @@ func (r *FeedRepo) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
 	}
 
 	f.ProxyID = proxyID.Int64
+	f.LastRun = lastRun.Time
 	f.ApiKey = apiKey.String
 	f.Cookie = cookie.String
 	f.UserAgent = userAgent.String

--- a/internal/database/indexer.go
+++ b/internal/database/indexer.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
@@ -48,10 +47,10 @@ func (r *IndexerRepo) Store(ctx context.Context, indexer domain.Indexer) (*domai
 	return &indexer, nil
 }
 
-func (r *IndexerRepo) Update(ctx context.Context, indexer domain.Indexer) (*domain.Indexer, error) {
+func (r *IndexerRepo) Update(ctx context.Context, indexer *domain.Indexer) error {
 	settings, err := json.Marshal(indexer.Settings)
 	if err != nil {
-		return nil, errors.Wrap(err, "error marshaling json data")
+		return errors.Wrap(err, "error marshaling json data")
 	}
 
 	queryBuilder := r.db.squirrel.
@@ -63,29 +62,29 @@ func (r *IndexerRepo) Update(ctx context.Context, indexer domain.Indexer) (*doma
 		Set("use_proxy", indexer.UseProxy).
 		Set("proxy_id", toNullInt64(indexer.ProxyID)).
 		Set("settings", settings).
-		Set("updated_at", time.Now().Format(time.RFC3339)).
+		Set("updated_at", sq.Expr("CURRENT_TIMESTAMP")).
 		Where(sq.Eq{"id": indexer.ID})
 
 	query, args, err := queryBuilder.ToSql()
 	if err != nil {
-		return nil, errors.Wrap(err, "error building query")
+		return errors.Wrap(err, "error building query")
 	}
 
 	result, err := r.db.Handler.ExecContext(ctx, query, args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "error executing query")
+		return errors.Wrap(err, "error executing query")
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return nil, errors.Wrap(err, "error rows affected")
+		return errors.Wrap(err, "error rows affected")
 	}
 
 	if rowsAffected == 0 {
-		return nil, domain.ErrUpdateFailed
+		return domain.ErrUpdateFailed
 	}
 
-	return &indexer, nil
+	return nil
 }
 
 func (r *IndexerRepo) List(ctx context.Context) ([]domain.Indexer, error) {

--- a/internal/database/indexer_test.go
+++ b/internal/database/indexer_test.go
@@ -68,16 +68,16 @@ func TestIndexerRepo_Update(t *testing.T) {
 			createdIndexer.Enabled = false
 
 			// Execute
-			updatedIndexer, err := repo.Update(context.Background(), *createdIndexer)
+			err = repo.Update(context.Background(), createdIndexer)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.NoError(t, err)
-			assert.Equal(t, "UpdatedName", updatedIndexer.Name)
-			assert.Equal(t, createdIndexer.Enabled, updatedIndexer.Enabled)
+			assert.Equal(t, "UpdatedName", createdIndexer.Name)
+			assert.Equal(t, createdIndexer.Enabled, false)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), int(updatedIndexer.ID))
+			_ = repo.Delete(context.Background(), int(createdIndexer.ID))
 		})
 	}
 }

--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -10,6 +10,7 @@ const (
 	EventReleasePushStatus        = "release:push"
 	EventNotificationSend         = "events:notification"
 	EventIndexerDelete            = "indexer:delete"
+	EventIndexerToggleEnabled     = "indexer:toggle-enabled"
 )
 
 type EventsReleasePushed struct {

--- a/internal/domain/feed.go
+++ b/internal/domain/feed.go
@@ -40,9 +40,10 @@ type Feed struct {
 	NextRun       time.Time         `json:"next_run"`
 
 	// belongs to Indexer
-	ProxyID  int64  `json:"-"`
-	UseProxy bool   `json:"-"`
-	Proxy    *Proxy `json:"-"`
+	IndexerEnabled bool   `json:"-"`
+	ProxyID        int64  `json:"-"`
+	UseProxy       bool   `json:"-"`
+	Proxy          *Proxy `json:"-"`
 }
 
 // Validate rejects field values that would make every feed request fail at the transport layer.

--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -34,27 +34,35 @@ type Indexer struct {
 	Settings           map[string]string     `json:"settings,omitempty"`
 }
 
-func (i Indexer) MarshalJSON() ([]byte, error) {
-	// Define secret keys that should be redacted
-	secretKeys := map[string]bool{
-		"rsskey":       true,
-		"rss_key":      true,
-		"passkey":      true,
-		"authkey":      true,
-		"torrentpass":  true,
-		"torrent_pass": true,
-		"api_key":      true,
-		"apikey":       true,
-		"uid":          true,
-		"key":          true,
-		"token":        true,
-		"cookie":       true,
-	}
+// secretSettingKeys are indexer settings redacted in API responses; updates must echo them
+// back, redacted or not, so a saved credential is never silently dropped.
+var secretSettingKeys = map[string]struct{}{
+	"rsskey":       {},
+	"rss_key":      {},
+	"passkey":      {},
+	"authkey":      {},
+	"torrentpass":  {},
+	"torrent_pass": {},
+	"api_key":      {},
+	"apikey":       {},
+	"uid":          {},
+	"userid":       {},
+	"key":          {},
+	"token":        {},
+	"cookie":       {},
+}
 
+// IsSecretIndexerSetting reports whether an indexer setting key holds a credential.
+func IsSecretIndexerSetting(key string) bool {
+	_, ok := secretSettingKeys[strings.ToLower(key)]
+	return ok
+}
+
+func (i Indexer) MarshalJSON() ([]byte, error) {
 	// Create a copy of the settings map with redacted secrets
 	redactedSettings := make(map[string]string)
 	for key, value := range i.Settings {
-		if secretKeys[strings.ToLower(key)] {
+		if IsSecretIndexerSetting(key) {
 			redactedSettings[key] = RedactString(value)
 		} else {
 			redactedSettings[key] = value

--- a/internal/events/subscribers.go
+++ b/internal/events/subscribers.go
@@ -16,6 +16,7 @@ import (
 type feedService interface {
 	FindOne(ctx context.Context, params domain.FindOneParams) (*domain.Feed, error)
 	Delete(ctx context.Context, id int) error
+	ToggleIndexerEnabled(ctx context.Context, indexerID int, enabled bool) error
 }
 
 type notificationSender interface {
@@ -54,6 +55,7 @@ func (s *Subscriber) Register() {
 	s.eventbus.Subscribe(domain.EventReleasePushStatus, s.handleReleasePushStatus)
 	s.eventbus.Subscribe(domain.EventNotificationSend, s.handleSendNotification)
 	s.eventbus.Subscribe(domain.EventIndexerDelete, s.handleIndexerDelete)
+	s.eventbus.Subscribe(domain.EventIndexerToggleEnabled, s.handleIndexerToggleEnabled)
 }
 
 func (s *Subscriber) handleReleaseActionStatus(actionStatus *domain.ReleaseActionStatus) {
@@ -101,5 +103,19 @@ func (s *Subscriber) handleIndexerDelete(indexer *domain.Indexer) {
 		}
 
 		s.log.Debug().Str("feed_name", feedItem.Name).Msg("removed feed")
+	}
+}
+
+// handleIndexerToggleEnabled stops or starts the indexer's feed job via event because the feed
+// service can't be imported in the indexer service
+func (s *Subscriber) handleIndexerToggleEnabled(indexer *domain.Indexer) {
+	s.log.Trace().Str("event", domain.EventIndexerToggleEnabled).Int("indexer_id", int(indexer.ID)).Bool("enabled", indexer.Enabled).Msg("indexer toggle enabled event")
+
+	if !indexer.ImplementationIsFeed() {
+		return
+	}
+
+	if err := s.feedSvc.ToggleIndexerEnabled(context.Background(), int(indexer.ID), indexer.Enabled); err != nil {
+		s.log.Error().Err(err).Int("indexer_id", int(indexer.ID)).Msg("could not toggle feed job for indexer")
 	}
 }

--- a/internal/events/subscribers.go
+++ b/internal/events/subscribers.go
@@ -16,7 +16,7 @@ import (
 type feedService interface {
 	FindOne(ctx context.Context, params domain.FindOneParams) (*domain.Feed, error)
 	Delete(ctx context.Context, id int) error
-	ToggleIndexerEnabled(ctx context.Context, indexerID int, enabled bool) error
+	ToggleIndexerEnabled(ctx context.Context, indexerID int) error
 }
 
 type notificationSender interface {
@@ -106,8 +106,10 @@ func (s *Subscriber) handleIndexerDelete(indexer *domain.Indexer) {
 	}
 }
 
-// handleIndexerToggleEnabled stops or starts the indexer's feed job via event because the feed
-// service can't be imported in the indexer service
+// handleIndexerToggleEnabled reconciles the indexer's feed job via event because the feed
+// service can't be imported in the indexer service. The payload's enabled flag is deliberately
+// not forwarded: racing toggles can deliver events out of order, so the feed service re-reads
+// the persisted state instead.
 func (s *Subscriber) handleIndexerToggleEnabled(indexer *domain.Indexer) {
 	s.log.Trace().Str("event", domain.EventIndexerToggleEnabled).Int("indexer_id", int(indexer.ID)).Bool("enabled", indexer.Enabled).Msg("indexer toggle enabled event")
 
@@ -115,7 +117,7 @@ func (s *Subscriber) handleIndexerToggleEnabled(indexer *domain.Indexer) {
 		return
 	}
 
-	if err := s.feedSvc.ToggleIndexerEnabled(context.Background(), int(indexer.ID), indexer.Enabled); err != nil {
+	if err := s.feedSvc.ToggleIndexerEnabled(context.Background(), int(indexer.ID)); err != nil {
 		s.log.Error().Err(err).Int("indexer_id", int(indexer.ID)).Msg("could not toggle feed job for indexer")
 	}
 }

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -74,6 +75,24 @@ type feedInstance struct {
 	Timeout        time.Duration
 }
 
+// guardedJob wraps a scheduled feed job with the feed's run guard so it cannot overlap a force
+// run; an overlapping fire is skipped, the next interval catches up.
+type guardedJob struct {
+	guard *sync.Mutex
+	log   zerolog.Logger
+	job   cron.Job
+}
+
+func (g *guardedJob) Run() {
+	if !g.guard.TryLock() {
+		g.log.Debug().Msg("feed refresh already running, skipping scheduled run")
+		return
+	}
+	defer g.guard.Unlock()
+
+	g.job.Run()
+}
+
 // feedKey creates a unique identifier to be used for controlling jobs in the scheduler
 type feedKey struct {
 	id int
@@ -86,6 +105,11 @@ func (k feedKey) ToString() string {
 
 type Service struct {
 	log zerolog.Logger
+
+	// runGuards holds one mutex per feed so a force run and a scheduled run cannot fetch and
+	// process the same feed concurrently; cron's SkipIfStillRunning only covers a single entry
+	// and force runs use their own job instance
+	runGuards sync.Map
 
 	repo       feedRepo
 	cacheRepo  feedCacheRepo
@@ -167,6 +191,32 @@ func (s *Service) Test(ctx context.Context, feed *domain.Feed) error {
 	return s.test(ctx, feed)
 }
 
+// ToggleIndexerEnabled stops or starts the feed job when its indexer is toggled; the feed's own
+// enabled flag is left untouched so the job comes back when the indexer does.
+func (s *Service) ToggleIndexerEnabled(ctx context.Context, indexerID int, enabled bool) error {
+	feed, err := s.repo.FindOne(ctx, domain.FindOneParams{IndexerID: indexerID})
+	if err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			return nil
+		}
+
+		return errors.Wrap(err, "could not find feed for indexer %d", indexerID)
+	}
+
+	if !enabled {
+		s.log.Debug().Str("feed", feed.Name).Msg("indexer disabled, stopping feed job")
+		return s.stopFeedJob(feed.ID)
+	}
+
+	if !feed.Enabled {
+		return nil
+	}
+
+	s.log.Debug().Str("feed", feed.Name).Msg("indexer enabled, starting feed job")
+
+	return s.startJob(feed)
+}
+
 func (s *Service) Start() error {
 	return s.start()
 }
@@ -234,6 +284,8 @@ func (s *Service) delete(ctx context.Context, id int) error {
 		s.log.Error().Err(err).Str("feed", f.Name).Msg("error deleting feed cache")
 	}
 
+	s.runGuards.Delete(id)
+
 	return nil
 }
 
@@ -253,6 +305,11 @@ func (s *Service) toggleEnabled(ctx context.Context, id int, enabled bool) error
 		if enabled {
 			// override enabled
 			f.Enabled = true
+
+			if !f.IndexerEnabled {
+				s.log.Debug().Str("feed", f.Name).Msg("indexer disabled, feed job starts when the indexer is enabled")
+				return nil
+			}
 
 			if err := s.startJob(f); err != nil {
 				s.log.Error().Err(err).Msg("error starting feed job")
@@ -464,8 +521,26 @@ func (s *Service) start() error {
 				continue
 			}
 
-			if err := s.startJob(&feed); err != nil {
-				s.log.Error().Err(err).Str("feed", feed.Name).Msg("failed to initialize feed job")
+			if !feed.IndexerEnabled {
+				s.log.Trace().Str("feed", feed.Name).Msg("indexer disabled, skipping feed")
+				continue
+			}
+
+			// the staggered sleeps make the snapshot minutes old by the tail, so re-fetch;
+			// a feed or indexer toggled during the window must not be started from stale state
+			fresh, err := s.repo.FindOne(context.TODO(), domain.FindOneParams{FeedID: feed.ID})
+			if err != nil {
+				s.log.Error().Err(err).Str("feed", feed.Name).Msg("failed to refresh feed before start")
+				continue
+			}
+
+			if !fresh.Enabled || !fresh.IndexerEnabled {
+				s.log.Trace().Str("feed", fresh.Name).Msg("feed or indexer disabled since startup, skipping")
+				continue
+			}
+
+			if err := s.startJob(fresh); err != nil {
+				s.log.Error().Err(err).Str("feed", fresh.Name).Msg("failed to initialize feed job")
 				continue
 			}
 
@@ -478,7 +553,7 @@ func (s *Service) start() error {
 }
 
 func (s *Service) restartJob(f *domain.Feed) error {
-	if !f.Enabled {
+	if !f.Enabled || !f.IndexerEnabled {
 		if err := s.stopFeedJob(f.ID); err != nil {
 			s.log.Error().Err(err).Msg("error stopping feed job")
 			return err
@@ -546,6 +621,10 @@ func (s *Service) startJob(f *domain.Feed) error {
 		return errors.New("feed %s not enabled", f.Name)
 	}
 
+	if !f.IndexerEnabled {
+		return errors.New("indexer for feed %s not enabled", f.Name)
+	}
+
 	// get url from settings
 	if f.URL == "" {
 		return errors.New("no URL provided for feed: %s", f.Name)
@@ -582,11 +661,22 @@ func (s *Service) startJob(f *domain.Feed) error {
 func (s *Service) scheduleJob(fi feedInstance, job cron.Job) error {
 	identifierKey := feedKey{fi.Feed.ID}.ToString()
 
-	if _, err := s.scheduler.ScheduleJobAnchored(job, fi.CronSchedule, fi.Feed.LastRun, identifierKey); err != nil {
+	guarded := &guardedJob{
+		guard: s.runGuard(fi.Feed.ID),
+		log:   s.log.With().Str("feed", fi.Name).Int("feed_id", fi.Feed.ID).Logger(),
+		job:   job,
+	}
+
+	if _, err := s.scheduler.ScheduleJobAnchored(guarded, fi.CronSchedule, fi.Feed.LastRun, identifierKey); err != nil {
 		return errors.Wrap(err, "add job %s failed", identifierKey)
 	}
 
 	return nil
+}
+
+func (s *Service) runGuard(feedID int) *sync.Mutex {
+	guard, _ := s.runGuards.LoadOrStore(feedID, &sync.Mutex{})
+	return guard.(*sync.Mutex)
 }
 
 func (s *Service) createTorznabJob(f feedInstance) (RefreshFeedJob, error) {
@@ -717,6 +807,12 @@ func (s *Service) ForceRun(ctx context.Context, id int) error {
 		s.log.Error().Err(err).Msg("failed to initialize feed job")
 		return err
 	}
+
+	guard := s.runGuard(feed.ID)
+	if !guard.TryLock() {
+		return errors.New("feed %s is already running", feed.Name)
+	}
+	defer guard.Unlock()
 
 	if err := job.RunE(ctx); err != nil {
 		s.log.Error().Err(err).Msg("failed to refresh feed")

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -106,16 +106,22 @@ func (k feedKey) ToString() string {
 type Service struct {
 	log zerolog.Logger
 
-	// runGuards holds one mutex per feed so a force run and a scheduled run cannot fetch and
-	// process the same feed concurrently; cron's SkipIfStillRunning only covers a single entry
-	// and force runs use their own job instance
-	runGuards sync.Map
+	// guards holds per-feed mutexes: run keeps a force run and a scheduled run from fetching
+	// and processing the same feed concurrently (cron's SkipIfStillRunning only covers a single
+	// entry and force runs use their own job instance); schedule serializes syncFeedJob so two
+	// reconciliations cannot apply their start/stop in inverted order
+	guards sync.Map
 
 	repo       feedRepo
 	cacheRepo  feedCacheRepo
 	releaseSvc releaseService
 	proxySvc   proxyService
 	scheduler  schedulerService
+}
+
+type feedGuards struct {
+	schedule sync.Mutex
+	run      sync.Mutex
 }
 
 func NewService(log zerolog.Logger, repo feedRepo, cacheRepo feedCacheRepo, releaseSvc releaseService, proxySvc proxyService, scheduler schedulerService) *Service {
@@ -193,7 +199,10 @@ func (s *Service) Test(ctx context.Context, feed *domain.Feed) error {
 
 // ToggleIndexerEnabled stops or starts the feed job when its indexer is toggled; the feed's own
 // enabled flag is left untouched so the job comes back when the indexer does.
-func (s *Service) ToggleIndexerEnabled(ctx context.Context, indexerID int, enabled bool) error {
+// ToggleIndexerEnabled reconciles the feed job after its indexer was toggled. The persisted
+// state is re-read instead of trusting the event: racing toggles can deliver events in a
+// different order than their writes committed.
+func (s *Service) ToggleIndexerEnabled(ctx context.Context, indexerID int) error {
 	feed, err := s.repo.FindOne(ctx, domain.FindOneParams{IndexerID: indexerID})
 	if err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
@@ -203,18 +212,7 @@ func (s *Service) ToggleIndexerEnabled(ctx context.Context, indexerID int, enabl
 		return errors.Wrap(err, "could not find feed for indexer %d", indexerID)
 	}
 
-	if !enabled {
-		s.log.Debug().Str("feed", feed.Name).Msg("indexer disabled, stopping feed job")
-		return s.stopFeedJob(feed.ID)
-	}
-
-	if !feed.Enabled {
-		return nil
-	}
-
-	s.log.Debug().Str("feed", feed.Name).Msg("indexer enabled, starting feed job")
-
-	return s.startJob(feed)
+	return s.syncFeedJob(ctx, feed.ID)
 }
 
 func (s *Service) Start() error {
@@ -244,14 +242,7 @@ func (s *Service) update(ctx context.Context, feed *domain.Feed) error {
 		return err
 	}
 
-	// get Feed again for ProxyID and UseProxy to be correctly populated
-	feed, err = s.repo.FindOne(ctx, domain.FindOneParams{FeedID: feed.ID})
-	if err != nil {
-		s.log.Error().Err(err).Msg("error finding feed")
-		return err
-	}
-
-	if err := s.restartJob(feed); err != nil {
+	if err := s.syncFeedJob(ctx, feed.ID); err != nil {
 		s.log.Error().Err(err).Msg("error restarting feed")
 		return err
 	}
@@ -284,7 +275,7 @@ func (s *Service) delete(ctx context.Context, id int) error {
 		s.log.Error().Err(err).Str("feed", f.Name).Msg("error deleting feed cache")
 	}
 
-	s.runGuards.Delete(id)
+	s.guards.Delete(id)
 
 	return nil
 }
@@ -302,38 +293,10 @@ func (s *Service) toggleEnabled(ctx context.Context, id int, enabled bool) error
 	}
 
 	if f.Enabled != enabled {
-		if enabled {
-			// override enabled
-			f.Enabled = true
-
-			if !f.IndexerEnabled {
-				s.log.Debug().Str("feed", f.Name).Msg("indexer disabled, feed job starts when the indexer is enabled")
-				return nil
-			}
-
-			if err := s.startJob(f); err != nil {
-				s.log.Error().Err(err).Msg("error starting feed job")
-				return err
-			}
-
-			s.log.Debug().Str("feed", f.Name).Msg("feed started")
-
-			return nil
-		}
-
-		s.log.Debug().Str("feed", f.Name).Msg("stopping feed")
-
-		if err := s.stopFeedJob(f.ID); err != nil {
-			s.log.Error().Err(err).Msg("error stopping feed job")
-			return err
-		}
-
-		s.log.Debug().Str("feed", f.Name).Msg("feed stopped")
-
-		return nil
+		s.log.Debug().Str("feed", f.Name).Bool("enabled", enabled).Msg("feed toggled")
 	}
 
-	return nil
+	return s.syncFeedJob(ctx, id)
 }
 
 func (s *Service) test(ctx context.Context, feed *domain.Feed) error {
@@ -526,21 +489,11 @@ func (s *Service) start() error {
 				continue
 			}
 
-			// the staggered sleeps make the snapshot minutes old by the tail, so re-fetch;
-			// a feed or indexer toggled during the window must not be started from stale state
-			fresh, err := s.repo.FindOne(context.TODO(), domain.FindOneParams{FeedID: feed.ID})
-			if err != nil {
-				s.log.Error().Err(err).Str("feed", feed.Name).Msg("failed to refresh feed before start")
-				continue
-			}
-
-			if !fresh.Enabled || !fresh.IndexerEnabled {
-				s.log.Trace().Str("feed", fresh.Name).Msg("feed or indexer disabled since startup, skipping")
-				continue
-			}
-
-			if err := s.startJob(fresh); err != nil {
-				s.log.Error().Err(err).Str("feed", fresh.Name).Msg("failed to initialize feed job")
+			// syncFeedJob re-fetches: the staggered sleeps make this snapshot minutes old by
+			// the tail, and a feed or indexer toggled during the window must not be started
+			// from stale state
+			if err := s.syncFeedJob(context.TODO(), feed.ID); err != nil {
+				s.log.Error().Err(err).Str("feed", feed.Name).Msg("failed to initialize feed job")
 				continue
 			}
 
@@ -552,27 +505,6 @@ func (s *Service) start() error {
 	return nil
 }
 
-func (s *Service) restartJob(f *domain.Feed) error {
-	if !f.Enabled || !f.IndexerEnabled {
-		if err := s.stopFeedJob(f.ID); err != nil {
-			s.log.Error().Err(err).Msg("error stopping feed job")
-			return err
-		}
-
-		return nil
-	}
-
-	// startJob replaces any existing entry for the feed, so the old job is never removed
-	// before its replacement is registered; a failed start leaves the old schedule running
-	if err := s.startJob(f); err != nil {
-		s.log.Error().Err(err).Msg("error starting feed job")
-		return err
-	}
-
-	s.log.Debug().Str("feed", f.Name).Msg("restarted feed")
-
-	return nil
-}
 func newFeedInstance(f *domain.Feed) feedInstance {
 	// cron schedule to run every X minutes
 	fi := feedInstance{
@@ -662,7 +594,7 @@ func (s *Service) scheduleJob(fi feedInstance, job cron.Job) error {
 	identifierKey := feedKey{fi.Feed.ID}.ToString()
 
 	guarded := &guardedJob{
-		guard: s.runGuard(fi.Feed.ID),
+		guard: &s.feedGuard(fi.Feed.ID).run,
 		log:   s.log.With().Str("feed", fi.Name).Int("feed_id", fi.Feed.ID).Logger(),
 		job:   job,
 	}
@@ -674,9 +606,34 @@ func (s *Service) scheduleJob(fi feedInstance, job cron.Job) error {
 	return nil
 }
 
-func (s *Service) runGuard(feedID int) *sync.Mutex {
-	guard, _ := s.runGuards.LoadOrStore(feedID, &sync.Mutex{})
-	return guard.(*sync.Mutex)
+func (s *Service) feedGuard(feedID int) *feedGuards {
+	guard, _ := s.guards.LoadOrStore(feedID, &feedGuards{})
+	return guard.(*feedGuards)
+}
+
+// syncFeedJob converges the scheduled job with the persisted feed and indexer state. Every
+// start/stop decision goes through here on a fresh fetch: enabled flags carried by events or
+// pre-write snapshots can be stale when toggles race, and acting on them can strand an enabled
+// feed without a job. The per-feed lock keeps racing reconciliations from applying out of order.
+func (s *Service) syncFeedJob(ctx context.Context, feedID int) error {
+	guard := s.feedGuard(feedID)
+	guard.schedule.Lock()
+	defer guard.schedule.Unlock()
+
+	feed, err := s.repo.FindOne(ctx, domain.FindOneParams{FeedID: feedID})
+	if err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			return s.stopFeedJob(feedID)
+		}
+
+		return errors.Wrap(err, "could not find feed %d", feedID)
+	}
+
+	if !feed.Enabled || !feed.IndexerEnabled {
+		return s.stopFeedJob(feed.ID)
+	}
+
+	return s.startJob(feed)
 }
 
 func (s *Service) createTorznabJob(f feedInstance) (RefreshFeedJob, error) {
@@ -808,7 +765,7 @@ func (s *Service) ForceRun(ctx context.Context, id int) error {
 		return err
 	}
 
-	guard := s.runGuard(feed.ID)
+	guard := &s.feedGuard(feed.ID).run
 	if !guard.TryLock() {
 		return errors.New("feed %s is already running", feed.Name)
 	}
@@ -822,13 +779,7 @@ func (s *Service) ForceRun(ctx context.Context, id int) error {
 	// the schedule anchors to last_run, which the run just updated; reschedule so the next
 	// scheduled run is a full interval from now instead of from the previous run. Detached
 	// from ctx so a client disconnect after the fetch cannot leave the stale schedule behind
-	feed, err = s.FindByID(context.WithoutCancel(ctx), id)
-	if err != nil {
-		s.log.Error().Err(err).Int("feed_id", id).Msg("could not find feed after force run")
-		return nil
-	}
-
-	if err := s.restartJob(feed); err != nil {
+	if err := s.syncFeedJob(context.WithoutCancel(ctx), id); err != nil {
 		s.log.Error().Err(err).Int("feed_id", id).Msg("could not reschedule feed after force run")
 	}
 

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -49,7 +49,7 @@ type feedCacheRepo interface {
 }
 
 type schedulerService interface {
-	ScheduleJobJittered(job cron.Job, interval time.Duration, identifier string) (int, error)
+	ScheduleJobAnchored(job cron.Job, interval time.Duration, lastRun time.Time, identifier string) (int, error)
 	AddJob(job cron.Job, spec string, identifier string) (int, error)
 	RemoveJobByIdentifier(id string) error
 	GetNextRun(id string) (time.Time, error)
@@ -85,8 +85,7 @@ func (k feedKey) ToString() string {
 }
 
 type Service struct {
-	log  zerolog.Logger
-	jobs map[string]int
+	log zerolog.Logger
 
 	repo       feedRepo
 	cacheRepo  feedCacheRepo
@@ -98,7 +97,6 @@ type Service struct {
 func NewService(log zerolog.Logger, repo feedRepo, cacheRepo feedCacheRepo, releaseSvc releaseService, proxySvc proxyService, scheduler schedulerService) *Service {
 	return &Service{
 		log:        log.With().Str("module", "feed").Logger(),
-		jobs:       map[string]int{},
 		repo:       repo,
 		cacheRepo:  cacheRepo,
 		releaseSvc: releaseSvc,
@@ -480,22 +478,23 @@ func (s *Service) start() error {
 }
 
 func (s *Service) restartJob(f *domain.Feed) error {
-	s.log.Debug().Str("feed", f.Name).Msg("stopping feed")
-
-	// stop feed job
-	if err := s.stopFeedJob(f.ID); err != nil {
-		s.log.Error().Err(err).Msg("error stopping feed job")
-		return err
-	}
-
-	if f.Enabled {
-		if err := s.startJob(f); err != nil {
-			s.log.Error().Err(err).Msg("error starting feed job")
+	if !f.Enabled {
+		if err := s.stopFeedJob(f.ID); err != nil {
+			s.log.Error().Err(err).Msg("error stopping feed job")
 			return err
 		}
 
-		s.log.Debug().Str("feed", f.Name).Msg("restarted feed")
+		return nil
 	}
+
+	// startJob replaces any existing entry for the feed, so the old job is never removed
+	// before its replacement is registered; a failed start leaves the old schedule running
+	if err := s.startJob(f); err != nil {
+		s.log.Error().Err(err).Msg("error starting feed job")
+		return err
+	}
+
+	s.log.Debug().Str("feed", f.Name).Msg("restarted feed")
 
 	return nil
 }
@@ -583,14 +582,9 @@ func (s *Service) startJob(f *domain.Feed) error {
 func (s *Service) scheduleJob(fi feedInstance, job cron.Job) error {
 	identifierKey := feedKey{fi.Feed.ID}.ToString()
 
-	// schedule job
-	id, err := s.scheduler.ScheduleJobJittered(job, fi.CronSchedule, identifierKey)
-	if err != nil {
+	if _, err := s.scheduler.ScheduleJobAnchored(job, fi.CronSchedule, fi.Feed.LastRun, identifierKey); err != nil {
 		return errors.Wrap(err, "add job %s failed", identifierKey)
 	}
-
-	// add to job map
-	s.jobs[identifierKey] = id
 
 	return nil
 }
@@ -667,13 +661,9 @@ func (s *Service) createCleanupJob() error {
 	identifierKey := "feed-cache-cleanup"
 
 	// schedule job for every day at 03:05
-	id, err := s.scheduler.AddJob(job, "5 3 * * *", identifierKey)
-	if err != nil {
+	if _, err := s.scheduler.AddJob(job, "5 3 * * *", identifierKey); err != nil {
 		return errors.Wrap(err, "add job %s failed", identifierKey)
 	}
-
-	// add to job map
-	s.jobs[identifierKey] = id
 
 	return nil
 }
@@ -731,6 +721,19 @@ func (s *Service) ForceRun(ctx context.Context, id int) error {
 	if err := job.RunE(ctx); err != nil {
 		s.log.Error().Err(err).Msg("failed to refresh feed")
 		return err
+	}
+
+	// the schedule anchors to last_run, which the run just updated; reschedule so the next
+	// scheduled run is a full interval from now instead of from the previous run. Detached
+	// from ctx so a client disconnect after the fetch cannot leave the stale schedule behind
+	feed, err = s.FindByID(context.WithoutCancel(ctx), id)
+	if err != nil {
+		s.log.Error().Err(err).Int("feed_id", id).Msg("could not find feed after force run")
+		return nil
+	}
+
+	if err := s.restartJob(feed); err != nil {
+		s.log.Error().Err(err).Int("feed_id", id).Msg("could not reschedule feed after force run")
 	}
 
 	return nil

--- a/internal/http/indexer.go
+++ b/internal/http/indexer.go
@@ -17,7 +17,7 @@ import (
 
 type indexerService interface {
 	Store(ctx context.Context, indexer domain.Indexer) (*domain.Indexer, error)
-	Update(ctx context.Context, indexer domain.Indexer) (*domain.Indexer, error)
+	Update(ctx context.Context, indexer *domain.Indexer) error
 	List(ctx context.Context) ([]domain.Indexer, error)
 	FindByID(ctx context.Context, id int) (*domain.Indexer, error)
 	GetAll() ([]*domain.IndexerDefinition, error)
@@ -90,13 +90,17 @@ func (h indexerHandler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	indexer, err := h.service.Update(r.Context(), data)
-	if err != nil {
+	if err := h.service.Update(r.Context(), &data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("indexer not found"))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusOK, indexer)
+	h.encoder.StatusResponse(w, http.StatusOK, data)
 }
 
 func (h indexerHandler) delete(w http.ResponseWriter, r *http.Request) {
@@ -107,6 +111,11 @@ func (h indexerHandler) delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Delete(r.Context(), indexerID); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("indexer not found"))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -144,7 +153,7 @@ func (h indexerHandler) findByID(w http.ResponseWriter, r *http.Request) {
 	indexer, err := h.service.FindByID(r.Context(), indexerID)
 	if err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
-			h.encoder.NotFoundErr(w, errors.New("indexer with id %d not found", indexerID))
+			h.encoder.NotFoundErr(w, errors.New("indexer not found"))
 			return
 		}
 
@@ -173,6 +182,11 @@ func (h indexerHandler) testApi(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.TestApi(r.Context(), req); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("indexer not found"))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -203,6 +217,11 @@ func (h indexerHandler) toggleEnabled(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.ToggleEnabled(r.Context(), indexerID, data.Enabled); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("indexer not found"))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/indexer/definition_test.go
+++ b/internal/indexer/definition_test.go
@@ -4,11 +4,30 @@
 package indexer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/stretchr/testify/assert"
 )
+
+// Secret-typed settings are redacted per field type in definition responses, while stored
+// indexer settings are redacted per key name via domain.IsSecretIndexerSetting; the two must
+// agree or a saved credential leaks unredacted through one of the API paths.
+func TestIndexerYamlSecretSettings(t *testing.T) {
+	t.Parallel()
+	s := &Service{definitions: map[string]domain.IndexerDefinition{}}
+	err := s.LoadIndexerDefinitions()
+	assert.NoError(t, err)
+
+	for _, d := range s.definitions {
+		for _, setting := range d.Settings {
+			secretType := strings.EqualFold(string(setting.Type), "secret")
+			assert.Equal(t, secretType, domain.IsSecretIndexerSetting(setting.Name),
+				"definition %s setting %s: type '%s' and domain.IsSecretIndexerSetting disagree", d.Identifier, setting.Name, setting.Type)
+		}
+	}
+}
 
 func TestIndexerYamlExpectations(t *testing.T) {
 	t.Parallel()

--- a/internal/indexer/definitions/fuzer.yaml
+++ b/internal/indexer/definitions/fuzer.yaml
@@ -13,7 +13,7 @@ supports:
 # source: gazelle
 settings:
   - name: uid
-    type: text
+    type: secret
     required: true
     label: User ID
     help: Create rss link at https://www.fuzer.me/getrss.php and find at &u=11111

--- a/internal/indexer/definitions/orpheus.yaml
+++ b/internal/indexer/definitions/orpheus.yaml
@@ -16,7 +16,7 @@ supports:
 # source: gazelle
 settings:
   - name: torrent_pass
-    type: text
+    type: secret
     required: true
     label: Torrent pass
     help: Right click DL on a torrent and get the torrent_pass.

--- a/internal/indexer/definitions/phoenixproject.yaml
+++ b/internal/indexer/definitions/phoenixproject.yaml
@@ -15,7 +15,7 @@ supports:
 # source: gazelle
 settings:
   - name: torrent_pass
-    type: text
+    type: secret
     required: true
     label: Torrent pass
     help: Right click DL on a torrent and get the torrent_pass.

--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -155,10 +155,11 @@ func (s *Service) Update(ctx context.Context, indexer *domain.Indexer) error {
 		return err
 	}
 
-	changed := currentIndexer.Enabled != indexer.Enabled
-	if currentIndexer.ImplementationIsFeed() && changed {
-		// publish the stored indexer, not the update payload, so the handler sees a
-		// populated Implementation regardless of what the request carried
+	// always publish: a changed-gate computed from the pre-write snapshot misses racing
+	// opposite toggles, and the handler reconciles idempotently against persisted state.
+	// Publish the stored indexer, not the update payload, so the handler sees a populated
+	// Implementation regardless of what the request carried
+	if currentIndexer.ImplementationIsFeed() {
 		toggled := *currentIndexer
 		toggled.Enabled = indexer.Enabled
 		s.bus.Publish(domain.EventIndexerToggleEnabled, &toggled)
@@ -768,7 +769,6 @@ func (s *Service) ToggleEnabled(ctx context.Context, indexerID int, enabled bool
 		return err
 	}
 
-	changed := indexer.Enabled != enabled
 	indexer.Enabled = enabled
 
 	// update indexerInstances
@@ -778,8 +778,9 @@ func (s *Service) ToggleEnabled(ctx context.Context, indexerID int, enabled bool
 	}
 
 	// feed jobs are stopped and started by the feed service via event because the feed service
-	// can't be imported here
-	if indexer.ImplementationIsFeed() && changed {
+	// can't be imported here. Always published: a changed-gate computed from the pre-write
+	// snapshot misses racing opposite toggles, and the handler reconciles idempotently
+	if indexer.ImplementationIsFeed() {
 		s.bus.Publish(domain.EventIndexerToggleEnabled, indexer)
 	}
 

--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -23,17 +23,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type schedulerService interface {
-	RemoveJobByIdentifier(id string) error
-}
-
 type releaseRepo interface {
 	UpdateBaseURL(ctx context.Context, indexer string, oldBaseURL, newBaseURL string) error
 }
 
 type indexerRepo interface {
 	Store(ctx context.Context, indexer domain.Indexer) (*domain.Indexer, error)
-	Update(ctx context.Context, indexer domain.Indexer) (*domain.Indexer, error)
+	Update(ctx context.Context, indexer *domain.Indexer) error
 	List(ctx context.Context) ([]domain.Indexer, error)
 	Delete(ctx context.Context, id int) error
 	FindByFilterID(ctx context.Context, id int) ([]domain.Indexer, error)
@@ -48,7 +44,6 @@ type Service struct {
 	repo        indexerRepo
 	releaseRepo releaseRepo
 	ApiService  apiService
-	scheduler   schedulerService
 	bus         EventBus.Bus
 
 	// contains all raw indexer definitions
@@ -57,21 +52,17 @@ type Service struct {
 	mappedDefinitions map[string]*domain.IndexerDefinition
 	// map server:channel:announce to indexer.Identifier
 	lookupIRCServerDefinition map[string]map[string]*domain.IndexerDefinition
-	// feed indexers
-	feedIndexers map[string]*domain.IndexerDefinition
 }
 
-func NewService(log zerolog.Logger, config *domain.Config, bus EventBus.Bus, repo indexerRepo, releaseRepo releaseRepo, apiService apiService, scheduler schedulerService) *Service {
+func NewService(log zerolog.Logger, config *domain.Config, bus EventBus.Bus, repo indexerRepo, releaseRepo releaseRepo, apiService apiService) *Service {
 	return &Service{
 		log:                       log.With().Str("module", "indexer").Logger(),
 		config:                    config,
 		repo:                      repo,
 		releaseRepo:               releaseRepo,
 		ApiService:                apiService,
-		scheduler:                 scheduler,
 		bus:                       bus,
 		lookupIRCServerDefinition: make(map[string]map[string]*domain.IndexerDefinition),
-		feedIndexers:              make(map[string]*domain.IndexerDefinition),
 		definitions:               make(map[string]domain.IndexerDefinition),
 		mappedDefinitions:         make(map[string]*domain.IndexerDefinition),
 	}
@@ -113,10 +104,10 @@ func (s *Service) Store(ctx context.Context, indexer domain.Indexer) (*domain.In
 	return i, nil
 }
 
-func (s *Service) Update(ctx context.Context, indexer domain.Indexer) (*domain.Indexer, error) {
+func (s *Service) Update(ctx context.Context, indexer *domain.Indexer) error {
 	currentIndexer, err := s.repo.FindByID(ctx, int(indexer.ID))
 	if err != nil {
-		return nil, errors.Wrap(err, "could not find indexer by id: %v", indexer.ID)
+		return errors.Wrap(err, "could not find indexer by id: %v", indexer.ID)
 	}
 
 	// sanitize user input
@@ -126,7 +117,7 @@ func (s *Service) Update(ctx context.Context, indexer domain.Indexer) (*domain.I
 		if domain.IsRedactedString(val) {
 			currentVal, ok := currentIndexer.Settings[key]
 			if !ok {
-				return nil, errors.New("could not find setting in current indexer")
+				return errors.New("could not find setting in current indexer")
 			}
 			//indexer.Settings[key] = sanitize.String(currentVal)
 			indexer.Settings[key] = currentVal
@@ -139,7 +130,7 @@ func (s *Service) Update(ctx context.Context, indexer domain.Indexer) (*domain.I
 	// only IRC indexers have baseURL set
 	if indexer.Implementation == domain.IndexerImplementationIRC {
 		if indexer.BaseURL == "" {
-			return nil, errors.New("indexer baseURL must not be empty")
+			return errors.New("indexer baseURL must not be empty")
 		}
 
 		// check if baseURL has been updated and update releases if it was
@@ -148,32 +139,34 @@ func (s *Service) Update(ctx context.Context, indexer domain.Indexer) (*domain.I
 			// update urls of releases
 			err = s.releaseRepo.UpdateBaseURL(ctx, indexer.Identifier, currentIndexer.BaseURL, indexer.BaseURL)
 			if err != nil {
-				return nil, errors.Wrap(err, "could not update release urls with new baseURL: %s", indexer.BaseURL)
+				return errors.Wrap(err, "could not update release urls with new baseURL: %s", indexer.BaseURL)
 			}
 		}
 	}
 
-	i, err := s.repo.Update(ctx, indexer)
-	if err != nil {
+	if err := s.repo.Update(ctx, indexer); err != nil {
 		s.log.Error().Err(err).Interface("indexer", indexer).Msg("could not update indexer")
-		return nil, err
+		return err
 	}
 
 	// add to indexerInstances
-	if err = s.updateIndexer(*i); err != nil {
+	if err = s.updateIndexer(indexer); err != nil {
 		s.log.Error().Err(err).Str("indexer", indexer.Name).Msg("failed to add indexer")
-		return nil, err
+		return err
 	}
 
-	if currentIndexer.ImplementationIsFeed() {
-		if currentIndexer.Enabled && !indexer.Enabled {
-			s.stopFeed(indexer.Identifier)
-		}
+	changed := currentIndexer.Enabled != indexer.Enabled
+	if currentIndexer.ImplementationIsFeed() && changed {
+		// publish the stored indexer, not the update payload, so the handler sees a
+		// populated Implementation regardless of what the request carried
+		toggled := *currentIndexer
+		toggled.Enabled = indexer.Enabled
+		s.bus.Publish(domain.EventIndexerToggleEnabled, &toggled)
 	}
 
 	s.log.Debug().Str("indexer", indexer.Name).Msg("successfully updated indexer")
 
-	return i, nil
+	return nil
 }
 
 func (s *Service) Delete(ctx context.Context, id int) error {
@@ -328,7 +321,7 @@ func (s *Service) mapIndexer(indexer domain.Indexer) (*domain.IndexerDefinition,
 	return d, nil
 }
 
-func (s *Service) updateMapIndexer(indexer domain.Indexer) (*domain.IndexerDefinition, error) {
+func (s *Service) updateMapIndexer(indexer *domain.Indexer) (*domain.IndexerDefinition, error) {
 	d, ok := s.mappedDefinitions[indexer.Identifier]
 	if !ok {
 		return nil, domain.ErrIndexerNotFound
@@ -416,10 +409,6 @@ func (s *Service) Start() error {
 					s.log.Error().Stack().Err(err).Str("indexer", indexer.Identifier).Msg("indexer.start: could not init indexer api client")
 				}
 			}
-
-		// handle feeds
-		case domain.IndexerImplementationRSS, domain.IndexerImplementationTorznab, domain.IndexerImplementationNewznab:
-			s.feedIndexers[indexer.Identifier] = indexer
 		}
 	}
 
@@ -429,12 +418,6 @@ func (s *Service) Start() error {
 }
 
 func (s *Service) removeIndexer(indexer domain.Indexer) {
-	// handle feeds
-	switch indexer.Implementation {
-	case domain.IndexerImplementationRSS, domain.IndexerImplementationTorznab, domain.IndexerImplementationNewznab:
-		delete(s.feedIndexers, indexer.Identifier)
-	}
-
 	// remove mapped definition
 	delete(s.mappedDefinitions, indexer.Identifier)
 }
@@ -460,10 +443,6 @@ func (s *Service) addIndexer(indexer domain.Indexer) error {
 				s.log.Error().Stack().Err(err).Str("indexer", indexer.Identifier).Msg("indexer.addIndexer: could not init indexer api client")
 			}
 		}
-
-	// handle feeds
-	case domain.IndexerImplementationRSS, domain.IndexerImplementationTorznab, domain.IndexerImplementationNewznab:
-		s.feedIndexers[indexer.Identifier] = indexerDefinition
 	}
 
 	s.mappedDefinitions[indexer.Identifier] = indexerDefinition
@@ -471,7 +450,7 @@ func (s *Service) addIndexer(indexer domain.Indexer) error {
 	return nil
 }
 
-func (s *Service) updateIndexer(indexer domain.Indexer) error {
+func (s *Service) updateIndexer(indexer *domain.Indexer) error {
 	indexerDefinition, err := s.updateMapIndexer(indexer)
 	if err != nil {
 		return err
@@ -492,10 +471,6 @@ func (s *Service) updateIndexer(indexer domain.Indexer) error {
 				s.log.Error().Stack().Err(err).Str("indexer", indexer.Identifier).Msg("indexer.updateIndexer: could not init indexer api client")
 			}
 		}
-
-	// handle feeds
-	case domain.IndexerImplementationRSS, domain.IndexerImplementationTorznab, domain.IndexerImplementationNewznab:
-		s.feedIndexers[indexer.Identifier] = indexerDefinition
 	}
 
 	s.mappedDefinitions[indexer.Identifier] = indexerDefinition
@@ -744,17 +719,6 @@ func (s *Service) GetMappedDefinitionByName(name string) (*domain.IndexerDefinit
 	return v, true
 }
 
-func (s *Service) stopFeed(indexer string) {
-	_, ok := s.feedIndexers[indexer]
-	if !ok {
-		return
-	}
-
-	if err := s.scheduler.RemoveJobByIdentifier(indexer); err != nil {
-		return
-	}
-}
-
 func (s *Service) TestApi(ctx context.Context, req domain.IndexerTestApiRequest) error {
 	indexer, err := s.FindByID(ctx, req.IndexerId)
 	if err != nil {
@@ -804,16 +768,19 @@ func (s *Service) ToggleEnabled(ctx context.Context, indexerID int, enabled bool
 		return err
 	}
 
+	changed := indexer.Enabled != enabled
 	indexer.Enabled = enabled
 
 	// update indexerInstances
-	if err := s.updateIndexer(*indexer); err != nil {
+	if err := s.updateIndexer(indexer); err != nil {
 		s.log.Error().Err(err).Str("indexer", indexer.Name).Msg("failed to update indexer")
 		return err
 	}
 
-	if indexer.ImplementationIsFeed() && !enabled {
-		s.stopFeed(indexer.Identifier)
+	// feed jobs are stopped and started by the feed service via event because the feed service
+	// can't be imported here
+	if indexer.ImplementationIsFeed() && changed {
+		s.bus.Publish(domain.EventIndexerToggleEnabled, indexer)
 	}
 
 	s.log.Debug().Str("indexer", indexer.Name).Int("indexer_id", indexerID).Bool("enabled", enabled).Msg("indexer.toggleEnabled: update indexer state")

--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -127,6 +127,18 @@ func (s *Service) Update(ctx context.Context, indexer *domain.Indexer) error {
 		indexer.Settings[key] = sanitize.String(val)
 	}
 
+	// settings are persisted wholesale, so an update that omits a saved credential would
+	// silently delete it; require the client to echo it back, redacted or not
+	for key, val := range currentIndexer.Settings {
+		if val == "" || !domain.IsSecretIndexerSetting(key) {
+			continue
+		}
+
+		if _, ok := indexer.Settings[key]; !ok {
+			return errors.New("update omits saved secret setting '%s'", key)
+		}
+	}
+
 	// only IRC indexers have baseURL set
 	if indexer.Implementation == domain.IndexerImplementationIRC {
 		if indexer.BaseURL == "" {

--- a/internal/indexer/service_test.go
+++ b/internal/indexer/service_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package indexer
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/autobrr/autobrr/internal/domain"
+
+	"github.com/asaskevich/EventBus"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubIndexerRepo struct {
+	current *domain.Indexer
+	updated *domain.Indexer
+}
+
+func (r *stubIndexerRepo) Store(_ context.Context, indexer domain.Indexer) (*domain.Indexer, error) {
+	return &indexer, nil
+}
+
+func (r *stubIndexerRepo) Update(_ context.Context, indexer *domain.Indexer) error {
+	r.updated = indexer
+	return nil
+}
+
+func (r *stubIndexerRepo) List(_ context.Context) ([]domain.Indexer, error) { return nil, nil }
+
+func (r *stubIndexerRepo) Delete(_ context.Context, _ int) error { return nil }
+
+func (r *stubIndexerRepo) FindByFilterID(_ context.Context, _ int) ([]domain.Indexer, error) {
+	return nil, nil
+}
+
+func (r *stubIndexerRepo) FindByID(_ context.Context, _ int) (*domain.Indexer, error) {
+	indexer := *r.current
+	settings := make(map[string]string, len(r.current.Settings))
+	maps.Copy(settings, r.current.Settings)
+	indexer.Settings = settings
+
+	return &indexer, nil
+}
+
+func (r *stubIndexerRepo) GetBy(_ context.Context, _ domain.GetIndexerRequest) (*domain.Indexer, error) {
+	return nil, nil
+}
+
+func (r *stubIndexerRepo) ToggleEnabled(_ context.Context, _ int, _ bool) error { return nil }
+
+func TestServiceUpdate_SecretSettings(t *testing.T) {
+	t.Parallel()
+
+	current := &domain.Indexer{
+		ID:             1,
+		Name:           "Test RSS",
+		Identifier:     "rss-test-rss",
+		Implementation: "rss",
+		Enabled:        true,
+		Settings:       map[string]string{"api_key": "secret123", "host": "https://example.org"},
+	}
+
+	tests := []struct {
+		name        string
+		settings    map[string]string
+		wantErr     string
+		wantUpdated map[string]string
+	}{
+		{
+			name:     "omitting a saved secret is rejected",
+			settings: map[string]string{},
+			wantErr:  "update omits saved secret setting 'api_key'",
+		},
+		{
+			name:     "nil settings are rejected",
+			settings: nil,
+			wantErr:  "update omits saved secret setting 'api_key'",
+		},
+		{
+			name:        "redacted placeholder restores the saved value",
+			settings:    map[string]string{"api_key": domain.RedactedStr, "host": "https://example.org"},
+			wantUpdated: map[string]string{"api_key": "secret123", "host": "https://example.org"},
+		},
+		{
+			name:        "explicit new value replaces the saved one",
+			settings:    map[string]string{"api_key": "rotated", "host": "https://example.org"},
+			wantUpdated: map[string]string{"api_key": "rotated", "host": "https://example.org"},
+		},
+		{
+			name:        "non-secret settings may be omitted",
+			settings:    map[string]string{"api_key": domain.RedactedStr},
+			wantUpdated: map[string]string{"api_key": "secret123"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &stubIndexerRepo{current: current}
+
+			svc := NewService(zerolog.Nop(), nil, EventBus.New(), repo, nil, nil)
+			svc.mappedDefinitions[current.Identifier] = &domain.IndexerDefinition{Identifier: current.Identifier, Implementation: "rss"}
+
+			update := &domain.Indexer{ID: 1, Name: "Test RSS", Identifier: current.Identifier, Implementation: "rss", Enabled: true, Settings: tt.settings}
+
+			err := svc.Update(context.Background(), update)
+
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Nil(t, repo.updated, "a rejected update must not persist")
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, repo.updated)
+			assert.Equal(t, tt.wantUpdated, repo.updated.Settings)
+		})
+	}
+}
+
+func TestServiceUpdate_EmptySavedSecretMayBeOmitted(t *testing.T) {
+	t.Parallel()
+
+	repo := &stubIndexerRepo{current: &domain.Indexer{
+		ID:             1,
+		Name:           "Test RSS",
+		Identifier:     "rss-test-rss",
+		Implementation: "rss",
+		Settings:       map[string]string{"api_key": ""},
+	}}
+
+	svc := NewService(zerolog.Nop(), nil, EventBus.New(), repo, nil, nil)
+	svc.mappedDefinitions["rss-test-rss"] = &domain.IndexerDefinition{Identifier: "rss-test-rss", Implementation: "rss"}
+
+	err := svc.Update(context.Background(), &domain.Indexer{ID: 1, Name: "Test RSS", Identifier: "rss-test-rss", Implementation: "rss", Settings: map[string]string{}})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, repo.updated)
+}

--- a/internal/scheduler/schedule.go
+++ b/internal/scheduler/schedule.go
@@ -8,39 +8,124 @@ import (
 	"time"
 )
 
-// jitteredSchedule runs a job every interval, phase-shifted by a stable per-job offset.
+// catchUpGrace delays the catch-up run of a job that never ran or became overdue while the
+// process was down, so a burst of overdue jobs at startup does not fire before boot settles.
+const catchUpGrace = 10 * time.Second
+
+// maxPinWheel caps the pin wheel: 2 minutes keeps the anchor within ±1 minute of
+// lastRun+interval for every interval while leaving 120 slots, enough to make same-second
+// collisions rare - and a colliding pair only costs two concurrent fetches.
+const maxPinWheel = 2 * time.Minute
+
+// anchoredSchedule runs a job every interval, anchored to the job's last run: the next fire is
+// lastRun+interval instead of an arbitrary phase within the interval, so what the UI reports
+// matches what a user expects from a refresh interval.
 //
-// cron.Every rounds every fire time to the second and reschedules all entries due in a tick from
-// the same timestamp, so jobs registered together with the same interval fire on the same second
-// and stay locked together for the life of the process. The offset spreads them across the
-// interval instead. Each job still runs once per interval, so this costs no freshness.
-type jitteredSchedule struct {
+// Fires are pinned to a stable identifier-derived slot within a wheel that divides the interval,
+// so every fire lands on the same slot. cron reschedules every entry due in a tick from the same
+// timestamp, so jobs sharing an interval that ever collide on a fire second would otherwise stay
+// locked together for the life of the process; distinct pins keep them permanently apart at the
+// cost of shifting the anchor by at most half a wheel.
+type anchoredSchedule struct {
 	interval time.Duration
-	offset   time.Duration
+	first    time.Time
 }
 
-// newJitteredSchedule derives the offset from identifier so a job keeps its slot across restarts.
-func newJitteredSchedule(interval time.Duration, identifier string) jitteredSchedule {
+// newAnchoredSchedule computes the first fire from lastRun; a zero lastRun means the job never
+// ran. Jobs that never ran or are already overdue catch up within a wheel of now instead of
+// waiting up to a full interval.
+func newAnchoredSchedule(interval time.Duration, lastRun time.Time, now time.Time, identifier string) anchoredSchedule {
 	if interval < time.Second {
 		interval = time.Second
 	}
 
-	// whole seconds only, to match cron.Every
+	// whole seconds only, cron fires are second-resolution
 	interval -= interval % time.Second
 
-	h := fnv.New32a()
-	h.Write([]byte(identifier))
+	now = now.Truncate(time.Second)
 
-	seconds := uint64(interval / time.Second)
+	var wheel, pin time.Duration
+	if interval%time.Minute == 0 {
+		wheel = pinWheel(interval)
 
-	return jitteredSchedule{
-		interval: interval,
-		offset:   time.Duration(uint64(h.Sum32())%seconds) * time.Second,
+		h := fnv.New32a()
+		h.Write([]byte(identifier))
+		pin = time.Duration(uint64(h.Sum32())%uint64(wheel/time.Second)) * time.Second
 	}
+
+	if lastRun.After(now) {
+		lastRun = now
+	}
+
+	if !lastRun.IsZero() {
+		first := pinNearest(lastRun.Truncate(time.Second), wheel, pin).Add(interval)
+
+		// the margin keeps a fire due at registration from being computed as already
+		// past once cron picks the entry up, which would skip a whole interval
+		if first.After(now.Add(time.Second)) {
+			return anchoredSchedule{interval: interval, first: first}
+		}
+	}
+
+	return anchoredSchedule{interval: interval, first: pinAfter(now.Add(catchUpGrace), wheel, pin)}
 }
 
-func (s jitteredSchedule) Next(t time.Time) time.Time {
-	next := t.Truncate(s.interval).Add(s.offset)
+// pinWheel returns the largest whole-minute divisor of interval capped at maxPinWheel, the
+// largest pin space in which every fire of the interval still lands on the same pin.
+func pinWheel(interval time.Duration) time.Duration {
+	minutes := interval / time.Minute
+
+	for d := maxPinWheel / time.Minute; d > 1; d-- {
+		if minutes%d == 0 {
+			return d * time.Minute
+		}
+	}
+
+	return time.Minute
+}
+
+// pinNearest returns the time closest to t that sits on pin within the wheel, at most half a
+// wheel away.
+func pinNearest(t time.Time, wheel, pin time.Duration) time.Time {
+	if wheel == 0 {
+		return t
+	}
+
+	pinned := t.Truncate(wheel).Add(pin)
+
+	if d := pinned.Sub(t); d > wheel/2 {
+		return pinned.Add(-wheel)
+	} else if d <= -wheel/2 {
+		return pinned.Add(wheel)
+	}
+
+	return pinned
+}
+
+// pinAfter returns the first time strictly after t that sits on pin within the wheel.
+func pinAfter(t time.Time, wheel, pin time.Duration) time.Time {
+	if wheel == 0 {
+		return t
+	}
+
+	pinned := t.Truncate(wheel).Add(pin)
+
+	for !pinned.After(t) {
+		pinned = pinned.Add(wheel)
+	}
+
+	return pinned
+}
+
+// Next returns the first grid point first+k*interval strictly after t, so a delayed wake skips
+// forward on the fixed grid instead of drifting the phase.
+func (s anchoredSchedule) Next(t time.Time) time.Time {
+	if s.first.After(t) {
+		return s.first
+	}
+
+	elapsed := t.Sub(s.first)
+	next := s.first.Add(elapsed - elapsed%s.interval)
 
 	for !next.After(t) {
 		next = next.Add(s.interval)

--- a/internal/scheduler/schedule_test.go
+++ b/internal/scheduler/schedule_test.go
@@ -8,63 +8,116 @@ import (
 	"testing"
 	"time"
 
-	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJitteredSchedule_Next(t *testing.T) {
+func TestAnchoredSchedule_Next(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2025, time.November, 28, 14, 42, 13, 500_000_000, time.UTC)
 
-	t.Run("returns a time after now", func(t *testing.T) {
+	t.Run("first run is lastRun plus interval", func(t *testing.T) {
 		t.Parallel()
 
-		for i := 0; i < 100; i++ {
-			schedule := newJitteredSchedule(15*time.Minute, fmt.Sprintf("feed-%d", i))
-			assert.True(t, schedule.Next(now).After(now), "next run must be in the future")
+		lastRun := now.Add(-5 * time.Minute)
+
+		for i := range 100 {
+			schedule := newAnchoredSchedule(15*time.Minute, lastRun, now, fmt.Sprintf("feed-%d", i))
+
+			next := schedule.Next(now)
+			assert.True(t, next.After(now), "next run must be in the future")
+			// the pin may shift the anchor by up to half a wheel
+			assert.WithinDuration(t, lastRun.Add(15*time.Minute), next, pinWheel(15*time.Minute)/2)
 		}
 	})
 
 	t.Run("keeps the interval between runs", func(t *testing.T) {
 		t.Parallel()
 
-		schedule := newJitteredSchedule(15*time.Minute, "feed-1")
+		schedule := newAnchoredSchedule(15*time.Minute, now.Add(-5*time.Minute), now, "feed-1")
 
 		next := schedule.Next(now)
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			following := schedule.Next(next)
 			assert.Equal(t, 15*time.Minute, following.Sub(next))
 			next = following
 		}
 	})
 
-	t.Run("offset stays within the interval", func(t *testing.T) {
+	t.Run("recovers cadence after a delayed wake", func(t *testing.T) {
 		t.Parallel()
 
-		for i := 0; i < 100; i++ {
-			schedule := newJitteredSchedule(15*time.Minute, fmt.Sprintf("feed-%d", i))
-			assert.GreaterOrEqual(t, schedule.offset, time.Duration(0))
-			assert.Less(t, schedule.offset, 15*time.Minute)
-			assert.LessOrEqual(t, schedule.Next(now).Sub(now), 15*time.Minute)
+		schedule := newAnchoredSchedule(15*time.Minute, now.Add(-5*time.Minute), now, "feed-1")
+
+		next := schedule.Next(now)
+		following := schedule.Next(next.Add(90 * time.Second))
+		assert.Equal(t, 15*time.Minute, following.Sub(next), "late wake must stay on the grid, not shift the phase")
+	})
+
+	t.Run("job that never ran catches up within a wheel", func(t *testing.T) {
+		t.Parallel()
+
+		for i := range 100 {
+			schedule := newAnchoredSchedule(720*time.Minute, time.Time{}, now, fmt.Sprintf("feed-%d", i))
+
+			next := schedule.Next(now)
+			assert.True(t, next.After(now.Add(catchUpGrace)))
+			assert.LessOrEqual(t, next.Sub(now), catchUpGrace+maxPinWheel, "catch-up must not wait a full interval")
 		}
+	})
+
+	t.Run("overdue job catches up within a wheel", func(t *testing.T) {
+		t.Parallel()
+
+		lastRun := now.Add(-13 * time.Hour)
+		schedule := newAnchoredSchedule(720*time.Minute, lastRun, now, "feed-1")
+
+		next := schedule.Next(now)
+		assert.True(t, next.After(now))
+		assert.LessOrEqual(t, next.Sub(now), catchUpGrace+maxPinWheel)
+
+		assert.Equal(t, 720*time.Minute, schedule.Next(next).Sub(next), "interval resumes from the catch-up run")
+	})
+
+	t.Run("lastRun in the future is clamped to now", func(t *testing.T) {
+		t.Parallel()
+
+		schedule := newAnchoredSchedule(15*time.Minute, now.Add(24*time.Hour), now, "feed-1")
+
+		next := schedule.Next(now)
+		assert.True(t, next.After(now))
+		assert.WithinDuration(t, now.Add(15*time.Minute), next, pinWheel(15*time.Minute)/2)
 	})
 
 	t.Run("is stable for the same identifier", func(t *testing.T) {
 		t.Parallel()
 
-		a := newJitteredSchedule(15*time.Minute, "feed-7")
-		b := newJitteredSchedule(15*time.Minute, "feed-7")
+		lastRun := now.Add(-5 * time.Minute)
 
-		assert.Equal(t, a.offset, b.offset)
+		a := newAnchoredSchedule(15*time.Minute, lastRun, now, "feed-7")
+		b := newAnchoredSchedule(15*time.Minute, lastRun, now, "feed-7")
+
+		assert.Equal(t, a.first, b.first)
 		assert.Equal(t, a.Next(now), b.Next(now))
+	})
+
+	t.Run("restart re-anchors to the same phase", func(t *testing.T) {
+		t.Parallel()
+
+		schedule := newAnchoredSchedule(720*time.Minute, now.Add(-5*time.Hour), now, "feed-7")
+		fireAt := schedule.Next(now)
+
+		// process restarts a while after the fire; last_run was written seconds into the run
+		rescheduled := newAnchoredSchedule(720*time.Minute, fireAt.Add(4*time.Second), fireAt.Add(2*time.Hour), "feed-7")
+
+		assert.Equal(t, fireAt.Add(720*time.Minute), rescheduled.Next(fireAt.Add(2*time.Hour)))
 	})
 
 	t.Run("clamps intervals below a second", func(t *testing.T) {
 		t.Parallel()
 
 		for _, interval := range []time.Duration{0, -time.Minute, 500 * time.Millisecond} {
-			schedule := newJitteredSchedule(interval, "feed-1")
+			schedule := newAnchoredSchedule(interval, time.Time{}, now, "feed-1")
 
 			assert.Equal(t, time.Second, schedule.interval)
 			assert.True(t, schedule.Next(now).After(now))
@@ -74,17 +127,41 @@ func TestJitteredSchedule_Next(t *testing.T) {
 	t.Run("truncates sub-second intervals to whole seconds", func(t *testing.T) {
 		t.Parallel()
 
-		schedule := newJitteredSchedule(90*time.Second+400*time.Millisecond, "feed-1")
+		schedule := newAnchoredSchedule(90*time.Second+400*time.Millisecond, time.Time{}, now, "feed-1")
 
 		assert.Equal(t, 90*time.Second, schedule.interval)
 		assert.Zero(t, schedule.Next(now).Nanosecond())
 	})
 }
 
-// Feeds sharing an interval must not fire on the same second. cron.Every reschedules every entry
-// due in a tick from the same timestamp, so without a per-feed offset they stay locked together
-// for the life of the process.
-func TestJitteredSchedule_SpreadsFeedsSharingAnInterval(t *testing.T) {
+func TestPinWheel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		interval time.Duration
+		wheel    time.Duration
+	}{
+		{time.Minute, time.Minute},
+		{5 * time.Minute, time.Minute},
+		{15 * time.Minute, time.Minute},
+		{30 * time.Minute, 2 * time.Minute},
+		{60 * time.Minute, 2 * time.Minute},
+		{720 * time.Minute, 2 * time.Minute},
+		{7 * time.Minute, time.Minute},
+		{13 * time.Minute, time.Minute},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.wheel, pinWheel(tt.interval), "interval %s", tt.interval)
+		assert.Zero(t, tt.interval%pinWheel(tt.interval), "wheel must divide the interval so the pin survives every run")
+	}
+}
+
+// Feeds sharing an interval must not fire on the same second: cron reschedules every entry due in
+// a tick from the same timestamp, so entries that collide once would stay locked together for the
+// life of the process. The identifier-derived pin keeps them apart, even when their last runs
+// coincide and even after a delayed wake that makes several feeds due in the same tick.
+func TestAnchoredSchedule_SpreadsFeedsSharingAnInterval(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -93,21 +170,48 @@ func TestJitteredSchedule_SpreadsFeedsSharingAnInterval(t *testing.T) {
 	)
 
 	now := time.Date(2025, time.November, 28, 14, 42, 13, 0, time.UTC)
+	lastRun := now.Add(-3 * time.Minute)
 
-	constant := make(map[time.Time]int)
-	jittered := make(map[time.Time]int)
+	fires := make(map[time.Time]int)
+	afterMergedWake := make(map[time.Time]int)
 
-	for i := 0; i < feeds; i++ {
-		identifier := fmt.Sprintf("feed-%d", i)
+	for i := range feeds {
+		schedule := newAnchoredSchedule(interval, lastRun, now, fmt.Sprintf("feed-%d", i))
 
-		constant[cron.Every(interval).Next(now)]++
-		jittered[newJitteredSchedule(interval, identifier).Next(now)]++
+		fires[schedule.Next(now)]++
+
+		// a delayed wake shared by every feed must not merge the fire times afterwards
+		afterMergedWake[schedule.Next(now.Add(interval+time.Minute))]++
 	}
 
-	assert.Len(t, constant, 1, "cron.Every fires every feed on the same second")
-	assert.Greater(t, len(jittered), feeds/2, "jittered feeds should be spread across the interval")
+	for _, m := range []map[time.Time]int{fires, afterMergedWake} {
+		assert.Greater(t, len(m), feeds/2, "fires should be spread across distinct seconds")
 
-	for fireTime, count := range jittered {
-		assert.LessOrEqual(t, count, 3, "too many feeds landed on %s", fireTime)
+		for fireTime, count := range m {
+			assert.LessOrEqual(t, count, 3, "too many feeds landed on %s", fireTime)
+		}
+	}
+}
+
+// Overdue feeds at boot all catch up from the same moment; their pins must still spread them.
+func TestAnchoredSchedule_SpreadsOverdueFeedsAtBoot(t *testing.T) {
+	t.Parallel()
+
+	const feeds = 30
+
+	now := time.Date(2025, time.November, 28, 14, 42, 13, 0, time.UTC)
+	lastRun := now.Add(-13 * time.Hour)
+
+	fires := make(map[time.Time]int)
+
+	for i := range feeds {
+		schedule := newAnchoredSchedule(720*time.Minute, lastRun, now, fmt.Sprintf("feed-%d", i))
+		fires[schedule.Next(now)]++
+	}
+
+	assert.Greater(t, len(fires), feeds*3/4, "catch-up fires should be spread across the wheel")
+
+	for fireTime, count := range fires {
+		assert.LessOrEqual(t, count, 2, "too many feeds landed on %s", fireTime)
 	}
 }

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -89,55 +89,59 @@ func (s *Service) addAppJobs() {
 func (s *Service) Stop() {
 	s.log.Debug().Msg("scheduler.Stop")
 	s.cron.Stop()
-	return
+}
+
+// registerJob replaces any entry already registered under identifier while holding the lock, so
+// concurrent (re)schedules of the same job cannot leave an orphaned entry firing alongside the
+// new one.
+func (s *Service) registerJob(identifier string, schedule cron.Schedule, job cron.Job) int {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if old, ok := s.jobs[identifier]; ok {
+		s.cron.Remove(old)
+	}
+
+	id := s.cron.Schedule(schedule, cron.NewChain(cron.SkipIfStillRunning(cron.DiscardLogger)).Then(job))
+	s.jobs[identifier] = id
+
+	return int(id)
 }
 
 // ScheduleJob takes a time duration and adds a job
 func (s *Service) ScheduleJob(job cron.Job, interval time.Duration, identifier string) (int, error) {
-	id := s.cron.Schedule(cron.Every(interval), cron.NewChain(cron.SkipIfStillRunning(cron.DiscardLogger)).Then(job))
+	id := s.registerJob(identifier, cron.Every(interval), job)
 
-	s.log.Debug().Str("job", identifier).Int("job_id", int(id)).Msg("job scheduled")
+	s.log.Debug().Str("job", identifier).Int("job_id", id).Msg("job scheduled")
 
-	s.m.Lock()
-	// add to job map
-	s.jobs[identifier] = id
-	s.m.Unlock()
-
-	return int(id), nil
+	return id, nil
 }
 
-// ScheduleJobJittered takes a time duration and adds a job, spreading jobs that share an interval
-// across it so they do not all fire on the same second.
-func (s *Service) ScheduleJobJittered(job cron.Job, interval time.Duration, identifier string) (int, error) {
-	schedule := newJitteredSchedule(interval, identifier)
+// ScheduleJobAnchored adds a job that runs every interval anchored to its last run: the next fire
+// is lastRun+interval, or shortly after now when the job never ran or is overdue. Jobs sharing an
+// interval fire on distinct identifier-derived seconds so they do not run in lockstep.
+func (s *Service) ScheduleJobAnchored(job cron.Job, interval time.Duration, lastRun time.Time, identifier string) (int, error) {
+	schedule := newAnchoredSchedule(interval, lastRun, time.Now(), identifier)
 
-	id := s.cron.Schedule(schedule, cron.NewChain(cron.SkipIfStillRunning(cron.DiscardLogger)).Then(job))
+	id := s.registerJob(identifier, schedule, job)
 
-	s.log.Debug().Str("identifier", identifier).Int("entry_id", int(id)).Dur("interval", schedule.interval).Dur("offset", schedule.offset).Msg("scheduler.ScheduleJobJittered: job successfully added")
+	s.log.Debug().Str("job", identifier).Int("job_id", id).Dur("interval", schedule.interval).Time("first_run", schedule.first).Msg("job scheduled anchored")
 
-	s.m.Lock()
-	s.jobs[identifier] = id
-	s.m.Unlock()
-
-	return int(id), nil
+	return id, nil
 }
 
 // AddJob takes a cron schedule and adds a job
 func (s *Service) AddJob(job cron.Job, spec string, identifier string) (int, error) {
-	id, err := s.cron.AddJob(spec, cron.NewChain(cron.SkipIfStillRunning(cron.DiscardLogger)).Then(job))
-
+	schedule, err := cron.ParseStandard(spec)
 	if err != nil {
-		return 0, errors.Wrap(err, "could not add job to cron")
+		return 0, errors.Wrap(err, "could not parse cron spec: %s", spec)
 	}
 
-	s.log.Debug().Str("job", identifier).Int("job_id", int(id)).Msg("job added")
+	id := s.registerJob(identifier, schedule, job)
 
-	s.m.Lock()
-	// add to job map
-	s.jobs[identifier] = id
-	s.m.Unlock()
+	s.log.Debug().Str("job", identifier).Int("job_id", id).Msg("job added")
 
-	return int(id), nil
+	return id, nil
 }
 
 func (s *Service) RemoveJobByIdentifier(id string) error {


### PR DESCRIPTION
# Description

Feeds with long refresh intervals showed "next run" times that had nothing to do with their interval (reported on Discord: four feeds at 720 min showing next runs in 2-9 hours right after a run). Root cause: the v1.83.0 jitter (#2271) phase-anchored every feed at a hash-derived offset spread across the *entire* interval, decoupling next run from last run; the offset is a stable hash, so restarts and cache clears changed nothing.

**Scheduling fix**

* New `anchoredSchedule` replaces `jitteredSchedule`: next run = `last_run + interval`, surviving restarts (re-anchored from the DB)
* Feeds that never ran or became overdue while the app was down catch up shortly after startup instead of waiting up to a full interval
* Fires stay pinned to a per-feed slot inside a small "pin wheel" (largest whole-minute divisor of the interval, capped at 2 min), so same-interval feeds can never lock onto the same fire second - the problem #2271 solved - while next run stays within +-1 min of `last_run + interval`
* Force run now reschedules the job, so the next scheduled run is a full interval from the manual run
* `last_run` is now scanned in `FeedRepo.FindOne`/`FindByID` (previously only `Find`), so all scheduling paths see it

**Related fixes that surfaced during review**

* Disabling a feed-backed indexer never stopped its feed job: `stopFeed` passed the indexer identifier but jobs are keyed `feed-<feedID>` (broken since #1073), and re-enabling never restarted it. Now wired via a new `EventIndexerToggleEnabled` event handled by the feed service; `Feed.IndexerEnabled` (scanned from `i.enabled`) also keeps boot from starting jobs for feeds of disabled indexers
* Every job start/stop decision now goes through `syncFeedJob`, a per-feed-serialized reconciler that re-reads persisted state (`feed.Enabled && indexer.enabled`) before acting: racing opposite toggles previously could persist enabled while a stale event or pre-write snapshot stopped the job, leaving "enabled" feeds silently unscheduled. Toggle events carry no authority and are always published
* Scheduler `registerJob` replaces same-identifier entries under the lock: racing feed enable/update can no longer leave a duplicated cron entry firing twice per interval, and a job is never removed before its replacement is registered
* Per-feed run guard: a force run and a scheduled run of the same feed can no longer fetch/process concurrently (`SkipIfStillRunning` only ever covered a single cron entry, not the separate job instance a force run builds)
* Cleanup: dead write-only maps removed (`feed.Service.jobs`, `indexer.Service.feedIndexers`), indexer service's unused scheduler dependency dropped, `IndexerRepo.Update` simplified to `(ctx, *domain.Indexer) error` with `updated_at` set by `CURRENT_TIMESTAMP`

**Secret settings hardening (pre-existing, flagged by QA on this PR)**

* Updating an indexer with a payload that omits a saved secret setting silently deleted the credential (settings are persisted wholesale): `Update` now rejects with a validation error naming the key; clearing via empty string still works
* The secret-key set moved out of `Indexer.MarshalJSON` into `domain.IsSecretIndexerSetting`, shared by response redaction and update validation so they cannot drift
* Definitions audit: `userId` (DasUnerwartete) was missing from the redaction set and returned unredacted; `torrent_pass` (Orpheus, PhoenixProject) and `uid` (Fuzer) were typed `text` and leaked values in definition responses - all `secret` now

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor / maintenance (no functional change)

## How has this been tested?

* Rewritten `internal/scheduler/schedule_test.go`: anchoring to last run, catch-up for never-run/overdue feeds, exact cadence through delayed wakes, pin-wheel divisor properties, spread/no-lockstep with shared last runs (steady state and overdue-at-boot)
* New `internal/indexer/service_test.go`: update rejects omitted saved secrets, restores redacted placeholders, allows rotation and empty/non-secret omission
* New `TestIndexerYamlSecretSettings`: enforces secret-type/redaction-set agreement across all 115 definitions, both directions
* `go test ./...` (non-integration) passes; `go test -race` clean on `internal/feed`, `internal/scheduler`, `internal/indexer`
* `FeedRepo` integration tests pass on both SQLite and PostgreSQL (Docker)
* Multi-agent adversarial review passes over the diff (schedule math swept across ~40k input combinations, cron v3 internals, lock ordering, event-bus semantics); two Ito QA findings (toggle race, secret-setting loss) reproduced, fixed, and covered by the new tests

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed