### PR TITLE
fix(irc): set default auth mechanism and gate NickServ fallback

### DIFF
--- a/internal/domain/indexer.go
+++ b/internal/domain/indexer.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"text/template"
@@ -183,12 +184,16 @@ func (i IndexerImplementation) String() string {
 }
 
 func (i IndexerDefinition) HasApi() bool {
-	for _, a := range i.Supports {
-		if a == "api" {
-			return true
-		}
+	return slices.Contains(i.Supports, "api")
+}
+
+// ValidateIRCAuth rejects invalid authentication metadata in an indexer definition.
+func (i IndexerDefinition) ValidateIRCAuth() error {
+	if i.IRC == nil || i.IRC.Auth == nil {
+		return nil
 	}
-	return false
+
+	return i.IRC.Auth.Validate()
 }
 
 type IndexerDefinitionCustom struct {
@@ -243,6 +248,7 @@ func (i *IndexerDefinitionCustom) ToIndexerDefinition() *IndexerDefinition {
 			Server:      i.IRC.Server,
 			Port:        i.IRC.Port,
 			TLS:         i.IRC.TLS,
+			Auth:        i.IRC.Auth,
 			SettingsMap: i.IRC.SettingsMap,
 			Settings:    i.IRC.Settings,
 			Channels:    make([]IndexerIRCV2Channel, 0),
@@ -355,11 +361,26 @@ type IndexerIRC struct {
 	Server      string            `json:"server"`
 	Port        int               `json:"port"`
 	TLS         bool              `json:"tls"`
+	Auth        *IndexerIRCAuth   `json:"auth,omitempty"`
 	Channels    []string          `json:"channels"`
 	Announcers  []string          `json:"announcers"`
 	SettingsMap map[string]string `json:"-"`
 	Settings    []IndexerSetting  `json:"settings"`
 	Parse       *IndexerIRCParse  `json:"parse,omitempty"`
+}
+
+// IndexerIRCAuth declares the authentication mechanism used by an IRC network.
+type IndexerIRCAuth struct {
+	Mechanism IRCAuthMechanism `json:"mechanism"`
+}
+
+// Validate rejects undeclared and unknown authentication mechanisms.
+func (a IndexerIRCAuth) Validate() error {
+	if !a.Mechanism.IsValid() {
+		return errors.New("invalid IRC authentication mechanism: %q", a.Mechanism)
+	}
+
+	return nil
 }
 
 type IRCMappings map[string]map[string]map[string]string
@@ -369,6 +390,7 @@ type IndexerIRCV2 struct {
 	Server      string                          `json:"server"`
 	Port        int                             `json:"port"`
 	TLS         bool                            `json:"tls"`
+	Auth        *IndexerIRCAuth                 `json:"auth,omitempty"`
 	SettingsMap map[string]string               `json:"-"`
 	Settings    []IndexerSetting                `json:"settings"`
 	Channels    []IndexerIRCV2Channel           `json:"channels"`

--- a/internal/domain/irc.go
+++ b/internal/domain/irc.go
@@ -6,6 +6,8 @@ package domain
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/autobrr/autobrr/pkg/errors"
 )
 
 type IrcChannel struct {
@@ -40,6 +42,48 @@ type IRCAuth struct {
 	Mechanism IRCAuthMechanism `json:"mechanism,omitempty"`
 	Account   string           `json:"account,omitempty"`
 	Password  string           `json:"password,omitempty"`
+}
+
+// IsValid reports whether the mechanism is one of the supported explicit values.
+func (m IRCAuthMechanism) IsValid() bool {
+	switch m {
+	case IRCAuthMechanismNone, IRCAuthMechanismSASLPlain, IRCAuthMechanismNickServ:
+		return true
+	default:
+		return false
+	}
+}
+
+// Validate rejects unknown authentication mechanisms. Incomplete credentials
+// remain accepted so existing networks can still be edited; they simply do not
+// enable authentication at runtime.
+func (ia IRCAuth) Validate() error {
+	if ia.Mechanism == "" {
+		return nil
+	}
+
+	if !ia.Mechanism.IsValid() {
+		return errors.New("invalid IRC authentication mechanism: %q", ia.Mechanism)
+	}
+
+	return nil
+}
+
+// NickServEnabled reports whether NickServ identification is permitted. SASL
+// permits the existing NickServ fallback when negotiation does not complete. An
+// empty mechanism retains the historical password-only behavior for database
+// rows and API clients created before mechanisms were required.
+func (ia IRCAuth) NickServEnabled() bool {
+	switch ia.Mechanism {
+	case IRCAuthMechanismNickServ:
+		return ia.Password != ""
+	case IRCAuthMechanismSASLPlain:
+		return ia.Account != "" && ia.Password != ""
+	case "":
+		return ia.Password != ""
+	default:
+		return false
+	}
 }
 
 func (ia IRCAuth) MarshalJSON() ([]byte, error) {

--- a/internal/domain/irc_auth_test.go
+++ b/internal/domain/irc_auth_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package domain
+
+import "testing"
+
+func TestIRCAuthValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		auth    IRCAuth
+		wantErr bool
+	}{
+		{name: "none", auth: IRCAuth{Mechanism: IRCAuthMechanismNone}},
+		{name: "none retains credentials", auth: IRCAuth{Mechanism: IRCAuthMechanismNone, Account: "old", Password: "old"}},
+		{name: "sasl", auth: IRCAuth{Mechanism: IRCAuthMechanismSASLPlain, Account: "user", Password: "secret"}},
+		{name: "legacy sasl missing account", auth: IRCAuth{Mechanism: IRCAuthMechanismSASLPlain, Password: "secret"}},
+		{name: "legacy sasl missing password", auth: IRCAuth{Mechanism: IRCAuthMechanismSASLPlain, Account: "user"}},
+		{name: "nickserv with account", auth: IRCAuth{Mechanism: IRCAuthMechanismNickServ, Account: "user", Password: "secret"}},
+		{name: "nickserv password only", auth: IRCAuth{Mechanism: IRCAuthMechanismNickServ, Password: "secret"}},
+		{name: "legacy nickserv missing password", auth: IRCAuth{Mechanism: IRCAuthMechanismNickServ, Account: "user"}},
+		{name: "legacy empty mechanism", auth: IRCAuth{}},
+		{name: "legacy password only", auth: IRCAuth{Password: "secret"}},
+		{name: "unknown mechanism", auth: IRCAuth{Mechanism: "TYPO", Password: "secret"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.auth.Validate(); (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIRCAuthNickServEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		auth IRCAuth
+		want bool
+	}{
+		{name: "none with leftover credentials", auth: IRCAuth{Mechanism: IRCAuthMechanismNone, Password: "secret"}},
+		{name: "nickserv password only", auth: IRCAuth{Mechanism: IRCAuthMechanismNickServ, Password: "secret"}, want: true},
+		{name: "nickserv without password", auth: IRCAuth{Mechanism: IRCAuthMechanismNickServ}},
+		{name: "sasl fallback", auth: IRCAuth{Mechanism: IRCAuthMechanismSASLPlain, Account: "user", Password: "secret"}, want: true},
+		{name: "incomplete sasl", auth: IRCAuth{Mechanism: IRCAuthMechanismSASLPlain, Password: "secret"}},
+		{name: "legacy empty mechanism", auth: IRCAuth{Password: "secret"}, want: true},
+		{name: "unknown mechanism", auth: IRCAuth{Mechanism: "TYPO", Password: "secret"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.auth.NickServEnabled(); got != tt.want {
+				t.Fatalf("NickServEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/http/irc.go
+++ b/internal/http/irc.go
@@ -136,6 +136,11 @@ func (h ircHandler) storeNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := data.Auth.Validate(); err != nil {
+		h.encoder.BadRequestErr(w, err)
+		return
+	}
+
 	if err := h.service.StoreNetwork(r.Context(), &data); err != nil {
 		h.encoder.Error(w, err)
 		return
@@ -148,6 +153,11 @@ func (h ircHandler) updateNetwork(w http.ResponseWriter, r *http.Request) {
 	var data domain.IrcNetwork
 	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
 		h.encoder.Error(w, err)
+		return
+	}
+
+	if err := data.Auth.Validate(); err != nil {
+		h.encoder.BadRequestErr(w, err)
 		return
 	}
 

--- a/internal/http/irc_test.go
+++ b/internal/http/irc_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+type ircAuthValidationService struct {
+	storeCalls  int
+	updateCalls int
+}
+
+func (s *ircAuthValidationService) ListNetworks(context.Context) ([]domain.IrcNetwork, error) {
+	return nil, nil
+}
+
+func (s *ircAuthValidationService) GetNetworksWithHealth(context.Context) ([]domain.IrcNetworkWithHealth, error) {
+	return nil, nil
+}
+
+func (s *ircAuthValidationService) DeleteNetwork(context.Context, int64) error { return nil }
+
+func (s *ircAuthValidationService) GetNetworkByID(context.Context, int64) (*domain.IrcNetwork, error) {
+	return nil, nil
+}
+
+func (s *ircAuthValidationService) StoreNetwork(context.Context, *domain.IrcNetwork) error {
+	s.storeCalls++
+	return nil
+}
+
+func (s *ircAuthValidationService) UpdateNetwork(context.Context, *domain.IrcNetwork) error {
+	s.updateCalls++
+	return nil
+}
+
+func (s *ircAuthValidationService) StoreChannel(context.Context, int64, *domain.IrcChannel) error {
+	return nil
+}
+
+func (s *ircAuthValidationService) RestartNetwork(context.Context, int64) error { return nil }
+
+func (s *ircAuthValidationService) SendCmd(context.Context, *domain.SendIrcCmdRequest) error {
+	return nil
+}
+
+func (s *ircAuthValidationService) ManualProcessAnnounce(context.Context, *domain.IRCManualProcessRequest) error {
+	return nil
+}
+
+func (s *ircAuthValidationService) GetMessageHistory(context.Context, int64, string) ([]domain.IrcMessage, error) {
+	return nil, nil
+}
+
+func TestIRCHandlerRejectsInvalidAuthBeforeService(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "unknown mechanism", body: `{"auth":{"mechanism":"TYPO","password":"secret"}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &ircAuthValidationService{}
+			handler := newIrcHandler(encoder{}, nil, service)
+
+			for _, method := range []string{http.MethodPost, http.MethodPut} {
+				recorder := httptest.NewRecorder()
+				request := httptest.NewRequest(method, "/", strings.NewReader(tt.body))
+				if method == http.MethodPost {
+					handler.storeNetwork(recorder, request)
+				} else {
+					handler.updateNetwork(recorder, request)
+				}
+
+				assert.Equal(t, http.StatusBadRequest, recorder.Code, method)
+			}
+
+			assert.Zero(t, service.storeCalls)
+			assert.Zero(t, service.updateCalls)
+		})
+	}
+}
+
+func TestIRCHandlerAcceptsCompatibleAuth(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "omitted mechanism", body: `{"auth":{"password":"secret"}}`},
+		{name: "legacy incomplete sasl", body: `{"auth":{"mechanism":"SASL_PLAIN"}}`},
+		{name: "password only nickserv", body: `{"auth":{"mechanism":"NICKSERV","password":"secret"}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &ircAuthValidationService{}
+			handler := newIrcHandler(encoder{}, nil, service)
+
+			for _, method := range []string{http.MethodPost, http.MethodPut} {
+				recorder := httptest.NewRecorder()
+				request := httptest.NewRequest(method, "/", strings.NewReader(tt.body))
+				if method == http.MethodPost {
+					handler.storeNetwork(recorder, request)
+				} else {
+					handler.updateNetwork(recorder, request)
+				}
+
+				assert.Equal(t, http.StatusNoContent, recorder.Code, method)
+			}
+
+			assert.Equal(t, 1, service.storeCalls)
+			assert.Equal(t, 1, service.updateCalls)
+		})
+	}
+}

--- a/internal/indexer/definition_test.go
+++ b/internal/indexer/definition_test.go
@@ -4,11 +4,15 @@
 package indexer
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/autobrr/autobrr/internal/domain"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Secret-typed settings are redacted per field type in definition responses, while stored
@@ -53,5 +57,68 @@ func TestIndexerYamlExpectations(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDefinitionIRCAuth(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		mechanism string
+		want      domain.IRCAuthMechanism
+		wantErr   bool
+	}{
+		{name: "v1 nickserv", mechanism: "NICKSERV", want: domain.IRCAuthMechanismNickServ},
+		{name: "v2 none", version: "version: 2\n", mechanism: "NONE", want: domain.IRCAuthMechanismNone},
+		{name: "unknown", version: "version: 2\n", mechanism: "TYPO", wantErr: true},
+		{name: "empty", version: "version: 2\n", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "definition.yaml")
+			data := "---\n" + tt.version + `name: Test
+identifier: test
+implementation: irc
+irc:
+  network: Test
+  server: irc.test
+  port: 6697
+  tls: true
+  auth:
+    mechanism: ` + tt.mechanism + "\n"
+			require.NoError(t, os.WriteFile(file, []byte(data), 0o644))
+
+			definition, err := OpenAndProcessDefinition(file)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, definition.IRC)
+			require.NotNil(t, definition.IRC.Auth)
+			assert.Equal(t, tt.want, definition.IRC.Auth.Mechanism)
+		})
+	}
+}
+
+func TestBundledDefinitionIRCAuth(t *testing.T) {
+	s := &Service{definitions: map[string]domain.IndexerDefinition{}}
+	require.NoError(t, s.LoadIndexerDefinitions())
+
+	for _, identifier := range []string{
+		"aither", "animebytes", "brks", "docspedia", "funfile", "sharewood", "superbits", "torrentleech", "zenith",
+	} {
+		definition := s.definitions[identifier]
+		require.NotNil(t, definition.IRC, identifier)
+		require.NotNil(t, definition.IRC.Auth, identifier)
+		assert.Equal(t, domain.IRCAuthMechanismNickServ, definition.IRC.Auth.Mechanism, identifier)
+	}
+
+	for _, identifier := range []string{"alpharatio"} {
+		definition := s.definitions[identifier]
+		require.NotNil(t, definition.IRC, identifier)
+		assert.Nil(t, definition.IRC.Auth, identifier)
 	}
 }

--- a/internal/indexer/definitions/aither.yaml
+++ b/internal/indexer/definitions/aither.yaml
@@ -25,6 +25,8 @@ irc:
   server: irc.aither.cc
   port: 6697
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text

--- a/internal/indexer/definitions/animebytes.yaml
+++ b/internal/indexer/definitions/animebytes.yaml
@@ -25,6 +25,8 @@ irc:
   server: irc.animefriends.moe
   port: 7000
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text

--- a/internal/indexer/definitions/brokenstones.yaml
+++ b/internal/indexer/definitions/brokenstones.yaml
@@ -31,6 +31,8 @@ irc:
   server: irc.brokenstones.is
   port: 6697
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text

--- a/internal/indexer/definitions/docspedia.yaml
+++ b/internal/indexer/definitions/docspedia.yaml
@@ -25,6 +25,8 @@ irc:
   server: irc.docspedia.world
   port: 6697
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text

--- a/internal/indexer/definitions/funfile.yaml
+++ b/internal/indexer/definitions/funfile.yaml
@@ -25,6 +25,8 @@ irc:
   server: irc.funfile.org
   port: 6697
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text

--- a/internal/indexer/definitions/myanonamouse.yaml
+++ b/internal/indexer/definitions/myanonamouse.yaml
@@ -25,6 +25,8 @@ irc:
   server: irc.myanonamouse.net
   port: 6697
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text

--- a/internal/indexer/definitions/sharewood.yaml
+++ b/internal/indexer/definitions/sharewood.yaml
@@ -24,6 +24,8 @@ irc:
   server: hiddenforest.joe.dj
   port: 7000
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text
@@ -35,7 +37,7 @@ irc:
       type: text
       required: false
       label: NickServ Account
-      help: NickServ account. Make sure to group your user and bot. Change Mechanism from SASL to NickServ in IRC settings.
+      help: NickServ account. Make sure to group your user and bot.
 
     - name: auth.password
       type: secret

--- a/internal/indexer/definitions/superbits.yaml
+++ b/internal/indexer/definitions/superbits.yaml
@@ -26,6 +26,8 @@ irc:
   server: irc.superbits.org
   port: 6697
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text

--- a/internal/indexer/definitions/torrentleech.yaml
+++ b/internal/indexer/definitions/torrentleech.yaml
@@ -30,6 +30,8 @@ irc:
   server: irc.torrentleech.org
   port: 7021
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text

--- a/internal/indexer/definitions/zenith.yaml
+++ b/internal/indexer/definitions/zenith.yaml
@@ -25,6 +25,8 @@ irc:
   server: irc.znth.cx
   port: 6697
   tls: true
+  auth:
+    mechanism: NICKSERV
   settings:
     - name: nick
       type: text

--- a/internal/indexer/service.go
+++ b/internal/indexer/service.go
@@ -539,6 +539,9 @@ func (s *Service) LoadIndexerDefinitions() error {
 		if err = dec.Decode(&d); err != nil {
 			return errors.Wrap(err, "could not unmarshal indexer definition file: %s", file)
 		}
+		if err = d.ValidateIRCAuth(); err != nil {
+			return errors.Wrap(err, "invalid indexer definition file: %s", file)
+		}
 
 		d.Prepare()
 
@@ -580,6 +583,9 @@ func OpenAndProcessDefinition(file string) (*domain.IndexerDefinition, error) {
 		if err := dec.Decode(&d); err != nil {
 			return nil, errors.Wrap(err, "could not decode definition file: %s", file)
 		}
+		if err := d.ValidateIRCAuth(); err != nil {
+			return nil, errors.Wrap(err, "invalid definition file: %s", file)
+		}
 
 		d.Prepare()
 
@@ -604,7 +610,12 @@ func OpenAndProcessDefinition(file string) (*domain.IndexerDefinition, error) {
 		d.Implementation = domain.IndexerImplementationIRC
 	}
 
-	return d.ToIndexerDefinition(), nil
+	definition := d.ToIndexerDefinition()
+	if err := definition.ValidateIRCAuth(); err != nil {
+		return nil, errors.Wrap(err, "invalid definition file: %s", file)
+	}
+
+	return definition, nil
 }
 
 func OpenAndDecodeDefinition(file string, data any) error {

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -94,6 +94,7 @@ type Handler struct {
 	identifyAttempt     identifyForm
 	identifyEscalated   bool
 	identifyFormLearned identifyForm
+	identifyOutstanding bool
 
 	channels *haxmap.Map[string, *Channel]
 
@@ -570,6 +571,7 @@ func (h *Handler) SetNetwork(network *domain.IrcNetwork) {
 func (h *Handler) setNetworkLocked(network *domain.IrcNetwork) {
 	if h.network == nil || h.network.Auth != network.Auth {
 		h.identifyFormLearned = identifyFormBare
+		h.identifyOutstanding = false
 	}
 
 	h.network = network
@@ -592,6 +594,7 @@ func (h *Handler) resetChannelState() {
 func (h *Handler) Stop() {
 	h.m.Lock()
 	h.connectedSince = time.Time{}
+	h.identifyOutstanding = false
 	client := h.client
 	h.clientState = ircStopped
 	h.client = nil
@@ -707,6 +710,13 @@ func (h *Handler) handleNickServ(msg ircmsg.Message) {
 	h.log.Trace().Interface("msg_params", msg.Params).Msg("NOTICE from nickserv")
 
 	if len(msg.Params) < 2 {
+		return
+	}
+
+	h.m.RLock()
+	expectingReply := h.identifyOutstanding && !h.authenticated && !h.saslauthed && h.network.Auth.NickServEnabled()
+	h.m.RUnlock()
+	if !expectingReply {
 		return
 	}
 
@@ -858,13 +868,21 @@ func (h *Handler) setBotMode() {
 // authenticate sends NickServIdentify if not authenticated
 func (h *Handler) authenticate() {
 	h.m.RLock()
-	shouldSendNickserv := !h.authenticated && !h.saslauthed && h.network.Auth.Password != ""
+	authenticated := h.authenticated
+	saslauthed := h.saslauthed
+	identifyOutstanding := h.identifyOutstanding
+	nickServEnabled := h.network.Auth.NickServEnabled()
 	h.m.RUnlock()
 
-	if shouldSendNickserv {
-		h.log.Trace().Msg("on connect not authenticated and password not empty: send nickserv identify")
+	switch {
+	case authenticated || saslauthed:
+		h.setAuthenticated()
+	case identifyOutstanding:
+		return
+	case nickServEnabled:
+		h.log.Trace().Msg("sending NickServ identify")
 		h.NickServIdentify()
-	} else {
+	default:
 		h.setAuthenticated()
 	}
 }
@@ -892,6 +910,7 @@ func (h *Handler) handleLoggedIn(m ircmsg.Message) {
 func (h *Handler) handleSASLSuccess(_ ircmsg.Message) {
 	h.m.Lock()
 	h.saslauthed = true
+	h.identifyOutstanding = false
 	h.m.Unlock()
 }
 
@@ -938,6 +957,7 @@ func (h *Handler) handleSASLFail(_ ircmsg.Message) {
 func (h *Handler) setAuthenticated() {
 	h.m.Lock()
 	alreadyAuthenticated := h.authenticated
+	h.identifyOutstanding = false
 	if !alreadyAuthenticated {
 		h.authenticated = true
 		h.connectionErrors = []string{}
@@ -1679,10 +1699,15 @@ func (h *Handler) handleInviteResponse(msg ircmsg.Message) {
 // account-qualified form.
 func (h *Handler) identifyCommand() string {
 	h.m.RLock()
+	defer h.m.RUnlock()
+
+	return h.identifyCommandLocked()
+}
+
+func (h *Handler) identifyCommandLocked() string {
 	form := h.identifyAttempt
 	account := h.network.Auth.Account
 	password := h.network.Auth.Password
-	h.m.RUnlock()
 
 	if form == identifyFormAccount && account != "" {
 		return fmt.Sprintf("IDENTIFY %s %s", account, password)
@@ -1695,7 +1720,21 @@ func (h *Handler) identifyCommand() string {
 // PRIVMSG parameter: split across parameters it lands past the message body,
 // where every ircd discards it.
 func (h *Handler) NickServIdentify() error {
-	if err := h.Send("PRIVMSG", "NickServ", h.identifyCommand()); err != nil {
+	h.m.Lock()
+	if h.authenticated || h.saslauthed || !h.network.Auth.NickServEnabled() {
+		h.identifyOutstanding = false
+		h.m.Unlock()
+		return nil
+	}
+
+	command := h.identifyCommandLocked()
+	h.identifyOutstanding = true
+	h.m.Unlock()
+
+	if err := h.Send("PRIVMSG", "NickServ", command); err != nil {
+		h.m.Lock()
+		h.identifyOutstanding = false
+		h.m.Unlock()
 		h.log.Error().Stack().Err(err).Msg("error identifying with nickserv")
 		return err
 	}
@@ -1716,7 +1755,7 @@ func (h *Handler) canEscalateIdentify(currentNick string) bool {
 		return false
 	}
 
-	if h.network.Auth.Account == "" || h.network.Auth.Password == "" {
+	if !h.network.Auth.NickServEnabled() || h.network.Auth.Account == "" {
 		return false
 	}
 
@@ -1779,6 +1818,7 @@ func (h *Handler) escalateIdentify() {
 func (h *Handler) resetIdentifyForm() {
 	h.identifyAttempt = h.identifyFormLearned
 	h.identifyEscalated = false
+	h.identifyOutstanding = false
 }
 
 // unlearnIdentifyForm drops a remembered account-qualified form once it has
@@ -1808,18 +1848,18 @@ func (h *Handler) NickChange(nick string) error {
 func (h *Handler) CurrentNick() string {
 	if client := h.getClient(); client != nil {
 		return client.CurrentNick()
-	} else {
-		return ""
 	}
+
+	return ""
 }
 
 // PreferredNick returns our preferred nick from settings
 func (h *Handler) PreferredNick() string {
 	if client := h.getClient(); client != nil {
 		return client.PreferredNick()
-	} else {
-		return ""
 	}
+
+	return ""
 }
 
 // listens for MODE events

--- a/internal/irc/nickserv_identify_test.go
+++ b/internal/irc/nickserv_identify_test.go
@@ -34,14 +34,114 @@ func nickServNotice(nick, text string) ircmsg.Message {
 	}
 }
 
-// withNickServAuth configures a handler for NICKSERV auth with a bot nick that
-// differs from the account, i.e. the setup in issue #2528.
+// withNickServAuth configures a handler waiting for a NICKSERV reply with a bot
+// nick that differs from the account, i.e. the setup in issue #2528.
 func withNickServAuth(h *Handler, account string) {
 	h.network.Nick = "user_bot"
 	h.network.Auth = domain.IRCAuth{
 		Mechanism: domain.IRCAuthMechanismNickServ,
 		Account:   account,
 		Password:  "hunter2",
+	}
+	h.identifyOutstanding = true
+}
+
+func TestAuthenticateGatesNickServOnMechanism(t *testing.T) {
+	tests := []struct {
+		name              string
+		auth              domain.IRCAuth
+		saslauthed        bool
+		wantAuthenticated bool
+	}{
+		{
+			name:              "none ignores leftover password",
+			auth:              domain.IRCAuth{Mechanism: domain.IRCAuthMechanismNone, Password: "hunter2"},
+			wantAuthenticated: true,
+		},
+		{
+			name: "nickserv password only identifies",
+			auth: domain.IRCAuth{Mechanism: domain.IRCAuthMechanismNickServ, Password: "hunter2"},
+		},
+		{
+			name: "sasl falls back when negotiation did not complete",
+			auth: domain.IRCAuth{Mechanism: domain.IRCAuthMechanismSASLPlain, Account: "test_bot", Password: "hunter2"},
+		},
+		{
+			name:              "sasl success skips nickserv",
+			auth:              domain.IRCAuth{Mechanism: domain.IRCAuthMechanismSASLPlain, Account: "test_bot", Password: "hunter2"},
+			saslauthed:        true,
+			wantAuthenticated: true,
+		},
+		{
+			name:              "legacy empty mechanism keeps password behavior",
+			auth:              domain.IRCAuth{Password: "hunter2"},
+			wantAuthenticated: false,
+		},
+		{
+			name:              "unknown mechanism never identifies",
+			auth:              domain.IRCAuth{Mechanism: "TYPO", Password: "hunter2"},
+			wantAuthenticated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := newTestHandler()
+			h.network.Auth = tt.auth
+			h.saslauthed = tt.saslauthed
+
+			h.authenticate()
+
+			if h.authenticated != tt.wantAuthenticated {
+				t.Fatalf("authenticated = %v, want %v", h.authenticated, tt.wantAuthenticated)
+			}
+			if tt.wantAuthenticated && h.identifyOutstanding {
+				t.Fatal("authentication that skips NickServ must not leave an IDENTIFY outstanding")
+			}
+		})
+	}
+}
+
+func TestHandleNickServRequiresOutstandingIdentify(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*Handler)
+	}{
+		{name: "none", setup: func(h *Handler) { h.network.Auth.Mechanism = domain.IRCAuthMechanismNone }},
+		{name: "not outstanding", setup: func(h *Handler) { h.identifyOutstanding = false }},
+		{name: "already authenticated", setup: func(h *Handler) { h.authenticated = true }},
+		{name: "authenticated over sasl", setup: func(h *Handler) { h.saslauthed = true }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, _ := newTestHandler()
+			withNickServAuth(h, "test_bot")
+			tt.setup(h)
+
+			h.handleNickServ(nickServNotice("user_bot", "Password incorrect."))
+
+			if h.Stopped() {
+				t.Fatal("unsolicited NickServ notice stopped the network")
+			}
+			if len(h.connectionErrors) != 0 {
+				t.Fatalf("unsolicited NickServ notice added errors: %v", h.connectionErrors)
+			}
+		})
+	}
+}
+
+func TestOnConnectedSkipsNickServForNone(t *testing.T) {
+	h, _ := newTestHandler()
+	h.network.Auth = domain.IRCAuth{
+		Mechanism: domain.IRCAuthMechanismNone,
+		Password:  "leftover",
+	}
+
+	h.stateMachine.OnConnected()
+
+	if state := h.stateMachine.GetState(); state == StateAuthenticating {
+		t.Fatal("mechanism NONE entered the NickServ authentication state")
 	}
 }
 
@@ -205,6 +305,7 @@ func TestIdentifyFormIsStickyPerNetwork(t *testing.T) {
 	withNickServAuth(h, "test_bot")
 
 	h.handleNickServ(nickServNotice("user_bot", "Nick user_bot isn't registered."))
+	h.identifyOutstanding = true
 	h.handleNickServ(nickServNotice("user_bot", "Password accepted - you are now recognized."))
 
 	if !h.authenticated {
@@ -342,6 +443,7 @@ func TestHandleNickServStopsWhenAccountUnknownAfterEscalation(t *testing.T) {
 	withNickServAuth(h, "test_bot")
 
 	h.handleNickServ(nickServNotice("user_bot", "Nick user_bot isn't registered."))
+	h.identifyOutstanding = true
 	h.handleNickServ(nickServNotice("user_bot", "Nick test_bot isn't registered."))
 
 	if !h.Stopped() {
@@ -362,6 +464,7 @@ func TestHandleNickServBadCredentialsAfterEscalation(t *testing.T) {
 	withNickServAuth(h, "test_bot")
 
 	h.handleNickServ(nickServNotice("user_bot", "Your nick isn't registered."))
+	h.identifyOutstanding = true
 	h.handleNickServ(nickServNotice("user_bot", "Password incorrect."))
 
 	if !h.Stopped() {

--- a/internal/irc/service.go
+++ b/internal/irc/service.go
@@ -609,6 +609,9 @@ func (s *Service) UpdateNetwork(ctx context.Context, network *domain.IrcNetwork)
 	if domain.IsRedactedString(network.Auth.Password) {
 		network.Auth.Password = existingNetwork.Auth.Password
 	}
+	if err := network.Auth.Validate(); err != nil {
+		return err
+	}
 
 	s.log.Debug().Str("network", network.Name).Msg("update network")
 
@@ -673,6 +676,10 @@ func (s *Service) UpdateNetwork(ctx context.Context, network *domain.IrcNetwork)
 }
 
 func (s *Service) StoreNetwork(ctx context.Context, network *domain.IrcNetwork) error {
+	if err := network.Auth.Validate(); err != nil {
+		return err
+	}
+
 	existingNetwork, err := s.repo.CheckExistingNetwork(ctx, network)
 	if err != nil {
 		s.log.Error().Err(err).Msg("could not check for existing network")

--- a/internal/irc/state_machine.go
+++ b/internal/irc/state_machine.go
@@ -262,7 +262,7 @@ func (sm *ConnectionStateMachine) onStateEntry(state ConnectionState) {
 
 func (sm *ConnectionStateMachine) handleAuthentication() {
 	sm.handler.m.RLock()
-	needsAuth := sm.handler.network.Auth.Password != "" && !sm.handler.saslauthed
+	needsAuth := sm.handler.network.Auth.NickServEnabled() && !sm.handler.saslauthed
 	sm.handler.m.RUnlock()
 
 	if needsAuth {
@@ -308,7 +308,7 @@ func (sm *ConnectionStateMachine) OnConnected() {
 	// Determine next state based on auth requirements
 	sm.handler.m.RLock()
 	botMode := sm.handler.network.BotMode
-	needsAuth := sm.handler.network.Auth.Password != "" && !sm.handler.saslauthed
+	needsAuth := sm.handler.network.Auth.NickServEnabled() && !sm.handler.saslauthed
 	sm.handler.m.RUnlock()
 
 	if botMode && sm.handler.botModeSupported() {

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -420,6 +420,29 @@ type SelectValue = {
   value: string;
 };
 
+const buildIndexerIRCAuth = (
+  definitionAuth: IndexerIRCAuth | undefined,
+  formAuth: Partial<IrcAuth> | undefined
+): IrcAuth => {
+  const mechanism = definitionAuth?.mechanism ?? "SASL_PLAIN";
+  const account = formAuth?.account ?? "";
+  const password = formAuth?.password ?? "";
+
+  if (mechanism === "NICKSERV" && password !== "") {
+    return {
+      mechanism,
+      ...(account !== "" && { account }),
+      password
+    };
+  }
+
+  if (mechanism === "SASL_PLAIN" && account !== "" && password !== "") {
+    return { mechanism, account, password };
+  }
+
+  return { mechanism: "NONE" };
+};
+
 export function IndexerAddForm({ isOpen, toggle }: AddFormProps) {
   const { t } = useTranslation("settings");
   const [indexer, setIndexer] = useState<IndexerDefinition>({} as IndexerDefinition);
@@ -569,22 +592,10 @@ export function IndexerAddForm({ isOpen, toggle }: AddFormProps) {
           tls: ind.irc.tls,
           tls_skip_verify: false,
           nick: formData.irc.nick,
-          auth: {
-            mechanism: "NONE"
-            // account: formData.irc.auth.account,
-            // password: formData.irc.auth.password
-          },
+          auth: buildIndexerIRCAuth(ind.irc.auth, formData.irc.auth),
           invite_command: formData.irc.invite_command,
           channels: channels
         };
-
-        if (formData.irc.auth) {
-          if (formData.irc.auth.account !== "" && formData.irc.auth.password !== "") {
-            network.auth.mechanism = "SASL_PLAIN";
-            network.auth.account = formData.irc.auth.account;
-            network.auth.password = formData.irc.auth.password;
-          }
-        }
 
         mutation.mutate(formData as Indexer, {
           onSuccess: () => {

--- a/web/src/forms/settings/IrcForms.tsx
+++ b/web/src/forms/settings/IrcForms.tsx
@@ -207,16 +207,29 @@ export function IrcNetworkAddForm({ isOpen, toggle }: AddFormProps) {
             placeholder={t("forms.irc.nickPlaceholderAdd")}
             required={true}
           />
-          <TextFieldWide
-            name="auth.account"
-            label={t("forms.irc.authAccount")}
-            placeholder={t("forms.irc.authAccountPlaceholder")}
-            required={true}
+
+          <SelectField<IrcAuthMechanism>
+            name="auth.mechanism"
+            label={t("forms.irc.mechanism")}
+            isClearable={false}
+            options={IrcAuthMechanismTypeOptions}
           />
-          <PasswordFieldWide
-            name="auth.password"
-            label={t("forms.irc.authPassword")}
-          />
+
+          {values.auth.mechanism !== "NONE" && (
+            <>
+              <TextFieldWide
+                name="auth.account"
+                label={t("forms.irc.authAccount")}
+                placeholder={t("forms.irc.authAccountPlaceholder")}
+                required={values.auth.mechanism === "SASL_PLAIN"}
+              />
+              <PasswordFieldWide
+                name="auth.password"
+                label={t("forms.irc.authPassword")}
+                required={true}
+              />
+            </>
+          )}
           <PasswordFieldWide name="invite_command" label={t("forms.irc.inviteCommand")}/>
 
           <div className="border-t border-gray-200 dark:border-gray-700 py-5">
@@ -235,7 +248,7 @@ export function IrcNetworkAddForm({ isOpen, toggle }: AddFormProps) {
   );
 }
 
-const validateNetwork = (values: FormikValues, requiredMessage: string) => {
+const validateNetwork = (values: FormikValues, requiredMessage: string, existingAuth?: IrcAuth) => {
   const errors = {} as FormikErrors<FormikValues>;
 
   if (!values.name) {
@@ -252,6 +265,23 @@ const validateNetwork = (values: FormikValues, requiredMessage: string) => {
 
   if (!values.nick) {
     errors.nick = requiredMessage;
+  }
+
+  const authChanged = !existingAuth ||
+    values.auth?.mechanism !== existingAuth.mechanism ||
+    values.auth?.account !== existingAuth.account ||
+    values.auth?.password !== existingAuth.password;
+  if (authChanged) {
+    const authErrors: FormikErrors<IrcAuth> = {};
+    if (values.auth?.mechanism === "SASL_PLAIN" && !values.auth.account) {
+      authErrors.account = requiredMessage;
+    }
+    if ((values.auth?.mechanism === "SASL_PLAIN" || values.auth?.mechanism === "NICKSERV") && !values.auth.password) {
+      authErrors.password = requiredMessage;
+    }
+    if (Object.keys(authErrors).length > 0) {
+      errors.auth = authErrors;
+    }
   }
 
   return errors;
@@ -339,7 +369,7 @@ export function IrcNetworkUpdateForm({ isOpen, toggle, data: network }: UpdateFo
       deleteAction={deleteAction}
       initialValues={initialValues}
       validate={(values) => {
-        return validateNetwork(values, t("forms.irc.required"));
+        return validateNetwork(values, t("forms.irc.required"), network.auth);
       }}
     >
       {(values) => (
@@ -430,6 +460,7 @@ export function IrcNetworkUpdateForm({ isOpen, toggle, data: network }: UpdateFo
             <SelectField<IrcAuthMechanism>
               name="auth.mechanism"
               label={t("forms.irc.mechanism")}
+              isClearable={false}
               options={IrcAuthMechanismTypeOptions}
             />
 
@@ -470,9 +501,10 @@ interface SelectFieldProps<T> {
   label: string;
   options: OptionBasicTyped<T>[]
   placeholder?: string;
+  isClearable?: boolean;
 }
 
-export function SelectField<T>({ name, label, options, placeholder }: SelectFieldProps<T>) {
+export function SelectField<T>({ name, label, options, placeholder, isClearable = true }: SelectFieldProps<T>) {
   const { t } = useTranslation("settings");
   return (
     <div className="flex items-center justify-between space-y-1 px-4 sm:space-y-0 sm:grid sm:grid-cols-3 sm:gap-4">
@@ -493,7 +525,7 @@ export function SelectField<T>({ name, label, options, placeholder }: SelectFiel
             <Select
               {...field}
               id={name}
-              isClearable={true}
+              isClearable={isClearable}
               isSearchable={true}
               components={{
                 Input: common.SelectInput,

--- a/web/src/types/Indexer.d.ts
+++ b/web/src/types/Indexer.d.ts
@@ -65,8 +65,13 @@ interface IndexerIRC {
   server: string;
   port: number;
   tls: boolean;
+  auth?: IndexerIRCAuth;
   settings: IndexerSetting[];
   channels: IndexerIRCChannel[];
+}
+
+interface IndexerIRCAuth {
+  mechanism: IrcAuthMechanism;
 }
 
 interface IndexerIRCChannel {


### PR DESCRIPTION
# Description

Networks whose IRC services only support NickServ were set up with `SASL_PLAIN` when added through the indexer wizard, so the bot failed to authenticate and join until the mechanism was switched by hand (#2600). Definitions can now declare the correct mechanism, and NickServ identification is gated on the configured mechanism instead of just a non-empty password.

- Indexer definitions can declare `irc.auth.mechanism`; the add-indexer wizard uses it instead of always assuming `SASL_PLAIN`
- Declare `NICKSERV` for Aither, AnimeBytes, BrokenStones, DocsPedia, FunFile, MyAnonamouse, Sharewood, SuperBits, TorrentLeech and Zenith
- `IRCAuth.NickServEnabled()` gates all IDENTIFY paths: mechanism `NONE` never sends IDENTIFY (a leftover password no longer leaks to networks without services), an empty mechanism keeps the legacy password-only behavior, and `SASL_PLAIN` keeps the NickServ fallback when negotiation does not complete
- Track outstanding IDENTIFY requests so unsolicited NickServ notices no longer drive auth state
- Reject unknown mechanisms with `400` at the API layer and validate again in the IRC service and on definition load
- Add network form: mechanism select with conditional account/password fields; update form only validates auth when it actually changed, so redacted passwords keep working

Closes #2600.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* `go test ./...` - new unit tests for mechanism validation and `NickServEnabled` (`internal/domain`), IDENTIFY gating and outstanding-reply handling (`internal/irc`), API `400` rejection (`internal/http`), and auth validation across all bundled definitions (`internal/indexer`)
* `pnpm --dir web build` passes; lint reports no new problems compared to `develop`

## Screenshots (for UI changes)

*Add IRC network form: new Identification mechanism select; account/password fields shown per mechanism.*

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed