### PR TITLE
feat(indexers): update PeerGarden IRC server

### DIFF
--- a/internal/indexer/definitions/peergarden.yaml
+++ b/internal/indexer/definitions/peergarden.yaml
@@ -21,8 +21,8 @@ settings:
     help: "Click the cog icon in the top right corner, RSS key is located in the sidebar."
 
 irc:
-  network: P2P-Network
-  server: irc.p2p-network.net
+  network: PeerGarden
+  server: irc.peergarden.org
   port: 6697
   tls: true
   settings:
@@ -45,7 +45,7 @@ irc:
       help: NickServ password
 
   channels:
-    - name: "#peergarden"
+    - name: "#announce"
       announcers:
         - "PeerGarden"
       parse:


### PR DESCRIPTION
# Description

PeerGarden moved off P2P-Network to their own IRC network. This updates the `peergarden.yaml` definition to match:

* `network`: `P2P-Network` -> `PeerGarden`
* `server`: `irc.p2p-network.net` -> `irc.peergarden.org` (port `6697` with TLS, unchanged)
* announce channel: `#peergarden` -> `#announce`

The announce format and announcer (`PeerGarden`) are unchanged, so the existing parse rules still apply. Existing PeerGarden users need to update the server and channel on their IRC network manually, since definition updates do not migrate stored IRC network settings.

Fixes #2598

## Type of change

- [x] Indexer definition update

## How has this been tested?

* `go test ./internal/indexer/...` passes (validates the definition loads and parses)
* New network details match the PeerGarden news post quoted in #2598, including an example announce confirming the format is unchanged

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed