### PR TITLE
fix(irc): do not log entering Connecting state as invalid

### DIFF
--- a/internal/irc/state_machine.go
+++ b/internal/irc/state_machine.go
@@ -210,6 +210,9 @@ func (sm *ConnectionStateMachine) allEnabledChannelsMonitoring() bool {
 
 func (sm *ConnectionStateMachine) onStateEntry(state ConnectionState) {
 	switch state {
+	case StateConnecting:
+		// the connect attempt itself is driven by the handler; no entry action
+
 	case StateConnected:
 		sm.m.Lock()
 		sm.authAttempts = 0

--- a/internal/irc/state_machine.go
+++ b/internal/irc/state_machine.go
@@ -27,7 +27,7 @@ const (
 )
 
 func (s ConnectionState) String() string {
-	return [...]string{
+	names := [...]string{
 		"Disconnected",
 		"Connecting",
 		"Connected",
@@ -37,7 +37,13 @@ func (s ConnectionState) String() string {
 		"FullyOperational",
 		"PartiallyOperational",
 		"Error",
-	}[s]
+	}
+
+	if s < 0 || int(s) >= len(names) {
+		return fmt.Sprintf("ConnectionState(%d)", int(s))
+	}
+
+	return names[s]
 }
 
 var validTransitions = map[ConnectionState][]ConnectionState{

--- a/internal/irc/state_machine_test.go
+++ b/internal/irc/state_machine_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package irc
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOnStateEntryConnectingIsQuiet is a regression test for
+// https://github.com/autobrr/autobrr/issues/2586: Connecting is the only state
+// with no entry action and was missing from the onStateEntry switch, so every
+// connect attempt fell through to the default branch and logged "invalid
+// state" at error level.
+func TestOnStateEntryConnectingIsQuiet(t *testing.T) {
+	var buf bytes.Buffer
+	h, _ := newTestHandler()
+	h.log = zerolog.New(&buf)
+	sm := NewConnectionStateMachine(h)
+
+	sm.onStateEntry(StateConnecting)
+
+	assert.Empty(t, buf.String())
+}

--- a/internal/irc/state_machine_test.go
+++ b/internal/irc/state_machine_test.go
@@ -26,3 +26,19 @@ func TestOnStateEntryConnectingIsQuiet(t *testing.T) {
 
 	assert.Empty(t, buf.String())
 }
+
+// TestOnStateEntryUnknownStateLogs guards the default branch: it evaluates
+// state.String() while building the log event, so an out-of-range value must
+// stringify to a fallback instead of panicking on the name array index before
+// the diagnostic is emitted.
+func TestOnStateEntryUnknownStateLogs(t *testing.T) {
+	var buf bytes.Buffer
+	h, _ := newTestHandler()
+	h.log = zerolog.New(&buf)
+	sm := NewConnectionStateMachine(h)
+
+	sm.onStateEntry(ConnectionState(99))
+
+	assert.Contains(t, buf.String(), "invalid state")
+	assert.Contains(t, buf.String(), "ConnectionState(99)")
+}


### PR DESCRIPTION
# Description

Every connect attempt logged `ERR invalid state ... state=Connecting`. `ConnectionStateMachine.onStateEntry` guards unknown states with a `default` branch, but `Connecting` - the only state with no entry action - was missing from the switch, so a perfectly valid transition (`Disconnected -> Connecting` on connect, `Error -> Connecting` on retry) fell through and was reported as an error.

QA on this branch also found that the `default` guard could never actually fire: `ConnectionState.String()` indexed the name array with the raw value, so an out-of-range state panicked while the log event was being built, before the diagnostic was emitted. The invalid-transition log in `transition()` had the same latent panic.

- Add an explicit no-op `case StateConnecting` so the `default` guard only fires for genuinely unknown states
- Bounds-check `ConnectionState.String()` and fall back to `ConnectionState(%d)` so unknown states are logged instead of panicking
- Add regression tests asserting entry into `Connecting` logs nothing and entry into an unknown state logs `invalid state` without panicking

Closes #2586.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* `go test ./internal/irc/...` - new regression tests `TestOnStateEntryConnectingIsQuiet` and `TestOnStateEntryUnknownStateLogs` fail before their respective fixes and pass after; full test suite passes

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed