### PR TITLE
fix(notifications): respect Discord embed limits

### DIFF
--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -47,6 +47,48 @@ const (
 	GRAY       EmbedColors = 10070709 // 99aab5
 )
 
+// Per-field limits. Exceeding any of them makes Discord reject the whole
+// message with 400 rather than truncating it.
+// https://docs.discord.com/developers/resources/message#embed-object-embed-limits
+const (
+	discordEmbedTitleLimit       = 256
+	discordEmbedDescriptionLimit = 4096
+	discordEmbedFieldNameLimit   = 256
+	discordEmbedFieldValueLimit  = 1024
+)
+
+const discordTruncationMarker = " [...] "
+
+// truncateForDiscord shortens s to at most limit characters by dropping the
+// middle. A failed *arr push wraps its cause last, so keeping only the head
+// would discard the one part worth reading. Discord counts characters rather
+// than bytes.
+func truncateForDiscord(s string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+
+	if len(s) <= limit {
+		return s
+	}
+
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+
+	marker := []rune(discordTruncationMarker)
+	if limit <= len(marker) {
+		return string(runes[:limit])
+	}
+
+	keep := limit - len(marker)
+	head := (keep + 1) / 2
+	tail := keep - head
+
+	return string(runes[:head]) + discordTruncationMarker + string(runes[len(runes)-tail:])
+}
+
 type discordSender struct {
 	log      zerolog.Logger
 	Settings *domain.Notification
@@ -280,6 +322,12 @@ func (s *discordSender) buildEmbed(event domain.NotificationEvent, payload domai
 	if payload.Subject != "" && payload.Message != "" {
 		embed.Title = payload.Subject
 		embed.Description = payload.Message
+	}
+
+	embed.Title = truncateForDiscord(embed.Title, discordEmbedTitleLimit)
+	embed.Description = truncateForDiscord(embed.Description, discordEmbedDescriptionLimit)
+	for i := range embed.Fields {
+		embed.Fields[i].Value = truncateForDiscord(embed.Fields[i].Value, discordEmbedFieldValueLimit)
 	}
 
 	return embed

--- a/internal/notification/discord_test.go
+++ b/internal/notification/discord_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package notification
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/autobrr/autobrr/internal/domain"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateForDiscord(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		limit int
+		want  string
+	}{
+		{
+			name:  "shorter than limit is untouched",
+			input: "hello",
+			limit: 10,
+			want:  "hello",
+		},
+		{
+			name:  "exactly at limit is untouched",
+			input: "hello",
+			limit: 5,
+			want:  "hello",
+		},
+		{
+			name:  "keeps both ends and drops the middle",
+			input: "abcdefghijklmnop",
+			limit: 13,
+			want:  "abc [...] nop",
+		},
+		{
+			name:  "limit equal to the marker just cuts",
+			input: "abcdefghij",
+			limit: 7,
+			want:  "abcdefg",
+		},
+		{
+			name:  "one over the marker keeps a single leading rune",
+			input: "abcdefghij",
+			limit: 8,
+			want:  "a [...] ",
+		},
+		{
+			name:  "limit smaller than the marker just cuts",
+			input: "abcdefgh",
+			limit: 3,
+			want:  "abc",
+		},
+		{
+			name:  "zero limit yields empty",
+			input: "abcdefgh",
+			limit: 0,
+			want:  "",
+		},
+		{
+			name:  "negative limit yields empty",
+			input: "abcdefgh",
+			limit: -1,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := truncateForDiscord(tt.input, tt.limit)
+
+			assert.Equal(t, tt.want, got)
+			if tt.limit > 0 {
+				assert.LessOrEqual(t, utf8.RuneCountInString(got), tt.limit)
+			}
+		})
+	}
+}
+
+func TestTruncateForDiscord_CountsRunesNotBytes(t *testing.T) {
+	t.Parallel()
+
+	got := truncateForDiscord(strings.Repeat("日", 500), 100)
+
+	assert.Equal(t, 100, utf8.RuneCountInString(got))
+	assert.NotContains(t, got, "�")
+}
+
+// A failed *arr push puts the whole http.Request in its error string, which
+// reaches the Reasons field well over the 1024 character limit. Discord answers
+// 400 {"embeds": ["0"]} and drops the entire notification.
+func TestDiscordBuildEmbed_RespectsEmbedLimits(t *testing.T) {
+	t.Parallel()
+
+	sender := &discordSender{}
+
+	payload := domain.NotificationPayload{
+		Event:        domain.NotificationEventPushError,
+		ReleaseName:  strings.Repeat("Very Long Release Name ", 50),
+		Filter:       strings.Repeat("f", 2000),
+		Indexer:      strings.Repeat("i", 2000),
+		Action:       strings.Repeat("a", 2000),
+		ActionClient: strings.Repeat("c", 2000),
+		Status:       domain.ReleasePushStatusErr,
+		ActionType:   domain.ActionTypeRadarr,
+		Rejections:   []string{"radarr failed to push release: " + strings.Repeat("x", 4000) + ": i/o timeout"},
+	}
+
+	embed := sender.buildEmbed(payload.Event, payload)
+
+	assert.LessOrEqual(t, utf8.RuneCountInString(embed.Title), discordEmbedTitleLimit)
+	assert.LessOrEqual(t, utf8.RuneCountInString(embed.Description), discordEmbedDescriptionLimit)
+
+	var reasons string
+	for _, f := range embed.Fields {
+		assert.LessOrEqual(t, utf8.RuneCountInString(f.Name), discordEmbedFieldNameLimit)
+		assert.LessOrEqual(t, utf8.RuneCountInString(f.Value), discordEmbedFieldValueLimit, "field %q", f.Name)
+
+		if f.Name == "Reasons" {
+			reasons = f.Value
+		}
+	}
+
+	require.NotEmpty(t, reasons)
+	assert.True(t, strings.HasPrefix(reasons, "```\n"), "opening code fence was cut")
+	assert.True(t, strings.HasSuffix(reasons, "\n```"), "closing code fence was cut")
+	// the cause is wrapped last, so it is the part that has to survive
+	assert.Contains(t, reasons, "i/o timeout")
+}
+
+func TestDiscordBuildEmbed_TruncatesLongSubjectAndMessage(t *testing.T) {
+	t.Parallel()
+
+	sender := &discordSender{}
+
+	payload := domain.NotificationPayload{
+		Event:   domain.NotificationEventTest,
+		Subject: strings.Repeat("s", 1000),
+		Message: strings.Repeat("m", 9000),
+	}
+
+	embed := sender.buildEmbed(payload.Event, payload)
+
+	assert.Equal(t, discordEmbedTitleLimit, utf8.RuneCountInString(embed.Title))
+	assert.Equal(t, discordEmbedDescriptionLimit, utf8.RuneCountInString(embed.Description))
+}


### PR DESCRIPTION
# Description

Discord answers `400 {"embeds": ["0"]}` and drops the entire message when an embed field value goes over 1024 characters, and `buildEmbed` never capped anything.

It bites on PUSH_ERROR. A failed *arr push wraps the whole `http.Request` into its error string, that lands in the `Reasons` field, and the notification never arrives. So the one event you actually want to hear about is the one that reliably fails to send. It is not an edge case either: across 440 real PUSH_ERROR rows in my instance the rejection string has a median length of 1563 and a max of 1786, and 439 of the 440 are over the limit.

Checked against the real API by posting one of those 1787 character rejections through both versions of `buildEmbed`:

```
uncapped (develop)     longest field = 1795 runes -> HTTP 400 {"embeds": ["0"]}
capped (this PR)       longest field = 1024 runes -> HTTP 204
```

Long release names can do the same to the 256 character title limit, so title and description are capped too.

Truncation drops the middle rather than the tail. `errors.Wrap` prepends, so the cause of a failed push sits at the very end and tail truncation would throw away the only part worth reading. A useful side effect is that the middle is where the request dump keeps `X-Api-Key`, so the truncated field stops carrying it. The tracker passkey sits nearer the front and does survive, which is a separate bug at the source that I have opened a second PR for.

Only the four per-field limits are handled. The 6000 character combined limit and the 25 field cap are not: `buildEmbed` emits at most 10 fields, and I could not build a payload from any current call site that reaches 6000, so I would rather leave it than guess.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* `go test ./...` passes. New tests cover the helper, multi-byte input, a PUSH_ERROR shaped payload asserting every limit holds and the code fence survives, and an over-long Subject/Message pair.
* Mutation checked rather than assumed. Removing the cap fails the suite, and swapping middle truncation for tail truncation fails the assertion that the cause survives.
* The live before and after against a real Discord webhook, shown above.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Yes. Written with Claude Code (Claude Opus 5). The implementation and the tests are AI-written and I reviewed them, and the verification above is mine: the 440 row measurement and the live webhook check both come from my own instance.
