### PR TITLE
fix(irc): stop network after repeated short-lived connections

### DIFF
--- a/internal/irc/flapping_test.go
+++ b/internal/irc/flapping_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package irc
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/autobrr/autobrr/internal/domain"
+
+	"github.com/ergochat/irc-go/ircevent"
+	"github.com/ergochat/irc-go/ircmsg"
+)
+
+type recordingNotificationSender struct {
+	m       sync.Mutex
+	events  []domain.NotificationEvent
+	payload []domain.NotificationPayload
+}
+
+func (s *recordingNotificationSender) Send(event domain.NotificationEvent, payload domain.NotificationPayload) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	s.events = append(s.events, event)
+	s.payload = append(s.payload, payload)
+}
+
+func (s *recordingNotificationSender) snapshot() ([]domain.NotificationEvent, []domain.NotificationPayload) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	return append([]domain.NotificationEvent(nil), s.events...), append([]domain.NotificationPayload(nil), s.payload...)
+}
+
+func recordSessionEnd(h *Handler, lifetime time.Duration, endedAt time.Time) bool {
+	h.m.Lock()
+	defer h.m.Unlock()
+
+	return h.recordSessionEndLocked(lifetime, endedAt)
+}
+
+func TestFlappingBreakerTripsOnFifthShortSession(t *testing.T) {
+	h, _ := newTestHandler()
+	started := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+
+	for i := range flappingStopThreshold - 1 {
+		if recordSessionEnd(h, time.Second, started.Add(time.Duration(i)*time.Minute)) {
+			t.Fatalf("breaker tripped after %d short sessions", i+1)
+		}
+	}
+
+	if !recordSessionEnd(h, time.Second, started.Add(4*time.Minute)) {
+		t.Fatal("breaker did not trip on the fifth short session")
+	}
+
+	h.m.RLock()
+	defer h.m.RUnlock()
+	if len(h.shortSessionEnds) != 0 {
+		t.Fatalf("breaker did not reset after tripping: %v", h.shortSessionEnds)
+	}
+}
+
+func TestFlappingBreakerResetsAfterHealthySession(t *testing.T) {
+	h, _ := newTestHandler()
+	started := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+
+	for i := range flappingStopThreshold - 1 {
+		recordSessionEnd(h, time.Second, started.Add(time.Duration(i)*time.Minute))
+	}
+
+	if recordSessionEnd(h, flappingSessionMinLifetime, started.Add(4*time.Minute)) {
+		t.Fatal("healthy session tripped the breaker")
+	}
+
+	for i := range flappingStopThreshold - 1 {
+		if recordSessionEnd(h, time.Second, started.Add(time.Duration(i+5)*time.Minute)) {
+			t.Fatalf("pre-healthy short sessions leaked into the new streak at session %d", i+1)
+		}
+	}
+}
+
+func TestFlappingBreakerExpiresOldStreak(t *testing.T) {
+	h, _ := newTestHandler()
+	started := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+
+	for i := range flappingStopThreshold - 1 {
+		recordSessionEnd(h, time.Second, started.Add(time.Duration(i)*time.Minute))
+	}
+
+	windowStart := started.Add(flappingWindow)
+	if recordSessionEnd(h, time.Second, windowStart) {
+		t.Fatal("expired short sessions tripped the breaker")
+	}
+
+	for i := 1; i < flappingStopThreshold; i++ {
+		tripped := recordSessionEnd(h, time.Second, windowStart.Add(time.Duration(i)*time.Minute))
+		if tripped != (i == flappingStopThreshold-1) {
+			t.Fatalf("new window session %d: tripped=%t", i+1, tripped)
+		}
+	}
+}
+
+func TestFlappingBreakerUsesRollingWindow(t *testing.T) {
+	h, _ := newTestHandler()
+	started := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+
+	ends := []time.Time{
+		started,
+		started.Add(14 * time.Minute),
+		started.Add(14*time.Minute + 10*time.Second),
+		started.Add(14*time.Minute + 20*time.Second),
+		started.Add(flappingWindow + time.Second),
+	}
+	for i, endedAt := range ends {
+		if recordSessionEnd(h, time.Second, endedAt) {
+			t.Fatalf("breaker tripped at session %d before five sessions fit in the rolling window", i+1)
+		}
+	}
+
+	if !recordSessionEnd(h, time.Second, started.Add(flappingWindow+2*time.Second)) {
+		t.Fatal("breaker did not trip when the newest five sessions fit in the rolling window")
+	}
+}
+
+func TestManualStopResetsAndDoesNotFeedFlappingBreaker(t *testing.T) {
+	h, _ := newTestHandler()
+	started := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+
+	for i := range flappingStopThreshold - 1 {
+		recordSessionEnd(h, time.Second, started.Add(time.Duration(i)*time.Minute))
+	}
+
+	h.Stop()
+
+	h.m.Lock()
+	h.connectedSince = time.Now().Add(-time.Second)
+	h.m.Unlock()
+	h.onDisconnect(ircmsg.Message{})
+
+	h.m.RLock()
+	defer h.m.RUnlock()
+	if len(h.shortSessionEnds) != 0 {
+		t.Fatalf("manual stop left a flapping streak: %v", h.shortSessionEnds)
+	}
+	for _, err := range h.connectionErrors {
+		if strings.Contains(err, "connection flapping") {
+			t.Fatalf("manual disconnect tripped the breaker: %q", err)
+		}
+	}
+}
+
+func TestFlappingBreakerStopsNetworkAndNotifies(t *testing.T) {
+	h, _ := newTestHandler()
+	notifications := &recordingNotificationSender{}
+	h.notificationService = notifications
+	h.stateMachine.currentState = StateFullyOperational
+
+	now := time.Now()
+	for i := range flappingStopThreshold - 1 {
+		recordSessionEnd(h, time.Second, now.Add(time.Duration(i-flappingStopThreshold)*time.Second))
+	}
+
+	h.m.Lock()
+	h.connectedSince = time.Now().Add(-time.Second)
+	h.m.Unlock()
+
+	h.onDisconnect(ircmsg.Message{})
+
+	if !h.Stopped() {
+		t.Fatal("network remained running after the flapping threshold")
+	}
+	if !hasConnectError(h, "connection flapping") {
+		t.Fatalf("flapping reason was not surfaced: %v", h.connectionErrors)
+	}
+	if got := h.stateMachine.GetState(); got != StateError {
+		t.Fatalf("state=%s, want Error", got)
+	}
+
+	events, payloads := notifications.snapshot()
+	if len(events) != 1 || events[0] != domain.NotificationEventIRCDisconnected {
+		t.Fatalf("notifications=%v, want one IRC disconnected event", events)
+	}
+	if len(payloads) != 1 || !strings.Contains(payloads[0].Message, "TestNet stopped") {
+		t.Fatalf("notification payload=%v", payloads)
+	}
+}
+
+func TestStaleDisconnectCannotTripBreakerOnReplacement(t *testing.T) {
+	h, _ := newTestHandler()
+	oldClient := &ircevent.Connection{}
+	replacement := &ircevent.Connection{}
+	h.client = replacement
+
+	now := time.Now()
+	for i := range flappingStopThreshold - 1 {
+		recordSessionEnd(h, time.Second, now.Add(time.Duration(i-flappingStopThreshold)*time.Second))
+	}
+
+	h.onClientDisconnect(oldClient, ircmsg.Message{})
+
+	h.m.RLock()
+	defer h.m.RUnlock()
+	if h.client != replacement || h.clientState != ircLive {
+		t.Fatal("stale disconnect stopped the replacement client")
+	}
+	if len(h.shortSessionEnds) != flappingStopThreshold-1 {
+		t.Fatalf("stale disconnect changed breaker strikes: %v", h.shortSessionEnds)
+	}
+}

--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -58,6 +58,14 @@ const (
 	ircLive                       // (Handler.client) is non-nil and valid
 )
 
+// irc-go invokes disconnect callbacks only for registered sessions, so the
+// breaker does not count dial or registration failures handled by Run.
+const (
+	flappingSessionMinLifetime = 30 * time.Second
+	flappingStopThreshold      = 5
+	flappingWindow             = 15 * time.Minute
+)
+
 // identifyForm is the argument form of the outstanding NickServ IDENTIFY.
 //
 // The bare form is the default because its failures are always loud and are
@@ -88,6 +96,7 @@ type Handler struct {
 	clientState      ircState
 	connectedSince   time.Time
 	haveDisconnected bool
+	shortSessionEnds []time.Time
 	authenticated    bool
 	saslauthed       bool
 
@@ -377,7 +386,9 @@ func (h *Handler) Run() (err error) {
 	}
 
 	client.AddConnectCallback(h.onConnect)
-	client.AddDisconnectCallback(h.onDisconnect)
+	client.AddDisconnectCallback(func(msg ircmsg.Message) {
+		h.onClientDisconnect(client, msg)
+	})
 
 	client.AddCallback("MODE", h.handleMode)
 	if network.BotMode {
@@ -592,6 +603,7 @@ func (h *Handler) resetChannelState() {
 func (h *Handler) Stop() {
 	h.m.Lock()
 	h.connectedSince = time.Time{}
+	h.resetFlappingBreakerLocked()
 	client := h.client
 	h.clientState = ircStopped
 	h.client = nil
@@ -651,13 +663,29 @@ func (h *Handler) onConnect(m ircmsg.Message) {
 	h.stateMachine.OnConnected()
 }
 
-// onDisconnect is the disconnect callback
-func (h *Handler) onDisconnect(_ ircmsg.Message) {
+func (h *Handler) onDisconnect(msg ircmsg.Message) {
+	h.onClientDisconnect(h.getClient(), msg)
+}
+
+// onClientDisconnect handles a disconnect from the client that emitted it.
+func (h *Handler) onClientDisconnect(client *ircevent.Connection, _ ircmsg.Message) {
 	h.log.Debug().Msg("disconnect")
 
 	h.m.Lock()
+	if h.client != client {
+		if h.clientState == ircStopped && h.stateMachine.GetState() != StateDisconnected {
+			h.stateMachine.OnDisconnected()
+		}
+		h.m.Unlock()
+		return
+	}
 
-	// reset connectedSince
+	endedAt := time.Now()
+	sessionLifetime := time.Duration(0)
+	if !h.connectedSince.IsZero() {
+		sessionLifetime = endedAt.Sub(h.connectedSince)
+	}
+
 	h.connectedSince = time.Time{}
 
 	// reset authenticated
@@ -671,12 +699,45 @@ func (h *Handler) onDisconnect(_ ircmsg.Message) {
 
 	manuallyDisconnected := h.clientState == ircStopped
 	networkName := h.network.Name
+	stopForFlapping := !manuallyDisconnected && h.recordSessionEndLocked(sessionLifetime, endedAt)
+	var flappingError string
+	if stopForFlapping {
+		flappingError = fmt.Sprintf("connection flapping: %d sessions lasted under %s within %s; network stopped to avoid repeated reconnects", flappingStopThreshold, flappingSessionMinLifetime, flappingWindow)
+		if !slices.Contains(h.connectionErrors, flappingError) {
+			h.connectionErrors = append(h.connectionErrors, flappingError)
+		}
+		h.haveDisconnected = false
+		h.clientState = ircStopped
+		h.client = nil
+		h.resetFlappingBreakerLocked()
+		h.resetChannelState()
+		h.stateMachine.OnError(flappingError)
+	}
 
 	h.m.Unlock()
 
 	// reset channels monitored status and channel state machines so they
 	// rejoin cleanly on reconnect instead of getting stuck in Monitoring
-	h.resetChannelState()
+	if !stopForFlapping {
+		h.resetChannelState()
+	}
+
+	if stopForFlapping {
+		h.log.Error().
+			Int("sessions", flappingStopThreshold).
+			Dur("min_lifetime", flappingSessionMinLifetime).
+			Dur("window", flappingWindow).
+			Msg("connection flapping; stopping network")
+
+		h.notificationService.Send(domain.NotificationEventIRCDisconnected, domain.NotificationPayload{
+			Subject: "IRC network stopped",
+			Message: fmt.Sprintf("Network: %s stopped after repeated short-lived connections; restart it after resolving the connection issue", networkName),
+		})
+		if client != nil {
+			client.Quit()
+		}
+		return
+	}
 
 	// check if we are responsible for disconnect
 	if !manuallyDisconnected {
@@ -688,6 +749,34 @@ func (h *Handler) onDisconnect(_ ircmsg.Message) {
 	}
 
 	h.stateMachine.OnDisconnected()
+}
+
+// recordSessionEndLocked records one registered session and reports whether the
+// flapping threshold was reached. The caller must hold h.m.
+func (h *Handler) recordSessionEndLocked(lifetime time.Duration, endedAt time.Time) bool {
+	if lifetime >= flappingSessionMinLifetime {
+		h.resetFlappingBreakerLocked()
+		return false
+	}
+
+	keepFrom := 0
+	for keepFrom < len(h.shortSessionEnds) && endedAt.Sub(h.shortSessionEnds[keepFrom]) >= flappingWindow {
+		keepFrom++
+	}
+	h.shortSessionEnds = append(h.shortSessionEnds[keepFrom:], endedAt)
+
+	if len(h.shortSessionEnds) < flappingStopThreshold {
+		return false
+	}
+
+	h.resetFlappingBreakerLocked()
+	return true
+}
+
+// resetFlappingBreakerLocked clears the current short-session streak. The
+// caller must hold h.m.
+func (h *Handler) resetFlappingBreakerLocked() {
+	h.shortSessionEnds = nil
 }
 
 // onNotice handles NOTICE events


### PR DESCRIPTION
# Description

Split out of #2583 (the reconnect circuit breaker part; see that PR for the full TorrentLeech ban-wave context).

The irc-go client reconnects a dropped connection every 15 seconds forever, with no attempt cap or backoff growth. Recognized fatal failures already stop the network (SASL 904, 465 ban, TLS verification, bad NickServ credentials), but any unrecognized failure mode - e.g. a server that kills the bot shortly after registration each time - would cycle indefinitely at ~4 connects/minute until the user noticed.

`onDisconnect` now runs a circuit breaker over registered sessions:

* 5 sessions each shorter than 30 seconds, ending within a 15-minute rolling window, stop the network, surface the reason in the UI health status, and send a notification.
* A session that lives 30+ seconds clears the streak, entries older than the window expire, and user-initiated stops/restarts never count - a manual restart always opens a fresh window.
* The disconnect callback is now bound to the client that registered it, so a late disconnect from an old, already-replaced connection can not trip the breaker or tear down the live client.
* The breaker covers the post-registration path only (irc-go fires disconnect callbacks for registered connections); dial and registration failures remain bounded by the existing 25-attempt connect backoff and the in-band fatal handlers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* New unit tests in `internal/irc/flapping_test.go`: trip on the fifth short session, streak reset by a healthy session, expiry of stale entries, rolling-window semantics, manual stop excluded and resetting the breaker, the full trip path (network stopped, reason surfaced, state machine in Error, exactly one notification), and a stale disconnect from a replaced client being a no-op.
* `go test ./internal/irc -race` and the in-process ircd suite `go test -tags=irc_integration_test ./test/irc/... -race` both pass; `gofmt` clean.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed