### PR TITLE
fix(http): improve bad request and not found handling

### DIFF
--- a/internal/action/service.go
+++ b/internal/action/service.go
@@ -17,6 +17,7 @@ import (
 
 type actionRepo interface {
 	Store(ctx context.Context, action *domain.Action) error
+	Update(ctx context.Context, action domain.Action) (*domain.Action, error)
 	StoreFilterActions(ctx context.Context, filterID int64, actions []*domain.Action) ([]*domain.Action, error)
 	FindByFilterID(ctx context.Context, filterID int, active *bool, withClient bool) ([]*domain.Action, error)
 	List(ctx context.Context) ([]domain.Action, error)
@@ -65,6 +66,10 @@ func NewService(log zerolog.Logger, repo actionRepo, clientSvc clientService, do
 
 func (s *Service) Store(ctx context.Context, action *domain.Action) error {
 	return s.repo.Store(ctx, action)
+}
+
+func (s *Service) Update(ctx context.Context, action *domain.Action) (*domain.Action, error) {
+	return s.repo.Update(ctx, *action)
 }
 
 func (s *Service) StoreFilterActions(ctx context.Context, filterID int64, actions []*domain.Action) ([]*domain.Action, error) {

--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -683,9 +683,15 @@ func (r *ActionRepo) Delete(ctx context.Context, req *domain.DeleteActionRequest
 		return errors.Wrap(err, "error building query")
 	}
 
-	_, err = r.db.Handler.ExecContext(ctx, query, args...)
+	result, err := r.db.Handler.ExecContext(ctx, query, args...)
 	if err != nil {
 		return errors.Wrap(err, "error executing query")
+	}
+
+	if rowsAffected, err := result.RowsAffected(); err != nil {
+		return errors.Wrap(err, "error getting rows affected")
+	} else if rowsAffected == 0 {
+		return domain.ErrRecordNotFound
 	}
 
 	r.log.Debug().Int("action_id", req.ActionId).Msg("action delete")

--- a/internal/database/action.go
+++ b/internal/database/action.go
@@ -851,8 +851,15 @@ func (r *ActionRepo) Update(ctx context.Context, action domain.Action) (*domain.
 		return nil, errors.Wrap(err, "error building query")
 	}
 
-	if _, err := r.db.Handler.ExecContext(ctx, query, args...); err != nil {
+	result, err := r.db.Handler.ExecContext(ctx, query, args...)
+	if err != nil {
 		return nil, errors.Wrap(err, "error executing query")
+	}
+
+	if rowsAffected, err := result.RowsAffected(); err != nil {
+		return nil, errors.Wrap(err, "error getting rows affected")
+	} else if rowsAffected == 0 {
+		return nil, domain.ErrRecordNotFound
 	}
 
 	r.log.Debug().Int("action_id", action.ID).Msg("action update")
@@ -869,8 +876,6 @@ func (r *ActionRepo) StoreFilterActions(ctx context.Context, filterID int64, act
 	defer tx.Rollback()
 
 	for _, action := range actions {
-		action := action
-
 		if action.ID > 0 {
 			queryBuilder := r.db.squirrel.
 				Update("action").

--- a/internal/domain/error.go
+++ b/internal/domain/error.go
@@ -16,5 +16,6 @@ var (
 	ErrNoActiveFiltersFoundForIndexer = errors.New("no active filters found for indexer")
 	ErrUnexpectedLine                 = errors.New("unexpected line")
 	ErrIndexerNotFound                = errors.New("indexer not found")
+	ErrNotificationNotFound           = errors.New("notification not found")
 	ErrIRCNetworkHandlerNotFound      = errors.New("could not find network handler")
 )

--- a/internal/download_client/service.go
+++ b/internal/download_client/service.go
@@ -75,9 +75,9 @@ func (s *Service) List(ctx context.Context) ([]domain.DownloadClient, error) {
 }
 
 func (s *Service) FindByID(ctx context.Context, id int32) (*domain.DownloadClient, error) {
-	client := s.cache.Get(id)
-	if client != nil {
-		return client, nil
+	cachedClient := s.cache.Get(id)
+	if cachedClient != nil {
+		return cachedClient, nil
 	}
 
 	s.log.Trace().Int32("client_id", id).Msg("cache miss for client, continue to repo lookup")
@@ -236,6 +236,12 @@ func (s *Service) Update(ctx context.Context, client *domain.DownloadClient) err
 }
 
 func (s *Service) Delete(ctx context.Context, clientID int32) error {
+	_, err := s.FindByID(ctx, clientID)
+	if err != nil {
+		s.log.Error().Err(err).Int32("client_id", clientID).Msg("could not find download client")
+		return err
+	}
+
 	if err := s.repo.Delete(ctx, clientID); err != nil {
 		s.log.Error().Err(err).Int32("client_id", clientID).Msg("could not delete download client")
 		return err

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -283,7 +283,7 @@ func (s *Service) delete(ctx context.Context, feedID int) error {
 		s.log.Error().Err(err).Str("feed", f.Name).Msg("error deleting feed cache")
 	}
 
-	s.guards.Delete(id)
+	s.guards.Delete(feedID)
 
 	return nil
 }
@@ -304,7 +304,7 @@ func (s *Service) toggleEnabled(ctx context.Context, feedID int, enabled bool) e
 		s.log.Debug().Str("feed", f.Name).Bool("enabled", enabled).Msg("feed toggled")
 	}
 
-	return s.syncFeedJob(ctx, id)
+	return s.syncFeedJob(ctx, feedID)
 }
 
 func (s *Service) test(ctx context.Context, feed *domain.Feed) error {

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -22,9 +22,9 @@ import (
 
 type feedRepo interface {
 	FindOne(ctx context.Context, params domain.FindOneParams) (*domain.Feed, error)
-	FindByID(ctx context.Context, id int) (*domain.Feed, error)
+	FindByID(ctx context.Context, feedID int) (*domain.Feed, error)
 	Find(ctx context.Context) ([]domain.Feed, error)
-	GetLastRunDataByID(ctx context.Context, id int) (string, error)
+	GetLastRunDataByID(ctx context.Context, feedID int) (string, error)
 	Store(ctx context.Context, feed *domain.Feed) error
 	Update(ctx context.Context, feed *domain.Feed) error
 	UpdateLastRun(ctx context.Context, feedID int) error
@@ -111,8 +111,8 @@ func (s *Service) FindOne(ctx context.Context, params domain.FindOneParams) (*do
 	return s.repo.FindOne(ctx, params)
 }
 
-func (s *Service) FindByID(ctx context.Context, id int) (*domain.Feed, error) {
-	return s.repo.FindByID(ctx, id)
+func (s *Service) FindByID(ctx context.Context, feedID int) (*domain.Feed, error) {
+	return s.repo.FindByID(ctx, feedID)
 }
 
 func (s *Service) Find(ctx context.Context) ([]domain.Feed, error) {
@@ -133,8 +133,8 @@ func (s *Service) Find(ctx context.Context) ([]domain.Feed, error) {
 	return feeds, nil
 }
 
-func (s *Service) GetCacheByID(ctx context.Context, feedId int) ([]domain.FeedCacheItem, error) {
-	return s.cacheRepo.GetByFeed(ctx, feedId)
+func (s *Service) GetCacheByID(ctx context.Context, feedID int) ([]domain.FeedCacheItem, error) {
+	return s.cacheRepo.GetByFeed(ctx, feedID)
 }
 
 func (s *Service) Store(ctx context.Context, feed *domain.Feed) error {
@@ -149,20 +149,28 @@ func (s *Service) Update(ctx context.Context, feed *domain.Feed) error {
 	return s.update(ctx, feed)
 }
 
-func (s *Service) Delete(ctx context.Context, id int) error {
-	return s.delete(ctx, id)
+func (s *Service) Delete(ctx context.Context, feedID int) error {
+	return s.delete(ctx, feedID)
 }
 
-func (s *Service) DeleteFeedCache(ctx context.Context, id int) error {
-	return s.cacheRepo.DeleteByFeed(ctx, id)
+func (s *Service) DeleteFeedCache(ctx context.Context, feedCacheID int) error {
+	if _, err := s.repo.FindByID(ctx, feedCacheID); err != nil {
+		return err
+	}
+
+	if err := s.cacheRepo.DeleteByFeed(ctx, feedCacheID); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *Service) DeleteFeedCacheStale(ctx context.Context) error {
 	return s.cacheRepo.DeleteStale(ctx)
 }
 
-func (s *Service) ToggleEnabled(ctx context.Context, id int, enabled bool) error {
-	return s.toggleEnabled(ctx, id, enabled)
+func (s *Service) ToggleEnabled(ctx context.Context, feedID int, enabled bool) error {
+	return s.toggleEnabled(ctx, feedID, enabled)
 }
 
 func (s *Service) Test(ctx context.Context, feed *domain.Feed) error {
@@ -211,8 +219,8 @@ func (s *Service) update(ctx context.Context, feed *domain.Feed) error {
 	return nil
 }
 
-func (s *Service) delete(ctx context.Context, id int) error {
-	f, err := s.repo.FindOne(ctx, domain.FindOneParams{FeedID: id})
+func (s *Service) delete(ctx context.Context, feedID int) error {
+	f, err := s.repo.FindOne(ctx, domain.FindOneParams{FeedID: feedID})
 	if err != nil {
 		s.log.Error().Err(err).Msg("error finding feed")
 		return err
@@ -232,21 +240,21 @@ func (s *Service) delete(ctx context.Context, id int) error {
 	}
 
 	// if foreign keys are not enforced in SQLite clear feed cache explicitly
-	if err := s.cacheRepo.DeleteByFeed(ctx, id); err != nil {
+	if err := s.cacheRepo.DeleteByFeed(ctx, feedID); err != nil {
 		s.log.Error().Err(err).Str("feed", f.Name).Msg("error deleting feed cache")
 	}
 
 	return nil
 }
 
-func (s *Service) toggleEnabled(ctx context.Context, id int, enabled bool) error {
-	f, err := s.repo.FindOne(ctx, domain.FindOneParams{FeedID: id})
+func (s *Service) toggleEnabled(ctx context.Context, feedID int, enabled bool) error {
+	f, err := s.repo.FindOne(ctx, domain.FindOneParams{FeedID: feedID})
 	if err != nil {
 		s.log.Error().Err(err).Msg("error finding feed")
 		return err
 	}
 
-	if err := s.repo.ToggleEnabled(ctx, id, enabled); err != nil {
+	if err := s.repo.ToggleEnabled(ctx, feedID, enabled); err != nil {
 		s.log.Error().Err(err).Msg("error feed toggle enabled")
 		return err
 	}

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -219,7 +219,7 @@ func (s *Service) Store(ctx context.Context, filter *domain.Filter) error {
 		return err
 	}
 
-	if filter.AnnounceTypes == nil || len(filter.AnnounceTypes) == 0 {
+	if len(filter.AnnounceTypes) == 0 {
 		filter.AnnounceTypes = []string{string(domain.AnnounceTypeNew)}
 	}
 
@@ -232,15 +232,18 @@ func (s *Service) Store(ctx context.Context, filter *domain.Filter) error {
 }
 
 func (s *Service) Update(ctx context.Context, filter *domain.Filter) error {
-	err := filter.Validate()
-	if err != nil {
+	if err := filter.Validate(); err != nil {
 		s.log.Error().Err(err).Interface("filter_data", filter).Msg("validation error")
 		return err
 	}
 
-	err = filter.Sanitize()
-	if err != nil {
+	if err := filter.Sanitize(); err != nil {
 		s.log.Error().Err(err).Interface("filter_data", filter).Msg("could not sanitize filter")
+		return err
+	}
+
+	if _, err := s.repo.FindByID(ctx, filter.ID); err != nil {
+		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not find filter")
 		return err
 	}
 
@@ -249,28 +252,20 @@ func (s *Service) Update(ctx context.Context, filter *domain.Filter) error {
 		return err
 	}
 
-	if _, err := s.FindByID(ctx, filter.ID); err != nil {
-		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not find filter")
-		return err
-	}
-
 	// update
-	err = s.repo.Update(ctx, filter)
-	if err != nil {
+	if err := s.repo.Update(ctx, filter); err != nil {
 		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not update filter")
 		return err
 	}
 
 	// take care of connected indexers
-	err = s.repo.StoreIndexerConnections(ctx, filter.ID, filter.Indexers)
-	if err != nil {
+	if err := s.repo.StoreIndexerConnections(ctx, filter.ID, filter.Indexers); err != nil {
 		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not store filter indexer connections")
 		return err
 	}
 
 	// take care of connected external filters
-	err = s.repo.StoreFilterExternal(ctx, filter.ID, filter.External)
-	if err != nil {
+	if err := s.repo.StoreFilterExternal(ctx, filter.ID, filter.External); err != nil {
 		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not store external filters")
 		return err
 	}
@@ -285,8 +280,7 @@ func (s *Service) Update(ctx context.Context, filter *domain.Filter) error {
 	filter.Actions = actions
 
 	// take care of filter notifications
-	err = s.notificationSvc.StoreFilterNotifications(ctx, filter.ID, filter.Notifications)
-	if err != nil {
+	if err := s.notificationSvc.StoreFilterNotifications(ctx, filter.ID, filter.Notifications); err != nil {
 		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not store filter notifications")
 		return err
 	}
@@ -322,6 +316,16 @@ func (s *Service) validateIndexers(ctx context.Context, indexers []domain.Indexe
 }
 
 func (s *Service) UpdatePartial(ctx context.Context, filter domain.FilterUpdate) error {
+	if _, err := s.repo.FindByID(ctx, filter.ID); err != nil {
+		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not find filter")
+		return err
+	}
+
+	if err := s.validateIndexers(ctx, filter.Indexers); err != nil {
+		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("invalid indexers for filter")
+		return err
+	}
+
 	// cleanup
 	if filter.Shows != nil {
 		// replace newline with comma
@@ -329,18 +333,6 @@ func (s *Service) UpdatePartial(ctx context.Context, filter domain.FilterUpdate)
 		clean = strings.ReplaceAll(clean, ",,", ",")
 
 		filter.Shows = &clean
-	}
-
-	if filter.Indexers != nil {
-		if err := s.validateIndexers(ctx, filter.Indexers); err != nil {
-			s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("invalid indexers for filter")
-			return err
-		}
-	}
-
-	if _, err := s.FindByID(ctx, filter.ID); err != nil {
-		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not find filter")
-		return err
 	}
 
 	// update

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -249,6 +249,11 @@ func (s *Service) Update(ctx context.Context, filter *domain.Filter) error {
 		return err
 	}
 
+	if _, err := s.FindByID(ctx, filter.ID); err != nil {
+		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not find filter")
+		return err
+	}
+
 	// update
 	err = s.repo.Update(ctx, filter)
 	if err != nil {
@@ -333,6 +338,11 @@ func (s *Service) UpdatePartial(ctx context.Context, filter domain.FilterUpdate)
 		}
 	}
 
+	if _, err := s.FindByID(ctx, filter.ID); err != nil {
+		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not find filter")
+		return err
+	}
+
 	// update
 	if err := s.repo.UpdatePartial(ctx, filter); err != nil {
 		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not update partial filter")
@@ -378,6 +388,7 @@ func (s *Service) Duplicate(ctx context.Context, filterID int) (*domain.Filter, 
 	// find filter with actions, indexers and external filters
 	filter, err := s.FindByID(ctx, filterID)
 	if err != nil {
+		s.log.Error().Err(err).Int("filter_id", filterID).Msg("could not find filter")
 		return nil, err
 	}
 
@@ -421,6 +432,12 @@ func (s *Service) Duplicate(ctx context.Context, filterID int) (*domain.Filter, 
 }
 
 func (s *Service) ToggleEnabled(ctx context.Context, filterID int, enabled bool) error {
+	_, err := s.FindByID(ctx, filterID)
+	if err != nil {
+		s.log.Error().Err(err).Int("filter_id", filterID).Msg("could not find filter")
+		return err
+	}
+
 	if err := s.repo.ToggleEnabled(ctx, filterID, enabled); err != nil {
 		s.log.Error().Err(err).Msg("could not update filter enabled")
 		return err
@@ -434,6 +451,12 @@ func (s *Service) ToggleEnabled(ctx context.Context, filterID int, enabled bool)
 func (s *Service) Delete(ctx context.Context, filterID int) error {
 	if filterID == 0 {
 		return nil
+	}
+
+	_, err := s.FindByID(ctx, filterID)
+	if err != nil {
+		s.log.Error().Err(err).Int("filter_id", filterID).Msg("could not find filter")
+		return err
 	}
 
 	// take care of filter actions

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -67,6 +67,8 @@ type downloadService interface {
 }
 
 type notificationService interface {
+	Find(ctx context.Context, params domain.NotificationQueryParams) ([]domain.Notification, int, error)
+
 	GetFilterNotifications(ctx context.Context, filterID int) ([]domain.FilterNotification, error)
 	StoreFilterNotifications(ctx context.Context, filterID int, notifications []domain.FilterNotification) error
 	DeleteFilterNotifications(ctx context.Context, filterID int) error
@@ -252,6 +254,11 @@ func (s *Service) Update(ctx context.Context, filter *domain.Filter) error {
 		return err
 	}
 
+	if err := s.validateNotifications(ctx, filter.Notifications); err != nil {
+		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("invalid notifications for filter")
+		return err
+	}
+
 	// update
 	if err := s.repo.Update(ctx, filter); err != nil {
 		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not update filter")
@@ -315,6 +322,33 @@ func (s *Service) validateIndexers(ctx context.Context, indexers []domain.Indexe
 	return nil
 }
 
+// validateNotifications rejects notifications that do not exist, for the same
+// reason as validateIndexers: without foreign key enforcement unknown ids
+// would be stored as orphaned links and silently never fire.
+func (s *Service) validateNotifications(ctx context.Context, notifications []domain.FilterNotification) error {
+	if len(notifications) == 0 {
+		return nil
+	}
+
+	existing, _, err := s.notificationSvc.Find(ctx, domain.NotificationQueryParams{})
+	if err != nil {
+		return err
+	}
+
+	existingIDs := make(map[int]struct{}, len(existing))
+	for _, notification := range existing {
+		existingIDs[notification.ID] = struct{}{}
+	}
+
+	for _, notification := range notifications {
+		if _, ok := existingIDs[notification.NotificationID]; !ok {
+			return errors.Wrap(domain.ErrNotificationNotFound, "notification with id %d does not exist", notification.NotificationID)
+		}
+	}
+
+	return nil
+}
+
 func (s *Service) UpdatePartial(ctx context.Context, filter domain.FilterUpdate) error {
 	if _, err := s.repo.FindByID(ctx, filter.ID); err != nil {
 		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("could not find filter")
@@ -323,6 +357,11 @@ func (s *Service) UpdatePartial(ctx context.Context, filter domain.FilterUpdate)
 
 	if err := s.validateIndexers(ctx, filter.Indexers); err != nil {
 		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("invalid indexers for filter")
+		return err
+	}
+
+	if err := s.validateNotifications(ctx, filter.Notifications); err != nil {
+		s.log.Error().Err(err).Int("filter_id", filter.ID).Msg("invalid notifications for filter")
 		return err
 	}
 

--- a/internal/filter/service_test.go
+++ b/internal/filter/service_test.go
@@ -25,6 +25,20 @@ func (s *indexerSvcStub) List(_ context.Context) ([]domain.Indexer, error) {
 	return s.indexers, nil
 }
 
+// filterRepoStub answers the existence check; every other repo method panics
+// through the embedded nil interface, so reaching persistence fails the test.
+type filterRepoStub struct {
+	filterRepo
+	filter *domain.Filter
+}
+
+func (s *filterRepoStub) FindByID(_ context.Context, filterID int) (*domain.Filter, error) {
+	if s.filter == nil || s.filter.ID != filterID {
+		return nil, domain.ErrRecordNotFound
+	}
+	return s.filter, nil
+}
+
 func TestService_validateIndexers(t *testing.T) {
 	svc := &Service{
 		log:        zerolog.Nop(),
@@ -45,11 +59,10 @@ func TestService_validateIndexers(t *testing.T) {
 	})
 }
 
-// The repo fields are nil, so reaching any persistence call would panic. A
-// clean ErrIndexerNotFound proves validation runs before anything is stored.
 func TestService_Update_ValidatesIndexersBeforePersisting(t *testing.T) {
 	svc := &Service{
 		log:        zerolog.Nop(),
+		repo:       &filterRepoStub{filter: &domain.Filter{ID: 1}},
 		indexerSvc: &indexerSvcStub{indexers: []domain.Indexer{{ID: 1}}},
 	}
 
@@ -61,9 +74,25 @@ func TestService_Update_ValidatesIndexersBeforePersisting(t *testing.T) {
 	assert.ErrorIs(t, err, domain.ErrIndexerNotFound)
 }
 
+func TestService_Update_MissingFilterWinsOverUnknownIndexer(t *testing.T) {
+	svc := &Service{
+		log:        zerolog.Nop(),
+		repo:       &filterRepoStub{},
+		indexerSvc: &indexerSvcStub{indexers: []domain.Indexer{{ID: 1}}},
+	}
+
+	err := svc.Update(t.Context(), &domain.Filter{
+		ID:       99,
+		Name:     "filter",
+		Indexers: []domain.Indexer{{ID: 99}},
+	})
+	assert.ErrorIs(t, err, domain.ErrRecordNotFound)
+}
+
 func TestService_UpdatePartial_ValidatesIndexersBeforePersisting(t *testing.T) {
 	svc := &Service{
 		log:        zerolog.Nop(),
+		repo:       &filterRepoStub{filter: &domain.Filter{ID: 1}},
 		indexerSvc: &indexerSvcStub{indexers: []domain.Indexer{{ID: 1}}},
 	}
 
@@ -72,4 +101,18 @@ func TestService_UpdatePartial_ValidatesIndexersBeforePersisting(t *testing.T) {
 		Indexers: []domain.Indexer{{ID: 99}},
 	})
 	assert.ErrorIs(t, err, domain.ErrIndexerNotFound)
+}
+
+func TestService_UpdatePartial_MissingFilterWinsOverUnknownIndexer(t *testing.T) {
+	svc := &Service{
+		log:        zerolog.Nop(),
+		repo:       &filterRepoStub{},
+		indexerSvc: &indexerSvcStub{indexers: []domain.Indexer{{ID: 1}}},
+	}
+
+	err := svc.UpdatePartial(t.Context(), domain.FilterUpdate{
+		ID:       99,
+		Indexers: []domain.Indexer{{ID: 99}},
+	})
+	assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 }

--- a/internal/filter/service_test.go
+++ b/internal/filter/service_test.go
@@ -39,6 +39,15 @@ func (s *filterRepoStub) FindByID(_ context.Context, filterID int) (*domain.Filt
 	return s.filter, nil
 }
 
+type notificationSvcStub struct {
+	notificationService
+	notifications []domain.Notification
+}
+
+func (s *notificationSvcStub) Find(_ context.Context, _ domain.NotificationQueryParams) ([]domain.Notification, int, error) {
+	return s.notifications, len(s.notifications), nil
+}
+
 func TestService_validateIndexers(t *testing.T) {
 	svc := &Service{
 		log:        zerolog.Nop(),
@@ -115,4 +124,35 @@ func TestService_UpdatePartial_MissingFilterWinsOverUnknownIndexer(t *testing.T)
 		Indexers: []domain.Indexer{{ID: 99}},
 	})
 	assert.ErrorIs(t, err, domain.ErrRecordNotFound)
+}
+
+func TestService_Update_ValidatesNotificationsBeforePersisting(t *testing.T) {
+	svc := &Service{
+		log:             zerolog.Nop(),
+		repo:            &filterRepoStub{filter: &domain.Filter{ID: 1}},
+		indexerSvc:      &indexerSvcStub{},
+		notificationSvc: &notificationSvcStub{notifications: []domain.Notification{{ID: 1}}},
+	}
+
+	err := svc.Update(t.Context(), &domain.Filter{
+		ID:            1,
+		Name:          "filter",
+		Notifications: []domain.FilterNotification{{NotificationID: 99}},
+	})
+	assert.ErrorIs(t, err, domain.ErrNotificationNotFound)
+}
+
+func TestService_UpdatePartial_ValidatesNotificationsBeforePersisting(t *testing.T) {
+	svc := &Service{
+		log:             zerolog.Nop(),
+		repo:            &filterRepoStub{filter: &domain.Filter{ID: 1}},
+		indexerSvc:      &indexerSvcStub{},
+		notificationSvc: &notificationSvcStub{notifications: []domain.Notification{{ID: 1}}},
+	}
+
+	err := svc.UpdatePartial(t.Context(), domain.FilterUpdate{
+		ID:            1,
+		Notifications: []domain.FilterNotification{{NotificationID: 99}},
+	})
+	assert.ErrorIs(t, err, domain.ErrNotificationNotFound)
 }

--- a/internal/http/action.go
+++ b/internal/http/action.go
@@ -6,9 +6,7 @@ package http
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/autobrr/autobrr/internal/domain"
 
@@ -88,9 +86,9 @@ func (h actionHandler) updateAction(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h actionHandler) deleteAction(w http.ResponseWriter, r *http.Request) {
-	actionID, err := parseInt(chi.URLParam(r, "actionID"))
+	actionID, err := parseURLParamInt(r, "actionID")
 	if err != nil {
-		h.encoder.StatusError(w, http.StatusBadRequest, errors.New("bad param id"))
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -103,9 +101,9 @@ func (h actionHandler) deleteAction(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h actionHandler) toggleActionEnabled(w http.ResponseWriter, r *http.Request) {
-	actionID, err := parseInt(chi.URLParam(r, "actionID"))
+	actionID, err := parseURLParamInt(r, "actionID")
 	if err != nil {
-		h.encoder.StatusError(w, http.StatusBadRequest, errors.New("bad param id"))
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -115,12 +113,4 @@ func (h actionHandler) toggleActionEnabled(w http.ResponseWriter, r *http.Reques
 	}
 
 	h.encoder.StatusResponse(w, http.StatusCreated, nil)
-}
-
-func parseInt(s string) (int, error) {
-	u, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return int(u), nil
 }

--- a/internal/http/action.go
+++ b/internal/http/action.go
@@ -97,7 +97,7 @@ func (h actionHandler) deleteAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusNoContent, nil)
+	h.encoder.NoContent(w)
 }
 
 func (h actionHandler) toggleActionEnabled(w http.ResponseWriter, r *http.Request) {
@@ -112,5 +112,5 @@ func (h actionHandler) toggleActionEnabled(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusCreated, nil)
+	h.encoder.NoContent(w)
 }

--- a/internal/http/action.go
+++ b/internal/http/action.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/autobrr/autobrr/pkg/errors"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -93,6 +94,11 @@ func (h actionHandler) deleteAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Delete(r.Context(), &domain.DeleteActionRequest{ActionId: actionID}); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("action with id %d not found", actionID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -108,6 +114,11 @@ func (h actionHandler) toggleActionEnabled(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := h.service.ToggleEnabled(actionID); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("action with id %d not found", actionID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/action.go
+++ b/internal/http/action.go
@@ -17,6 +17,7 @@ import (
 type actionService interface {
 	List(ctx context.Context) ([]domain.Action, error)
 	Store(ctx context.Context, action *domain.Action) error
+	Update(ctx context.Context, action *domain.Action) (*domain.Action, error)
 	Delete(ctx context.Context, req *domain.DeleteActionRequest) error
 	ToggleEnabled(actionID int) error
 }
@@ -71,19 +72,32 @@ func (h actionHandler) storeAction(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h actionHandler) updateAction(w http.ResponseWriter, r *http.Request) {
+	actionID, err := parseURLParamInt(r, "actionID")
+	if err != nil {
+		h.encoder.BadRequestErr(w, err)
+		return
+	}
+
 	var data *domain.Action
 	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
 		h.encoder.Error(w, err)
 		return
 	}
 
-	err := h.service.Store(r.Context(), data)
+	data.ID = actionID
+
+	action, err := h.service.Update(r.Context(), data)
 	if err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("action with id %d not found", actionID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusCreated, data)
+	h.encoder.StatusResponse(w, http.StatusOK, action)
 }
 
 func (h actionHandler) deleteAction(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/download_client.go
+++ b/internal/http/download_client.go
@@ -61,13 +61,13 @@ func (h downloadClientHandler) listDownloadClients(w http.ResponseWriter, r *htt
 }
 
 func (h downloadClientHandler) findByID(w http.ResponseWriter, r *http.Request) {
-	clientID, err := parseURLParamInt(r, "clientID")
+	clientID, err := parseURLParamInt32(r, "clientID")
 	if err != nil {
 		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
-	client, err := h.service.FindByID(r.Context(), int32(clientID))
+	client, err := h.service.FindByID(r.Context(), clientID)
 	if err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
 			h.encoder.NotFoundErr(w, errors.New("download client with id %d not found", clientID))
@@ -82,13 +82,13 @@ func (h downloadClientHandler) findByID(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h downloadClientHandler) findArrTagsByID(w http.ResponseWriter, r *http.Request) {
-	clientID, err := parseURLParamInt(r, "clientID")
+	clientID, err := parseURLParamInt32(r, "clientID")
 	if err != nil {
 		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
-	client, err := h.service.GetArrTags(r.Context(), int32(clientID))
+	client, err := h.service.GetArrTags(r.Context(), clientID)
 	if err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
 			h.encoder.NotFoundErr(w, errors.New("download client with id %d not found", clientID))
@@ -160,13 +160,13 @@ func (h downloadClientHandler) update(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h downloadClientHandler) delete(w http.ResponseWriter, r *http.Request) {
-	clientID, err := parseURLParamInt(r, "clientID")
+	clientID, err := parseURLParamInt32(r, "clientID")
 	if err != nil {
 		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
-	if err = h.service.Delete(r.Context(), int32(clientID)); err != nil {
+	if err = h.service.Delete(r.Context(), clientID); err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
 			h.encoder.NotFoundErr(w, errors.New("download client with id %d not found", clientID))
 			return

--- a/internal/http/download_client.go
+++ b/internal/http/download_client.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
@@ -62,9 +61,9 @@ func (h downloadClientHandler) listDownloadClients(w http.ResponseWriter, r *htt
 }
 
 func (h downloadClientHandler) findByID(w http.ResponseWriter, r *http.Request) {
-	clientID, err := strconv.ParseInt(chi.URLParam(r, "clientID"), 10, 32)
+	clientID, err := parseURLParamInt(r, "clientID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -72,6 +71,7 @@ func (h downloadClientHandler) findByID(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
 			h.encoder.NotFoundErr(w, errors.New("download client with id %d not found", clientID))
+			return
 		}
 
 		h.encoder.Error(w, err)
@@ -82,9 +82,9 @@ func (h downloadClientHandler) findByID(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h downloadClientHandler) findArrTagsByID(w http.ResponseWriter, r *http.Request) {
-	clientID, err := strconv.ParseInt(chi.URLParam(r, "clientID"), 10, 32)
+	clientID, err := parseURLParamInt(r, "clientID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -92,6 +92,7 @@ func (h downloadClientHandler) findArrTagsByID(w http.ResponseWriter, r *http.Re
 	if err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
 			h.encoder.NotFoundErr(w, errors.New("download client with id %d not found", clientID))
+			return
 		}
 
 		h.encoder.Error(w, err)
@@ -125,6 +126,11 @@ func (h downloadClientHandler) test(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Test(r.Context(), data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("download client with id %d not found", data.ID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -141,6 +147,11 @@ func (h downloadClientHandler) update(w http.ResponseWriter, r *http.Request) {
 
 	err := h.service.Update(r.Context(), data)
 	if err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("download client with id %d not found", data.ID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -149,13 +160,18 @@ func (h downloadClientHandler) update(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h downloadClientHandler) delete(w http.ResponseWriter, r *http.Request) {
-	clientID, err := strconv.ParseInt(chi.URLParam(r, "clientID"), 10, 32)
+	clientID, err := parseURLParamInt(r, "clientID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	if err = h.service.Delete(r.Context(), int32(clientID)); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("download client with id %d not found", clientID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/download_client.go
+++ b/internal/http/download_client.go
@@ -156,7 +156,7 @@ func (h downloadClientHandler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusCreated, data)
+	h.encoder.StatusResponse(w, http.StatusOK, data)
 }
 
 func (h downloadClientHandler) delete(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -98,6 +98,20 @@ func (e encoder) NotFoundErr(w http.ResponseWriter, err error) {
 	}
 }
 
+func (e encoder) BadRequestErr(w http.ResponseWriter, err error) {
+	res := errorResponse{
+		Message: err.Error(),
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusBadRequest)
+
+	if encErr := json.NewEncoder(w).Encode(res); encErr != nil {
+		e.log.Error().Err(encErr).Msg("failed to encode bad request error response")
+		return
+	}
+}
+
 func (e encoder) Error(w http.ResponseWriter, err error) {
 	res := errorResponse{
 		Message: err.Error(),

--- a/internal/http/encoder.go
+++ b/internal/http/encoder.go
@@ -21,6 +21,7 @@ func newEncoder(log zerolog.Logger) encoder {
 }
 
 type errorResponse struct {
+	Code    string `json:"code,omitempty"`
 	Message string `json:"message"`
 	Status  int    `json:"status,omitempty"`
 }
@@ -79,12 +80,9 @@ func (e encoder) NoContent(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (e encoder) StatusNotFound(w http.ResponseWriter) {
-	w.WriteHeader(http.StatusNotFound)
-}
-
 func (e encoder) NotFoundErr(w http.ResponseWriter, err error) {
 	res := errorResponse{
+		Code:    "RECORD_NOT_FOUND",
 		Message: err.Error(),
 	}
 
@@ -100,6 +98,7 @@ func (e encoder) NotFoundErr(w http.ResponseWriter, err error) {
 
 func (e encoder) BadRequestErr(w http.ResponseWriter, err error) {
 	res := errorResponse{
+		Code:    "BAD_REQUEST_PARAMS",
 		Message: err.Error(),
 	}
 
@@ -114,6 +113,7 @@ func (e encoder) BadRequestErr(w http.ResponseWriter, err error) {
 
 func (e encoder) Error(w http.ResponseWriter, err error) {
 	res := errorResponse{
+		Code:    "INTERNAL_SERVER_ERROR",
 		Message: err.Error(),
 	}
 
@@ -155,5 +155,19 @@ func (e encoder) StatusWarning(w http.ResponseWriter, status int, message string
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(resp)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		e.log.Error().Err(err).Msg("failed to encode status warning")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
+func (e encoder) PlainText(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(body)); err != nil {
+		e.log.Error().Err(err).Msg("failed to encode plain text response")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 }

--- a/internal/http/feed.go
+++ b/internal/http/feed.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
@@ -71,9 +70,9 @@ func (h feedHandler) find(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h feedHandler) findByID(w http.ResponseWriter, r *http.Request) {
-	feedID, err := strconv.Atoi(chi.URLParam(r, "feedID"))
+	feedID, err := parseURLParamInt(r, "feedID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -115,6 +114,11 @@ func (h feedHandler) test(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Test(r.Context(), data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("could not find feed with id %d", data.ID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -147,6 +151,11 @@ func (h feedHandler) update(w http.ResponseWriter, r *http.Request) {
 
 	err := h.service.Update(r.Context(), data)
 	if err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("could not find feed with id %d", data.ID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -155,9 +164,9 @@ func (h feedHandler) update(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h feedHandler) forceRun(w http.ResponseWriter, r *http.Request) {
-	feedID, err := strconv.Atoi(chi.URLParam(r, "feedID"))
+	feedID, err := parseURLParamInt(r, "feedID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -175,9 +184,9 @@ func (h feedHandler) forceRun(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h feedHandler) capsByID(w http.ResponseWriter, r *http.Request) {
-	feedID, err := strconv.Atoi(chi.URLParam(r, "feedID"))
+	feedID, err := parseURLParamInt(r, "feedID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -196,9 +205,9 @@ func (h feedHandler) capsByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h feedHandler) toggleEnabled(w http.ResponseWriter, r *http.Request) {
-	feedID, err := strconv.Atoi(chi.URLParam(r, "feedID"))
+	feedID, err := parseURLParamInt(r, "feedID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -225,9 +234,9 @@ func (h feedHandler) toggleEnabled(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h feedHandler) delete(w http.ResponseWriter, r *http.Request) {
-	feedID, err := strconv.Atoi(chi.URLParam(r, "feedID"))
+	feedID, err := parseURLParamInt(r, "feedID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -245,13 +254,18 @@ func (h feedHandler) delete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h feedHandler) deleteCache(w http.ResponseWriter, r *http.Request) {
-	feedID, err := strconv.Atoi(chi.URLParam(r, "feedID"))
+	feedID, err := parseURLParamInt(r, "feedID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	if err := h.service.DeleteFeedCache(r.Context(), feedID); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("could not find feed with id %d", feedID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -260,14 +274,19 @@ func (h feedHandler) deleteCache(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h feedHandler) latestRun(w http.ResponseWriter, r *http.Request) {
-	feedID, err := strconv.Atoi(chi.URLParam(r, "feedID"))
+	feedID, err := parseURLParamInt(r, "feedID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	feed, err := h.service.GetLastRunData(r.Context(), feedID)
 	if err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("could not find feed with id %d", feedID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/feed.go
+++ b/internal/http/feed.go
@@ -160,7 +160,7 @@ func (h feedHandler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusCreated, data)
+	h.encoder.StatusResponse(w, http.StatusOK, data)
 }
 
 func (h feedHandler) forceRun(w http.ResponseWriter, r *http.Request) {
@@ -180,7 +180,7 @@ func (h feedHandler) forceRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusNoContent, nil)
+	h.encoder.NoContent(w)
 }
 
 func (h feedHandler) capsByID(w http.ResponseWriter, r *http.Request) {
@@ -230,7 +230,7 @@ func (h feedHandler) toggleEnabled(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusNoContent, nil)
+	h.encoder.NoContent(w)
 }
 
 func (h feedHandler) delete(w http.ResponseWriter, r *http.Request) {
@@ -250,7 +250,7 @@ func (h feedHandler) delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusNoContent, nil)
+	h.encoder.NoContent(w)
 }
 
 func (h feedHandler) deleteCache(w http.ResponseWriter, r *http.Request) {
@@ -270,7 +270,7 @@ func (h feedHandler) deleteCache(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusNoContent, nil)
+	h.encoder.NoContent(w)
 }
 
 func (h feedHandler) latestRun(w http.ResponseWriter, r *http.Request) {
@@ -292,11 +292,11 @@ func (h feedHandler) latestRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if feed == "" {
-		h.encoder.StatusNotFound(w)
-		w.Write([]byte("No data found"))
+		h.encoder.NotFoundErr(w, errors.New("no last run data found for feed with id %d", feedID))
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(feed))
+
 }

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -108,9 +107,9 @@ func (h filterHandler) getFilters(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h filterHandler) getByID(w http.ResponseWriter, r *http.Request) {
-	filterID, err := strconv.Atoi(chi.URLParam(r, "filterID"))
+	filterID, err := parseURLParamInt(r, "filterID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -129,9 +128,9 @@ func (h filterHandler) getByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h filterHandler) duplicate(w http.ResponseWriter, r *http.Request) {
-	filterID, err := strconv.Atoi(chi.URLParam(r, "filterID"))
+	filterID, err := parseURLParamInt(r, "filterID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -172,6 +171,11 @@ func (h filterHandler) update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Update(r.Context(), data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("filter with id %d not found", data.ID))
+			return
+		}
+
 		if errors.Is(err, domain.ErrIndexerNotFound) {
 			h.encoder.StatusError(w, http.StatusBadRequest, err)
 			return
@@ -186,9 +190,9 @@ func (h filterHandler) update(w http.ResponseWriter, r *http.Request) {
 
 func (h filterHandler) updatePartial(w http.ResponseWriter, r *http.Request) {
 	var data domain.FilterUpdate
-	filterID, err := strconv.Atoi(chi.URLParam(r, "filterID"))
+	filterID, err := parseURLParamInt(r, "filterID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 	data.ID = filterID
@@ -199,6 +203,11 @@ func (h filterHandler) updatePartial(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.UpdatePartial(r.Context(), data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("filter with id %d not found", data.ID))
+			return
+		}
+
 		if errors.Is(err, domain.ErrIndexerNotFound) {
 			h.encoder.StatusError(w, http.StatusBadRequest, err)
 			return
@@ -212,9 +221,9 @@ func (h filterHandler) updatePartial(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h filterHandler) toggleEnabled(w http.ResponseWriter, r *http.Request) {
-	filterID, err := strconv.Atoi(chi.URLParam(r, "filterID"))
+	filterID, err := parseURLParamInt(r, "filterID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -228,6 +237,11 @@ func (h filterHandler) toggleEnabled(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.ToggleEnabled(r.Context(), filterID, data.Enabled); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("filter with id %d not found", filterID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -236,13 +250,18 @@ func (h filterHandler) toggleEnabled(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h filterHandler) delete(w http.ResponseWriter, r *http.Request) {
-	filterID, err := strconv.Atoi(chi.URLParam(r, "filterID"))
+	filterID, err := parseURLParamInt(r, "filterID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	if err := h.service.Delete(r.Context(), filterID); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("filter with id %d not found", filterID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -251,14 +270,19 @@ func (h filterHandler) delete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h filterHandler) getFilterNotifications(w http.ResponseWriter, r *http.Request) {
-	filterID, err := strconv.Atoi(chi.URLParam(r, "filterID"))
+	filterID, err := parseURLParamInt(r, "filterID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	filter, err := h.service.FindByID(r.Context(), filterID)
 	if err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("filter with id %d not found", filterID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -268,9 +292,9 @@ func (h filterHandler) getFilterNotifications(w http.ResponseWriter, r *http.Req
 }
 
 func (h filterHandler) updateFilterNotifications(w http.ResponseWriter, r *http.Request) {
-	filterID, err := strconv.Atoi(chi.URLParam(r, "filterID"))
+	filterID, err := parseURLParamInt(r, "filterID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -287,6 +311,11 @@ func (h filterHandler) updateFilterNotifications(w http.ResponseWriter, r *http.
 	}
 
 	if err := h.service.UpdatePartial(r.Context(), update); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("filter with id %d not found", filterID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -163,7 +163,7 @@ func (h filterHandler) update(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if errors.Is(err, domain.ErrIndexerNotFound) {
-			h.encoder.StatusError(w, http.StatusBadRequest, err)
+			h.encoder.BadRequestErr(w, err)
 			return
 		}
 

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -70,32 +69,22 @@ func (h filterHandler) getFilters(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sort := r.URL.Query().Get("sort")
-	if sort != "" && strings.Contains(sort, "-") {
-		field := ""
-		order := ""
-
-		s := strings.Split(sort, "-")
-		if s[0] == "name" || s[0] == "priority" || s[0] == "created_at" || s[0] == "updated_at" {
-			field = s[0]
-		}
-
-		if s[1] == "asc" || s[1] == "desc" {
-			order = s[1]
+	if sort != "" {
+		field, order, found := strings.Cut(sort, "-")
+		validField := field == "name" || field == "priority" || field == "created_at" || field == "updated_at"
+		validOrder := order == "asc" || order == "desc"
+		if !found || !validField || !validOrder {
+			h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
+				"code":    "BAD_REQUEST_PARAMS",
+				"message": "sort parameter is invalid",
+			})
+			return
 		}
 
 		params.Sort[field] = order
 	}
 
-	u, err := url.Parse(r.URL.String())
-	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-			"code":    "BAD_REQUEST_PARAMS",
-			"message": "indexer parameter is invalid",
-		})
-		return
-	}
-	vals := u.Query()
-	params.Filters.Indexers = vals["indexer"]
+	params.Filters.Indexers = r.URL.Query()["indexer"]
 
 	filters, err := h.service.Find(r.Context(), params)
 	if err != nil {

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -74,10 +74,7 @@ func (h filterHandler) getFilters(w http.ResponseWriter, r *http.Request) {
 		validField := field == "name" || field == "priority" || field == "created_at" || field == "updated_at"
 		validOrder := order == "asc" || order == "desc"
 		if !found || !validField || !validOrder {
-			h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-				"code":    "BAD_REQUEST_PARAMS",
-				"message": "sort parameter is invalid",
-			})
+			h.encoder.BadRequestErr(w, errors.New("sort parameter is invalid"))
 			return
 		}
 
@@ -255,7 +252,7 @@ func (h filterHandler) delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusNoContent, nil)
+	h.encoder.NoContent(w)
 }
 
 func (h filterHandler) getFilterNotifications(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -162,7 +162,7 @@ func (h filterHandler) update(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if errors.Is(err, domain.ErrIndexerNotFound) {
+		if errors.Is(err, domain.ErrIndexerNotFound) || errors.Is(err, domain.ErrNotificationNotFound) {
 			h.encoder.BadRequestErr(w, err)
 			return
 		}
@@ -194,8 +194,8 @@ func (h filterHandler) updatePartial(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if errors.Is(err, domain.ErrIndexerNotFound) {
-			h.encoder.StatusError(w, http.StatusBadRequest, err)
+		if errors.Is(err, domain.ErrIndexerNotFound) || errors.Is(err, domain.ErrNotificationNotFound) {
+			h.encoder.BadRequestErr(w, err)
 			return
 		}
 
@@ -299,6 +299,11 @@ func (h filterHandler) updateFilterNotifications(w http.ResponseWriter, r *http.
 	if err := h.service.UpdatePartial(r.Context(), update); err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
 			h.encoder.NotFoundErr(w, errors.New("filter with id %d not found", filterID))
+			return
+		}
+
+		if errors.Is(err, domain.ErrNotificationNotFound) {
+			h.encoder.BadRequestErr(w, err)
 			return
 		}
 

--- a/internal/http/indexer.go
+++ b/internal/http/indexer.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
@@ -92,6 +91,11 @@ func (h indexerHandler) update(w http.ResponseWriter, r *http.Request) {
 
 	indexer, err := h.service.Update(r.Context(), data)
 	if err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("indexer with id %d not found", data.ID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -100,13 +104,18 @@ func (h indexerHandler) update(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h indexerHandler) delete(w http.ResponseWriter, r *http.Request) {
-	indexerID, err := strconv.Atoi(chi.URLParam(r, "indexerID"))
+	indexerID, err := parseURLParamInt(r, "indexerID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	if err := h.service.Delete(r.Context(), indexerID); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("indexer with id %d not found", indexerID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -135,9 +144,9 @@ func (h indexerHandler) list(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h indexerHandler) findByID(w http.ResponseWriter, r *http.Request) {
-	indexerID, err := strconv.Atoi(chi.URLParam(r, "indexerID"))
+	indexerID, err := parseURLParamInt(r, "indexerID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -156,9 +165,9 @@ func (h indexerHandler) findByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h indexerHandler) testApi(w http.ResponseWriter, r *http.Request) {
-	indexerID, err := strconv.Atoi(chi.URLParam(r, "indexerID"))
+	indexerID, err := parseURLParamInt(r, "indexerID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -173,6 +182,11 @@ func (h indexerHandler) testApi(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.TestApi(r.Context(), req); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("indexer with id %d not found", indexerID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -187,9 +201,9 @@ func (h indexerHandler) testApi(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h indexerHandler) toggleEnabled(w http.ResponseWriter, r *http.Request) {
-	indexerID, err := strconv.Atoi(chi.URLParam(r, "indexerID"))
+	indexerID, err := parseURLParamInt(r, "indexerID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -203,6 +217,11 @@ func (h indexerHandler) toggleEnabled(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.ToggleEnabled(r.Context(), indexerID, data.Enabled); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("indexer with id %d not found", indexerID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/indexer.go
+++ b/internal/http/indexer.go
@@ -56,7 +56,7 @@ func (h indexerHandler) Routes(r chi.Router) {
 	})
 }
 
-func (h indexerHandler) getSchema(w http.ResponseWriter, r *http.Request) {
+func (h indexerHandler) getSchema(w http.ResponseWriter, _ *http.Request) {
 	indexers, err := h.service.GetTemplates()
 	if err != nil {
 		h.encoder.Error(w, err)
@@ -120,10 +120,10 @@ func (h indexerHandler) delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusNoContent, nil)
+	h.encoder.NoContent(w)
 }
 
-func (h indexerHandler) getAll(w http.ResponseWriter, r *http.Request) {
+func (h indexerHandler) getAll(w http.ResponseWriter, _ *http.Request) {
 	indexers, err := h.service.GetAll()
 	if err != nil {
 		h.encoder.Error(w, err)

--- a/internal/http/irc.go
+++ b/internal/http/irc.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -90,9 +89,9 @@ func (h ircHandler) listNetworks(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h ircHandler) getNetworkByID(w http.ResponseWriter, r *http.Request) {
-	networkID, err := strconv.Atoi(chi.URLParam(r, "networkID"))
+	networkID, err := parseURLParamInt(r, "networkID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -111,9 +110,9 @@ func (h ircHandler) getNetworkByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h ircHandler) restartNetwork(w http.ResponseWriter, r *http.Request) {
-	networkID, err := strconv.Atoi(chi.URLParam(r, "networkID"))
+	networkID, err := parseURLParamInt(r, "networkID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -153,6 +152,11 @@ func (h ircHandler) updateNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.UpdateNetwork(r.Context(), &data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("network with id %d not found", data.ID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -161,9 +165,9 @@ func (h ircHandler) updateNetwork(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h ircHandler) sendCmd(w http.ResponseWriter, r *http.Request) {
-	networkID, err := strconv.Atoi(chi.URLParam(r, "networkID"))
+	networkID, err := parseURLParamInt(r, "networkID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -176,6 +180,11 @@ func (h ircHandler) sendCmd(w http.ResponseWriter, r *http.Request) {
 	data.NetworkId = int64(networkID)
 
 	if err := h.service.SendCmd(r.Context(), &data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("network with id %d not found", networkID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -185,9 +194,9 @@ func (h ircHandler) sendCmd(w http.ResponseWriter, r *http.Request) {
 
 // announceProcess manually trigger announce process
 func (h ircHandler) announceProcess(w http.ResponseWriter, r *http.Request) {
-	networkID, err := strconv.Atoi(chi.URLParam(r, "networkID"))
+	networkID, err := parseURLParamInt(r, "networkID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -219,9 +228,9 @@ func (h ircHandler) announceProcess(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h ircHandler) storeChannel(w http.ResponseWriter, r *http.Request) {
-	networkID, err := strconv.Atoi(chi.URLParam(r, "networkID"))
+	networkID, err := parseURLParamInt(r, "networkID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -232,6 +241,11 @@ func (h ircHandler) storeChannel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.StoreChannel(r.Context(), int64(networkID), &data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("network with id %d not found", networkID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -240,9 +254,9 @@ func (h ircHandler) storeChannel(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h ircHandler) deleteNetwork(w http.ResponseWriter, r *http.Request) {
-	networkID, err := strconv.Atoi(chi.URLParam(r, "networkID"))
+	networkID, err := parseURLParamInt(r, "networkID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -260,9 +274,9 @@ func (h ircHandler) deleteNetwork(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h ircHandler) getMessageHistory(w http.ResponseWriter, r *http.Request) {
-	networkID, err := strconv.Atoi(chi.URLParam(r, "networkID"))
+	networkID, err := parseURLParamInt(r, "networkID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 

--- a/internal/http/list.go
+++ b/internal/http/list.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/autobrr/autobrr/pkg/errors"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -80,6 +80,11 @@ func (h listHandler) update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.listSvc.Update(r.Context(), data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("could not find list"))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -88,13 +93,18 @@ func (h listHandler) update(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h listHandler) delete(w http.ResponseWriter, r *http.Request) {
-	listID, err := strconv.Atoi(chi.URLParam(r, "listID"))
+	listID, err := parseURLParamInt(r, "listID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	if err := h.listSvc.Delete(r.Context(), int64(listID)); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("could not find list"))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -112,13 +122,18 @@ func (h listHandler) refreshAll(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h listHandler) refreshList(w http.ResponseWriter, r *http.Request) {
-	listID, err := strconv.Atoi(chi.URLParam(r, "listID"))
+	listID, err := parseURLParamInt(r, "listID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	if err := h.listSvc.RefreshList(r.Context(), int64(listID)); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("could not find list"))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/notification.go
+++ b/internal/http/notification.go
@@ -52,7 +52,7 @@ func (h notificationHandler) Routes(r chi.Router) {
 func (h notificationHandler) list(w http.ResponseWriter, r *http.Request) {
 	list, _, err := h.service.Find(r.Context(), domain.NotificationQueryParams{})
 	if err != nil {
-		h.encoder.StatusNotFound(w)
+		h.encoder.Error(w, err)
 		return
 	}
 
@@ -82,7 +82,7 @@ func (h notificationHandler) findByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	notification, err := h.service.FindByID(r.Context(), notificationID)
+	notif, err := h.service.FindByID(r.Context(), notificationID)
 	if err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
 			h.encoder.NotFoundErr(w, errors.New("notification with id %d not found", notificationID))
@@ -93,7 +93,7 @@ func (h notificationHandler) findByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusNoContent, notification)
+	h.encoder.StatusResponse(w, http.StatusOK, notif)
 }
 
 func (h notificationHandler) update(w http.ResponseWriter, r *http.Request) {
@@ -133,7 +133,7 @@ func (h notificationHandler) delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusNoContent, nil)
+	h.encoder.NoContent(w)
 }
 
 func (h notificationHandler) test(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/notification.go
+++ b/internal/http/notification.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/notification"
@@ -77,9 +76,9 @@ func (h notificationHandler) store(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h notificationHandler) findByID(w http.ResponseWriter, r *http.Request) {
-	notificationID, err := strconv.Atoi(chi.URLParam(r, "notificationID"))
+	notificationID, err := parseURLParamInt(r, "notificationID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -104,8 +103,12 @@ func (h notificationHandler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := h.service.Update(r.Context(), data)
-	if err != nil {
+	if err := h.service.Update(r.Context(), data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("notification with id %d not found", data.ID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}
@@ -114,13 +117,18 @@ func (h notificationHandler) update(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h notificationHandler) delete(w http.ResponseWriter, r *http.Request) {
-	notificationID, err := strconv.Atoi(chi.URLParam(r, "notificationID"))
+	notificationID, err := parseURLParamInt(r, "notificationID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	if err := h.service.Delete(r.Context(), notificationID); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("notification with id %d not found", notificationID))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/notification.go
+++ b/internal/http/notification.go
@@ -154,7 +154,7 @@ func (h notificationHandler) test(w http.ResponseWriter, r *http.Request) {
 func (h notificationHandler) pushoverSounds(w http.ResponseWriter, r *http.Request) {
 	apiToken := r.URL.Query().Get("token")
 	if apiToken == "" {
-		h.encoder.Error(w, errors.New("api token is required"))
+		h.encoder.BadRequestErr(w, errors.New("token parameter is required"))
 		return
 	}
 

--- a/internal/http/params.go
+++ b/internal/http/params.go
@@ -20,3 +20,17 @@ func parseURLParamInt(r *http.Request, param string) (int, error) {
 
 	return value, nil
 }
+
+func parseQueryParamInt(r *http.Request, param string, defaultValue int) (int, error) {
+	value := r.URL.Query().Get(param)
+	if value == "" {
+		return defaultValue, nil
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 {
+		return 0, errors.New("%s parameter is invalid", param)
+	}
+
+	return parsed, nil
+}

--- a/internal/http/params.go
+++ b/internal/http/params.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package http
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/autobrr/autobrr/pkg/errors"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func parseURLParamInt(r *http.Request, param string) (int, error) {
+	value, err := strconv.Atoi(chi.URLParam(r, param))
+	if err != nil {
+		return 0, errors.New("%s parameter is invalid", param)
+	}
+
+	return value, nil
+}

--- a/internal/http/params.go
+++ b/internal/http/params.go
@@ -21,6 +21,15 @@ func parseURLParamInt(r *http.Request, param string) (int, error) {
 	return value, nil
 }
 
+func parseURLParamInt32(r *http.Request, param string) (int32, error) {
+	value, err := strconv.ParseInt(chi.URLParam(r, param), 10, 32)
+	if err != nil {
+		return 0, errors.New("%s parameter is invalid", param)
+	}
+
+	return int32(value), nil
+}
+
 func parseQueryParamInt(r *http.Request, param string, defaultValue int) (int, error) {
 	value := r.URL.Query().Get(param)
 	if value == "" {

--- a/internal/http/params_test.go
+++ b/internal/http/params_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseURLParamInt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{name: "valid", value: "42", want: 42},
+		{name: "negative", value: "-1", want: -1},
+		{name: "malformed", value: "not-an-integer", wantErr: true},
+		{name: "empty", value: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("indexerID", tt.value)
+
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			got, err := parseURLParamInt(r, "indexerID")
+			if tt.wantErr {
+				assert.EqualError(t, err, "indexerID parameter is invalid")
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/http/params_test.go
+++ b/internal/http/params_test.go
@@ -45,3 +45,32 @@ func Test_parseURLParamInt(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseQueryParamInt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		query   string
+		want    int
+		wantErr bool
+	}{
+		{name: "valid", query: "?limit=42", want: 42},
+		{name: "missing_uses_default", query: "", want: 20},
+		{name: "malformed", query: "?limit=not-an-integer", wantErr: true},
+		{name: "negative", query: "?limit=-1", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/"+tt.query, nil)
+
+			got, err := parseQueryParamInt(r, "limit", 20)
+			if tt.wantErr {
+				assert.EqualError(t, err, "limit parameter is invalid")
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/http/params_test.go
+++ b/internal/http/params_test.go
@@ -46,6 +46,39 @@ func Test_parseURLParamInt(t *testing.T) {
 	}
 }
 
+func Test_parseURLParamInt32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    int32
+		wantErr bool
+	}{
+		{name: "valid", value: "42", want: 42},
+		{name: "max_int32", value: "2147483647", want: 2147483647},
+		{name: "overflows_int32", value: "2147483648", wantErr: true},
+		{name: "malformed", value: "not-an-integer", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("clientID", tt.value)
+
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			got, err := parseURLParamInt32(r, "clientID")
+			if tt.wantErr {
+				assert.EqualError(t, err, "clientID parameter is invalid")
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func Test_parseQueryParamInt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/http/proxy.go
+++ b/internal/http/proxy.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
@@ -94,9 +93,9 @@ func (h proxyHandler) list(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h proxyHandler) findByID(w http.ResponseWriter, r *http.Request) {
-	proxyID, err := strconv.Atoi(chi.URLParam(r, "proxyID"))
+	proxyID, err := parseURLParamInt(r, "proxyID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -115,9 +114,9 @@ func (h proxyHandler) findByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h proxyHandler) delete(w http.ResponseWriter, r *http.Request) {
-	proxyID, err := strconv.Atoi(chi.URLParam(r, "proxyID"))
+	proxyID, err := parseURLParamInt(r, "proxyID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -143,6 +142,11 @@ func (h proxyHandler) test(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Test(r.Context(), &data); err != nil {
+		if errors.Is(err, domain.ErrRecordNotFound) {
+			h.encoder.NotFoundErr(w, errors.New("could not find proxy"))
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/release.go
+++ b/internal/http/release.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"strconv"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
@@ -107,22 +105,17 @@ func (h releaseHandler) Routes(r chi.Router) {
 }
 
 func (h releaseHandler) findReleases(w http.ResponseWriter, r *http.Request) {
-	limitP := r.URL.Query().Get("limit")
-	limit, err := strconv.Atoi(limitP)
-	if err != nil && limitP != "" {
+	limit, err := parseQueryParamInt(r, "limit", 20)
+	if err != nil {
 		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
 			"code":    "BAD_REQUEST_PARAMS",
 			"message": "limit parameter is invalid",
 		})
 		return
 	}
-	if limit == 0 {
-		limit = 20
-	}
 
-	offsetP := r.URL.Query().Get("offset")
-	offset, err := strconv.Atoi(offsetP)
-	if err != nil && offsetP != "" {
+	offset, err := parseQueryParamInt(r, "offset", 0)
+	if err != nil {
 		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
 			"code":    "BAD_REQUEST_PARAMS",
 			"message": "offset parameter is invalid",
@@ -130,29 +123,16 @@ func (h releaseHandler) findReleases(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cursorP := r.URL.Query().Get("cursor")
-	cursor := 0
-	if cursorP != "" {
-		cursor, err = strconv.Atoi(cursorP)
-		if err != nil {
-			h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-				"code":    "BAD_REQUEST_PARAMS",
-				"message": "cursor parameter is invalid",
-			})
-			return
-		}
-	}
-
-	u, err := url.Parse(r.URL.String())
+	cursor, err := parseQueryParamInt(r, "cursor", 0)
 	if err != nil {
 		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
 			"code":    "BAD_REQUEST_PARAMS",
-			"message": "indexer parameter is invalid",
+			"message": "cursor parameter is invalid",
 		})
 		return
 	}
-	vals := u.Query()
-	indexer := vals["indexer"]
+
+	indexer := r.URL.Query()["indexer"]
 
 	pushStatus := r.URL.Query().Get("push_status")
 	if pushStatus != "" {
@@ -253,17 +233,13 @@ func (h releaseHandler) getStats(w http.ResponseWriter, r *http.Request) {
 
 func (h releaseHandler) statsHandler(fetch func(ctx context.Context, days int) (any, error)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		days := 30
-		if daysP := r.URL.Query().Get("days"); daysP != "" {
-			parsed, err := strconv.Atoi(daysP)
-			if err != nil || parsed < 0 || parsed > 3650 {
-				h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-					"code":    "BAD_REQUEST_PARAMS",
-					"message": "days parameter is invalid",
-				})
-				return
-			}
-			days = parsed
+		days, err := parseQueryParamInt(r, "days", 30)
+		if err != nil || days > 3650 {
+			h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
+				"code":    "BAD_REQUEST_PARAMS",
+				"message": "days parameter is invalid",
+			})
+			return
 		}
 
 		stats, err := fetch(r.Context(), days)
@@ -282,18 +258,15 @@ func (h releaseHandler) statsHandler(fetch func(ctx context.Context, days int) (
 func (h releaseHandler) deleteReleases(w http.ResponseWriter, r *http.Request) {
 	req := domain.DeleteReleaseRequest{}
 
-	olderThanParam := r.URL.Query().Get("olderThan")
-	if olderThanParam != "" {
-		duration, err := strconv.Atoi(olderThanParam)
-		if err != nil {
-			h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-				"code":    "BAD_REQUEST_PARAMS",
-				"message": "olderThan parameter is invalid",
-			})
-			return
-		}
-		req.OlderThan = duration
+	olderThan, err := parseQueryParamInt(r, "olderThan", 0)
+	if err != nil {
+		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
+			"code":    "BAD_REQUEST_PARAMS",
+			"message": "olderThan parameter is invalid",
+		})
+		return
 	}
+	req.OlderThan = olderThan
 
 	indexers := r.URL.Query()["indexer"]
 	if len(indexers) > 0 {

--- a/internal/http/release.go
+++ b/internal/http/release.go
@@ -105,8 +105,8 @@ func (h releaseHandler) Routes(r chi.Router) {
 
 func (h releaseHandler) findReleases(w http.ResponseWriter, r *http.Request) {
 	limit, err := parseQueryParamInt(r, "limit", 20)
-	if err != nil {
-		h.encoder.BadRequestErr(w, err)
+	if err != nil || limit == 0 {
+		h.encoder.BadRequestErr(w, errors.New("limit parameter is invalid"))
 		return
 	}
 

--- a/internal/http/release.go
+++ b/internal/http/release.go
@@ -6,7 +6,6 @@ package http
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -107,42 +106,28 @@ func (h releaseHandler) Routes(r chi.Router) {
 func (h releaseHandler) findReleases(w http.ResponseWriter, r *http.Request) {
 	limit, err := parseQueryParamInt(r, "limit", 20)
 	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-			"code":    "BAD_REQUEST_PARAMS",
-			"message": "limit parameter is invalid",
-		})
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	offset, err := parseQueryParamInt(r, "offset", 0)
 	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-			"code":    "BAD_REQUEST_PARAMS",
-			"message": "offset parameter is invalid",
-		})
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	cursor, err := parseQueryParamInt(r, "cursor", 0)
 	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-			"code":    "BAD_REQUEST_PARAMS",
-			"message": "cursor parameter is invalid",
-		})
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
 	indexer := r.URL.Query()["indexer"]
 
 	pushStatus := r.URL.Query().Get("push_status")
-	if pushStatus != "" {
-		if !domain.ValidReleasePushStatus(pushStatus) {
-			h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-				"code":    "BAD_REQUEST_PARAMS",
-				"message": fmt.Sprintf("push_status parameter is of invalid type: %v", pushStatus),
-			})
-			return
-		}
+	if pushStatus != "" && !domain.ValidReleasePushStatus(pushStatus) {
+		h.encoder.BadRequestErr(w, errors.New("push_status parameter is of invalid type: %v", pushStatus))
+		return
 	}
 
 	search := r.URL.Query().Get("q")
@@ -161,10 +146,7 @@ func (h releaseHandler) findReleases(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.service.Find(r.Context(), query)
 	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusInternalServerError, map[string]any{
-			"code":    "INTERNAL_SERVER_ERROR",
-			"message": err.Error(),
-		})
+		h.encoder.Error(w, err)
 		return
 	}
 
@@ -174,10 +156,7 @@ func (h releaseHandler) findReleases(w http.ResponseWriter, r *http.Request) {
 func (h releaseHandler) findRecentReleases(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.service.Find(r.Context(), domain.ReleaseQueryParams{Limit: 10})
 	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusInternalServerError, map[string]any{
-			"code":    "INTERNAL_SERVER_ERROR",
-			"message": err.Error(),
-		})
+		h.encoder.Error(w, err)
 		return
 	}
 
@@ -208,10 +187,7 @@ func (h releaseHandler) getReleaseByID(w http.ResponseWriter, r *http.Request) {
 func (h releaseHandler) getIndexerOptions(w http.ResponseWriter, r *http.Request) {
 	stats, err := h.service.GetIndexerOptions(r.Context())
 	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusInternalServerError, map[string]any{
-			"code":    "INTERNAL_SERVER_ERROR",
-			"message": err.Error(),
-		})
+		h.encoder.Error(w, err)
 		return
 	}
 
@@ -221,10 +197,7 @@ func (h releaseHandler) getIndexerOptions(w http.ResponseWriter, r *http.Request
 func (h releaseHandler) getStats(w http.ResponseWriter, r *http.Request) {
 	stats, err := h.service.Stats(r.Context())
 	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusInternalServerError, map[string]any{
-			"code":    "INTERNAL_SERVER_ERROR",
-			"message": err.Error(),
-		})
+		h.encoder.Error(w, err)
 		return
 	}
 
@@ -235,19 +208,13 @@ func (h releaseHandler) statsHandler(fetch func(ctx context.Context, days int) (
 	return func(w http.ResponseWriter, r *http.Request) {
 		days, err := parseQueryParamInt(r, "days", 30)
 		if err != nil || days > 3650 {
-			h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-				"code":    "BAD_REQUEST_PARAMS",
-				"message": "days parameter is invalid",
-			})
+			h.encoder.BadRequestErr(w, errors.New("days parameter is invalid"))
 			return
 		}
 
 		stats, err := fetch(r.Context(), days)
 		if err != nil {
-			h.encoder.StatusResponse(w, http.StatusInternalServerError, map[string]any{
-				"code":    "INTERNAL_SERVER_ERROR",
-				"message": err.Error(),
-			})
+			h.encoder.Error(w, err)
 			return
 		}
 
@@ -260,10 +227,7 @@ func (h releaseHandler) deleteReleases(w http.ResponseWriter, r *http.Request) {
 
 	olderThan, err := parseQueryParamInt(r, "olderThan", 0)
 	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-			"code":    "BAD_REQUEST_PARAMS",
-			"message": "olderThan parameter is invalid",
-		})
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 	req.OlderThan = olderThan
@@ -285,10 +249,7 @@ func (h releaseHandler) deleteReleases(w http.ResponseWriter, r *http.Request) {
 		if _, valid := validStatuses[status]; valid {
 			filteredStatuses = append(filteredStatuses, status)
 		} else {
-			h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-				"code":    "INVALID_RELEASE_STATUS",
-				"message": "releaseStatus contains invalid value",
-			})
+			h.encoder.BadRequestErr(w, errors.New("releaseStatus contains invalid value: %v", status))
 			return
 		}
 	}
@@ -311,18 +272,12 @@ func (h releaseHandler) process(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.IndexerIdentifier == "" {
-		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-			"code":    "VALIDATION_ERROR",
-			"message": "field indexer_identifier empty",
-		})
+		h.encoder.BadRequestErr(w, errors.New("field indexer_identifier empty"))
 		return
 	}
 
 	if len(req.AnnounceLines) == 0 {
-		h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
-			"code":    "VALIDATION_ERROR",
-			"message": "field announce_lines empty",
-		})
+		h.encoder.BadRequestErr(w, errors.New("field announce_lines empty"))
 		return
 	}
 
@@ -355,7 +310,7 @@ func (h releaseHandler) retryAction(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.service.Retry(r.Context(), req); err != nil {
 		if errors.Is(err, domain.ErrRecordNotFound) {
-			h.encoder.NotFoundErr(w, err)
+			h.encoder.NotFoundErr(w, errors.New("action status with id %d not found for release %d", actionStatusId, releaseID))
 			return
 		}
 
@@ -385,18 +340,9 @@ func (h releaseHandler) storeReleaseProfileDuplicate(w http.ResponseWriter, r *h
 func (h releaseHandler) findReleaseProfileDuplicate(w http.ResponseWriter, r *http.Request) {
 	profiles, err := h.service.FindDuplicateReleaseProfiles(r.Context())
 	if err != nil {
-		h.encoder.StatusResponse(w, http.StatusInternalServerError, map[string]interface{}{
-			"code":    "INTERNAL_SERVER_ERROR",
-			"message": err.Error(),
-		})
+		h.encoder.Error(w, err)
 		return
 	}
-
-	//ret := struct {
-	//	Data       []*domain.DuplicateReleaseProfile `json:"data"`
-	//}{
-	//	Data:       profiles,
-	//}
 
 	h.encoder.StatusResponse(w, http.StatusOK, profiles)
 }
@@ -481,7 +427,7 @@ func (h releaseHandler) updateCleanupJob(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	h.encoder.StatusResponse(w, http.StatusCreated, data)
+	h.encoder.StatusResponse(w, http.StatusOK, data)
 }
 
 func (h releaseHandler) deleteCleanupJob(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/release.go
+++ b/internal/http/release.go
@@ -134,13 +134,13 @@ func (h releaseHandler) findReleases(w http.ResponseWriter, r *http.Request) {
 	cursor := 0
 	if cursorP != "" {
 		cursor, err = strconv.Atoi(cursorP)
-		if err != nil && cursorP != "" {
+		if err != nil {
 			h.encoder.StatusResponse(w, http.StatusBadRequest, map[string]any{
 				"code":    "BAD_REQUEST_PARAMS",
 				"message": "cursor parameter is invalid",
 			})
+			return
 		}
-		return
 	}
 
 	u, err := url.Parse(r.URL.String())
@@ -205,9 +205,9 @@ func (h releaseHandler) findRecentReleases(w http.ResponseWriter, r *http.Reques
 }
 
 func (h releaseHandler) getReleaseByID(w http.ResponseWriter, r *http.Request) {
-	releaseID, err := strconv.Atoi(chi.URLParam(r, "releaseID"))
+	releaseID, err := parseURLParamInt(r, "releaseID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -342,6 +342,7 @@ func (h releaseHandler) process(w http.ResponseWriter, r *http.Request) {
 			"code":    "VALIDATION_ERROR",
 			"message": "field indexer_identifier empty",
 		})
+		return
 	}
 
 	if len(req.AnnounceLines) == 0 {
@@ -349,6 +350,7 @@ func (h releaseHandler) process(w http.ResponseWriter, r *http.Request) {
 			"code":    "VALIDATION_ERROR",
 			"message": "field announce_lines empty",
 		})
+		return
 	}
 
 	err = h.service.ProcessManual(r.Context(), req)
@@ -361,15 +363,15 @@ func (h releaseHandler) process(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h releaseHandler) retryAction(w http.ResponseWriter, r *http.Request) {
-	releaseID, err := strconv.Atoi(chi.URLParam(r, "releaseID"))
+	releaseID, err := parseURLParamInt(r, "releaseID")
 	if err != nil {
-		h.encoder.StatusError(w, http.StatusBadRequest, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
-	actionStatusId, err := strconv.Atoi(chi.URLParam(r, "actionStatusID"))
+	actionStatusId, err := parseURLParamInt(r, "actionStatusID")
 	if err != nil {
-		h.encoder.StatusError(w, http.StatusBadRequest, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -427,11 +429,9 @@ func (h releaseHandler) findReleaseProfileDuplicate(w http.ResponseWriter, r *ht
 }
 
 func (h releaseHandler) deleteReleaseProfileDuplicate(w http.ResponseWriter, r *http.Request) {
-	//profileIdParam := chi.URLParam(r, "releaseId")
-
-	profileId, err := strconv.Atoi(chi.URLParam(r, "profileId"))
+	profileId, err := parseURLParamInt(r, "profileId")
 	if err != nil {
-		h.encoder.StatusError(w, http.StatusBadRequest, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -456,9 +456,9 @@ func (h releaseHandler) listCleanupJobs(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h releaseHandler) getCleanupJob(w http.ResponseWriter, r *http.Request) {
-	jobID, err := strconv.Atoi(chi.URLParam(r, "jobID"))
+	jobID, err := parseURLParamInt(r, "jobID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -512,9 +512,9 @@ func (h releaseHandler) updateCleanupJob(w http.ResponseWriter, r *http.Request)
 }
 
 func (h releaseHandler) deleteCleanupJob(w http.ResponseWriter, r *http.Request) {
-	jobID, err := strconv.Atoi(chi.URLParam(r, "jobID"))
+	jobID, err := parseURLParamInt(r, "jobID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -532,9 +532,9 @@ func (h releaseHandler) deleteCleanupJob(w http.ResponseWriter, r *http.Request)
 }
 
 func (h releaseHandler) toggleCleanupJobEnabled(w http.ResponseWriter, r *http.Request) {
-	jobID, err := strconv.Atoi(chi.URLParam(r, "jobID"))
+	jobID, err := parseURLParamInt(r, "jobID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 
@@ -561,9 +561,9 @@ func (h releaseHandler) toggleCleanupJobEnabled(w http.ResponseWriter, r *http.R
 }
 
 func (h releaseHandler) forceRunCleanupJob(w http.ResponseWriter, r *http.Request) {
-	jobID, err := strconv.Atoi(chi.URLParam(r, "jobID"))
+	jobID, err := parseURLParamInt(r, "jobID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 

--- a/internal/http/release_test.go
+++ b/internal/http/release_test.go
@@ -371,7 +371,7 @@ func TestReleaseHandler_UpdateCleanupJob(t *testing.T) {
 	assert.NoError(t, err)
 	defer resp.Body.Close()
 
-	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var updated domain.ReleaseCleanupJob
 	err = json.NewDecoder(resp.Body).Decode(&updated)

--- a/internal/http/webhook.go
+++ b/internal/http/webhook.go
@@ -6,7 +6,6 @@ package http
 import (
 	"context"
 	"net/http"
-	"strconv"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -41,9 +40,9 @@ func (h *webhookHandler) refreshAll(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *webhookHandler) refreshByID(w http.ResponseWriter, r *http.Request) {
-	listID, err := strconv.Atoi(chi.URLParam(r, "listID"))
+	listID, err := parseURLParamInt(r, "listID")
 	if err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 

--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -206,17 +206,17 @@ func (s *Service) FindByFilterID(ctx context.Context, id int) ([]domain.Indexer,
 		return nil, err
 	}
 
-	return indexers, err
+	return indexers, nil
 }
 
 func (s *Service) FindByID(ctx context.Context, id int) (*domain.Indexer, error) {
-	indexers, err := s.repo.FindByID(ctx, id)
+	indexer, err := s.repo.FindByID(ctx, id)
 	if err != nil {
 		s.log.Error().Err(err).Int("indexer_id", id).Msg("could not find indexer by id")
 		return nil, err
 	}
 
-	return indexers, err
+	return indexer, nil
 }
 
 func (s *Service) List(ctx context.Context) ([]domain.Indexer, error) {
@@ -226,7 +226,7 @@ func (s *Service) List(ctx context.Context) ([]domain.Indexer, error) {
 		return nil, err
 	}
 
-	return indexers, err
+	return indexers, nil
 }
 
 func (s *Service) GetBy(ctx context.Context, req domain.GetIndexerRequest) (*domain.Indexer, error) {
@@ -236,7 +236,7 @@ func (s *Service) GetBy(ctx context.Context, req domain.GetIndexerRequest) (*dom
 		return nil, err
 	}
 
-	return indexer, err
+	return indexer, nil
 }
 
 func (s *Service) GetAll() ([]*domain.IndexerDefinition, error) {

--- a/internal/irc/service.go
+++ b/internal/irc/service.go
@@ -383,14 +383,13 @@ func (s *Service) ManualProcessAnnounce(ctx context.Context, req *domain.IRCManu
 
 	handler, found := s.networkHandlers.Get(network.ID)
 	if !found {
-		return errors.New("could not find irc handler with id: %d", network.ID)
+		return errors.Wrap(domain.ErrRecordNotFound, "could not find irc handler with id: %d", network.ID)
 	}
 
 	// send to channels announce processor
 	channel, foundChannel := handler.channels.Get(req.Channel)
-
 	if !foundChannel {
-		return errors.New("could not find channel: %s", req.Channel)
+		return errors.Wrap(domain.ErrRecordNotFound, "could not find channel: %s", req.Channel)
 	}
 
 	if err := channel.QueueAnnounceLine(req.Message); err != nil {
@@ -763,6 +762,12 @@ func (s *Service) StoreNetwork(ctx context.Context, network *domain.IrcNetwork) 
 }
 
 func (s *Service) StoreChannel(ctx context.Context, networkID int64, channel *domain.IrcChannel) error {
+	_, err := s.GetNetworkByID(ctx, networkID)
+	if err != nil {
+		s.log.Error().Err(err).Msg("could not find existing network")
+		return err
+	}
+
 	if err := s.repo.StoreChannel(ctx, networkID, channel); err != nil {
 		return err
 	}
@@ -773,7 +778,7 @@ func (s *Service) StoreChannel(ctx context.Context, networkID int64, channel *do
 func (s *Service) SendCmd(_ context.Context, req *domain.SendIrcCmdRequest) error {
 	handler, found := s.networkHandlers.Get(req.NetworkId)
 	if !found {
-		return errors.New("could not find irc handler with id: %d", req.NetworkId)
+		return errors.Wrap(domain.ErrRecordNotFound, "could not find irc handler with id: %d", req.NetworkId)
 	}
 
 	if err := handler.SendMsg(req.Channel, req.Message); err != nil {

--- a/internal/list/service.go
+++ b/internal/list/service.go
@@ -161,14 +161,18 @@ func (s *Service) Update(ctx context.Context, list *domain.List) error {
 	return nil
 }
 
-func (s *Service) Delete(ctx context.Context, id int64) error {
-	err := s.repo.Delete(ctx, id)
-	if err != nil {
-		s.log.Error().Err(err).Int64("list_id", id).Msg("could not delete list by id")
+func (s *Service) Delete(ctx context.Context, listID int64) error {
+	if _, err := s.repo.FindByID(ctx, listID); err != nil {
+		s.log.Error().Err(err).Int64("list_id", listID).Msg("could not find list by id")
 		return err
 	}
 
-	s.log.Debug().Int64("list_id", id).Msg("successfully deleted list")
+	if err := s.repo.Delete(ctx, listID); err != nil {
+		s.log.Error().Err(err).Int64("list_id", listID).Msg("could not delete list by id")
+		return err
+	}
+
+	s.log.Debug().Int64("list_id", listID).Msg("successfully deleted list")
 
 	return nil
 }

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -138,15 +138,19 @@ func (s *Service) Update(ctx context.Context, notification *domain.Notification)
 	return nil
 }
 
-func (s *Service) Delete(ctx context.Context, id int) error {
-	err := s.repo.Delete(ctx, id)
-	if err != nil {
-		s.log.Error().Err(err).Int("notification_id", id).Msg("could not delete notification")
+func (s *Service) Delete(ctx context.Context, notificationID int) error {
+	if _, err := s.repo.FindByID(ctx, notificationID); err != nil {
+		s.log.Error().Err(err).Int("notification_id", notificationID).Msg("could not find notification by id")
+		return err
+	}
+
+	if err := s.repo.Delete(ctx, notificationID); err != nil {
+		s.log.Error().Err(err).Int("notification_id", notificationID).Msg("could not delete notification")
 		return err
 	}
 
 	// delete sender
-	delete(s.senders, id)
+	delete(s.senders, notificationID)
 
 	return nil
 }


### PR DESCRIPTION
# Description

API endpoints taking a numeric ID in the URL returned `500 Internal Server Error` with the raw Go parse error in the body (`{"message":"strconv.Atoi: parsing \"abc\": invalid syntax"}`) when the ID was malformed, and many mutation endpoints returned `500` instead of `404` when the record did not exist. This cleans up status codes and error bodies across the HTTP layer.

* new `parseURLParamInt` helper parses numeric URL params and returns a client-safe `"<param> parameter is invalid"` error, replacing per-handler `strconv.Atoi(chi.URLParam(...))` and the local `parseInt` in `action.go`
* new `encoder.BadRequestErr` writes `400` with the error message, without logging client mistakes as internal server errors
* swept every ID param site across the `action`, `download_client`, `feed`, `filter`, `indexer`, `irc`, `list`, `notification`, `proxy`, `release`, and `webhook` handlers: malformed IDs now return `400`, well-formed IDs for missing records keep returning `404`
* update/delete/toggle/test/refresh endpoints now return `404` for missing records: services check existence first and return `domain.ErrRecordNotFound` (filters, feeds, feed cache, lists, notifications, download clients), and IRC handler/channel lookups wrap it
* fixed missing `return` after the `404` branch in download client `findByID`/`findArrTagsByID`, which wrote a superfluous `500` on top of the `404`
* fixed `GET /api/release?cursor=...`: a misplaced `return` made any request with a cursor param return an empty `200` without ever querying
* fixed missing `return`s after the validation `400`s in the release `process` handler
* new `parseQueryParamInt` helper for numeric query params (empty falls back to a default, malformed or negative returns `400`); replaces the per-param `strconv.Atoi` blocks for `limit`/`offset`/`cursor`/`days`/`olderThan` - negative values previously wrapped through `uint64(...)` into enormous limits/offsets
* fixed `GET /api/filters?sort=...`: an invalid sort value put an empty field into the sort map, producing broken `ORDER BY` SQL and a `500`; invalid sort now returns `400`
* replaced the redundant `url.Parse(r.URL.String())` round-trip in release and filter list handlers with direct `r.URL.Query()` access
* `GET /api/notification/pushover/sounds` without a `token` now returns `400` instead of `500`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* `go test ./...` passes; new `Test_parseURLParamInt` and `Test_parseQueryParamInt` cover valid, negative, malformed, and empty params and pin the `400` message contract
* `go vet -tags integration ./internal/http/` to verify the existing handler tests still compile
* `gofmt` clean

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally