### PR TITLE
fix(indexers): bring back MAM VIP to FL mapping

### DIFF
--- a/internal/indexer/definitions/myanonamouse.yaml
+++ b/internal/indexer/definitions/myanonamouse.yaml
@@ -113,6 +113,11 @@ irc:
                   torrentId: "1262681"
                   releaseTags: VIP
 
+        mappings:
+          releaseTags:
+            "VIP":
+              freeleech: VIP
+
         match:
           infourl: "/t/{{ .torrentId }}"
           downloadurl: "/tor/download.php?tid={{ .torrentId }}"


### PR DESCRIPTION
# Description

PR #2593 updated the MyAnonamouse announce pattern to the new format, but also accidentally dropped the `mappings` block from `myanonamouse.yaml`. `releaseTags` was still captured (`VIP` / `Normal`), but nothing mapped it onto the release's freeleech field, so any filter with **Freeleech** enabled for MAM could never match - announces parsed fine and were silently dropped.

This restores the `releaseTags: VIP` → `freeleech` mapping. The regression never shipped in a release (`v1.83.0` carries the old definition).

Fixes #2602

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Restoring the block via `customDefinitions` was verified against live MAM announces on v1.83.0 - `VIP` marks the release freeleech, `Normal` stays non-freeleech
* `go test ./internal/indexer/...` passes (loads and validates the definition YAML)

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed