### PR TITLE
fix(downloadclients): report temporarily rejected arr pushes

### DIFF
--- a/pkg/arr/lidarr/lidarr.go
+++ b/pkg/arr/lidarr/lidarr.go
@@ -119,9 +119,10 @@ func (c *Client) Push(ctx context.Context, release Release) ([]string, error) {
 		return nil, errors.Wrap(err, "lidarr Client error json unmarshal")
 	}
 
-	// log and return if rejected
-	if pushResponse.Rejected {
-		c.logger(ctx).Debug().Strs("rejections", pushResponse.Rejections).Msg("lidarr release/push rejected")
+	// rejected is false when every rejection is temporary, and a temporarily rejected release
+	// waits in the pending queue instead of being grabbed, so both flags have to be reported
+	if pushResponse.Rejected || pushResponse.TempRejected {
+		c.logger(ctx).Debug().Bool("temporary", pushResponse.TempRejected).Strs("rejections", pushResponse.Rejections).Msg("lidarr release/push rejected")
 		return pushResponse.Rejections, nil
 	}
 

--- a/pkg/arr/lidarr/lidarr_test.go
+++ b/pkg/arr/lidarr/lidarr_test.go
@@ -185,3 +185,36 @@ func Test_client_Test(t *testing.T) {
 		})
 	}
 }
+
+// A temporarily rejected release comes back with rejected false and temporarilyRejected
+// true, and waits in Lidarr's pending queue instead of being grabbed, so its rejections
+// still have to reach the caller.
+func Test_client_Push_temporarilyRejected(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	mux.HandleFunc("/api/v1/release/push", func(w http.ResponseWriter, r *http.Request) {
+		jsonPayload, _ := os.ReadFile("testdata/release_push_temporarily_rejected_response.json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonPayload)
+	})
+
+	c := New(Config{Hostname: ts.URL})
+
+	rejections, err := c.Push(context.Background(), Release{
+		Title:            "Famous Artist - Great Album (2026) [FLAC]",
+		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
+		Size:             1048576,
+		Indexer:          "mock-indexer",
+		DownloadProtocol: "torrent",
+		Protocol:         "torrent",
+		PublishDate:      "2026-08-15T17:36:15Z",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Waiting for a better quality release"}, rejections)
+}

--- a/pkg/arr/lidarr/testdata/release_push_temporarily_rejected_response.json
+++ b/pkg/arr/lidarr/testdata/release_push_temporarily_rejected_response.json
@@ -1,0 +1,11 @@
+{
+  "title": "Famous Artist - Great Album (2026) [FLAC]",
+  "indexer": "mock-indexer",
+  "protocol": "torrent",
+  "approved": false,
+  "rejected": false,
+  "temporarilyRejected": true,
+  "rejections": [
+    "Waiting for a better quality release"
+  ]
+}

--- a/pkg/arr/radarr/radarr.go
+++ b/pkg/arr/radarr/radarr.go
@@ -130,9 +130,14 @@ func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string
 		return nil, errors.Wrap(err, "could not unmarshal data")
 	}
 
-	// log and return if rejected
-	if pushResponse[0].Rejected {
-		c.logger(ctx).Debug().Strs("rejections", pushResponse[0].Rejections).Msg("radarr release/push rejected")
+	if len(pushResponse) == 0 {
+		return nil, errors.New("radarr release/push returned an empty response")
+	}
+
+	// rejected is false when every rejection is temporary, and a temporarily rejected release
+	// waits in the pending queue instead of being grabbed, so both flags have to be reported
+	if pushResponse[0].Rejected || pushResponse[0].TempRejected {
+		c.logger(ctx).Debug().Bool("temporary", pushResponse[0].TempRejected).Strs("rejections", pushResponse[0].Rejections).Msg("radarr release/push rejected")
 		return pushResponse[0].Rejections, nil
 	}
 

--- a/pkg/arr/radarr/radarr_test.go
+++ b/pkg/arr/radarr/radarr_test.go
@@ -278,3 +278,36 @@ func Test_client_Push_invalid_download_client(t *testing.T) {
 		assert.Contains(t, err.Error(), "Download client does not exist.")
 	}
 }
+
+// A temporarily rejected release comes back with rejected false and temporarilyRejected
+// true, and waits in Radarr's pending queue instead of being grabbed, so its rejections
+// still have to reach the caller.
+func Test_client_Push_temporarilyRejected(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	mux.HandleFunc("/api/v3/release/push", func(w http.ResponseWriter, r *http.Request) {
+		jsonPayload, _ := os.ReadFile("testdata/release_push_temporarily_rejected_response.json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonPayload)
+	})
+
+	c := New(Config{Hostname: ts.URL})
+
+	rejections, err := c.Push(context.Background(), ReleasePushRequest{
+		Title:            "Movie.Title.2026.1080p.BluRay.x264-GROUP",
+		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
+		Size:             1048576,
+		Indexer:          "mock-indexer",
+		DownloadProtocol: "torrent",
+		Protocol:         "torrent",
+		PublishDate:      "2026-08-15T17:36:15Z",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Waiting for a better quality release"}, rejections)
+}

--- a/pkg/arr/radarr/testdata/release_push_temporarily_rejected_response.json
+++ b/pkg/arr/radarr/testdata/release_push_temporarily_rejected_response.json
@@ -1,0 +1,13 @@
+[
+  {
+    "title": "Movie.Title.2026.1080p.BluRay.x264-GROUP",
+    "indexer": "mock-indexer",
+    "protocol": "torrent",
+    "approved": false,
+    "rejected": false,
+    "temporarilyRejected": true,
+    "rejections": [
+      "Waiting for a better quality release"
+    ]
+  }
+]

--- a/pkg/arr/readarr/readarr.go
+++ b/pkg/arr/readarr/readarr.go
@@ -120,9 +120,10 @@ func (c *Client) Push(ctx context.Context, release Release) ([]string, error) {
 		return nil, errors.Wrap(err, "could not unmarshal data")
 	}
 
-	// log and return if rejected
-	if pushResponse.Rejected {
-		c.logger(ctx).Debug().Strs("rejections", pushResponse.Rejections).Msg("readarr release/push rejected")
+	// rejected is false when every rejection is temporary, and a temporarily rejected release
+	// waits in the pending queue instead of being grabbed, so both flags have to be reported
+	if pushResponse.Rejected || pushResponse.TempRejected {
+		c.logger(ctx).Debug().Bool("temporary", pushResponse.TempRejected).Strs("rejections", pushResponse.Rejections).Msg("readarr release/push rejected")
 		return pushResponse.Rejections, nil
 	}
 

--- a/pkg/arr/readarr/readarr_test.go
+++ b/pkg/arr/readarr/readarr_test.go
@@ -162,3 +162,36 @@ func Test_client_Test(t *testing.T) {
 		})
 	}
 }
+
+// A temporarily rejected release comes back with rejected false and temporarilyRejected
+// true, and waits in Readarr's pending queue instead of being grabbed, so its rejections
+// still have to reach the caller.
+func Test_client_Push_temporarilyRejected(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	mux.HandleFunc("/api/v1/release/push", func(w http.ResponseWriter, r *http.Request) {
+		jsonPayload, _ := os.ReadFile("testdata/release_push_temporarily_rejected_response.json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonPayload)
+	})
+
+	c := New(Config{Hostname: ts.URL})
+
+	rejections, err := c.Push(context.Background(), Release{
+		Title:            "The Best Book by Famous Author [English / epub, mobi]",
+		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
+		Size:             1048576,
+		Indexer:          "mock-indexer",
+		DownloadProtocol: "torrent",
+		Protocol:         "torrent",
+		PublishDate:      "2026-08-15T17:36:15Z",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Waiting for a better quality release"}, rejections)
+}

--- a/pkg/arr/readarr/testdata/release_push_temporarily_rejected_response.json
+++ b/pkg/arr/readarr/testdata/release_push_temporarily_rejected_response.json
@@ -1,0 +1,11 @@
+{
+  "title": "The Best Book by Famous Author [English / epub, mobi]",
+  "indexer": "mock-indexer",
+  "protocol": "torrent",
+  "approved": false,
+  "rejected": false,
+  "temporarilyRejected": true,
+  "rejections": [
+    "Waiting for a better quality release"
+  ]
+}

--- a/pkg/arr/sonarr/sonarr.go
+++ b/pkg/arr/sonarr/sonarr.go
@@ -132,9 +132,14 @@ func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string
 		return nil, errors.Wrap(err, "could not unmarshal data")
 	}
 
-	// log and return if rejected
-	if pushResponse[0].Rejected {
-		c.logger(ctx).Debug().Strs("rejections", pushResponse[0].Rejections).Msg("sonarr release/push rejected")
+	if len(pushResponse) == 0 {
+		return nil, errors.New("sonarr release/push returned an empty response")
+	}
+
+	// rejected is false when every rejection is temporary, and a temporarily rejected release
+	// waits in the pending queue instead of being grabbed, so both flags have to be reported
+	if pushResponse[0].Rejected || pushResponse[0].TempRejected {
+		c.logger(ctx).Debug().Bool("temporary", pushResponse[0].TempRejected).Strs("rejections", pushResponse[0].Rejections).Msg("sonarr release/push rejected")
 		return pushResponse[0].Rejections, nil
 	}
 

--- a/pkg/arr/sonarr/sonarr_test.go
+++ b/pkg/arr/sonarr/sonarr_test.go
@@ -235,3 +235,37 @@ func Test_client_Push_invalid_download_client(t *testing.T) {
 		assert.Contains(t, err.Error(), "Download client does not exist.")
 	}
 }
+
+// A temporarily rejected release comes back with rejected false and temporarilyRejected
+// true, and waits in Sonarr's pending queue instead of being grabbed, so its rejections
+// still have to reach the caller.
+func Test_client_Push_temporarilyRejected(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	log.SetOutput(io.Discard)
+
+	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	mux.HandleFunc("/api/v3/release/push", func(w http.ResponseWriter, r *http.Request) {
+		jsonPayload, _ := os.ReadFile("testdata/release_push_temporarily_rejected_response.json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonPayload)
+	})
+
+	c := New(Config{Hostname: ts.URL})
+
+	rejections, err := c.Push(context.Background(), ReleasePushRequest{
+		Title:            "Series.Title.S01E01.1080p.WEB-DL.x264-GROUP",
+		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
+		Size:             1048576,
+		Indexer:          "mock-indexer",
+		DownloadProtocol: "torrent",
+		Protocol:         "torrent",
+		PublishDate:      "2026-08-15T17:36:15Z",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Waiting for a better quality release"}, rejections)
+}

--- a/pkg/arr/sonarr/testdata/release_push_temporarily_rejected_response.json
+++ b/pkg/arr/sonarr/testdata/release_push_temporarily_rejected_response.json
@@ -1,0 +1,13 @@
+[
+  {
+    "title": "Series.Title.S01E01.1080p.WEB-DL.x264-GROUP",
+    "indexer": "mock-indexer",
+    "protocol": "torrent",
+    "approved": false,
+    "rejected": false,
+    "temporarilyRejected": true,
+    "rejections": [
+      "Waiting for a better quality release"
+    ]
+  }
+]

--- a/pkg/arr/sportarr/sportarr.go
+++ b/pkg/arr/sportarr/sportarr.go
@@ -123,9 +123,10 @@ func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string
 		return nil, errors.New("sportarr release/push returned an empty response")
 	}
 
-	// log and return if rejected
-	if pushResponse[0].Rejected {
-		c.logger(ctx).Debug().Strs("rejections", pushResponse[0].Rejections).Msg("sportarr release/push rejected")
+	// rejected is false when every rejection is temporary, and a temporarily rejected release
+	// waits in the pending queue instead of being grabbed, so both flags have to be reported
+	if pushResponse[0].Rejected || pushResponse[0].TempRejected {
+		c.logger(ctx).Debug().Bool("temporary", pushResponse[0].TempRejected).Strs("rejections", pushResponse[0].Rejections).Msg("sportarr release/push rejected")
 		return pushResponse[0].Rejections, nil
 	}
 

--- a/pkg/arr/sportarr/sportarr_test.go
+++ b/pkg/arr/sportarr/sportarr_test.go
@@ -211,3 +211,37 @@ func Test_SystemStatusResponse_SupportsNativeAPI(t *testing.T) {
 		})
 	}
 }
+
+// A temporarily rejected release comes back with rejected false and temporarilyRejected
+// true, and waits in Sportarr's pending queue instead of being grabbed, so its rejections
+// still have to reach the caller.
+func Test_client_Push_temporarilyRejected(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	log.SetOutput(io.Discard)
+
+	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	mux.HandleFunc("/api/release/push", func(w http.ResponseWriter, r *http.Request) {
+		jsonPayload, _ := os.ReadFile("testdata/release_push_temporarily_rejected_response.json")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(jsonPayload)
+	})
+
+	c := New(Config{Hostname: ts.URL})
+
+	rejections, err := c.Push(context.Background(), ReleasePushRequest{
+		Title:            "Formula.1.2026x10.Belgium.Race.SkyF1HD.1080p",
+		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
+		Size:             1048576,
+		Indexer:          "mock-indexer",
+		DownloadProtocol: "torrent",
+		Protocol:         "torrent",
+		PublishDate:      "2026-08-15T17:36:15Z",
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Waiting for a better quality release"}, rejections)
+}

--- a/pkg/arr/sportarr/testdata/release_push_temporarily_rejected_response.json
+++ b/pkg/arr/sportarr/testdata/release_push_temporarily_rejected_response.json
@@ -1,0 +1,13 @@
+[
+  {
+    "title": "Formula.1.2026x10.Belgium.Race.SkyF1HD.1080p",
+    "indexer": "mock-indexer",
+    "protocol": "torrent",
+    "approved": false,
+    "rejected": false,
+    "temporarilyRejected": true,
+    "rejections": [
+      "Waiting for a better quality release"
+    ]
+  }
+]

--- a/pkg/arr/whisparr/testdata/release_push_temporarily_rejected_response.json
+++ b/pkg/arr/whisparr/testdata/release_push_temporarily_rejected_response.json
@@ -1,0 +1,13 @@
+[
+  {
+    "title": "Brazzers.Goes.Black.2018.1080p.BluRay.x264-GROUP",
+    "indexer": "mock-indexer",
+    "protocol": "torrent",
+    "approved": false,
+    "rejected": false,
+    "temporarilyRejected": true,
+    "rejections": [
+      "Waiting for a better quality release"
+    ]
+  }
+]

--- a/pkg/arr/whisparr/whisparr.go
+++ b/pkg/arr/whisparr/whisparr.go
@@ -159,9 +159,10 @@ func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string
 		return nil, errors.New("whisparr push returned an empty response")
 	}
 
-	// log and return if rejected
-	if pushResponse[0].Rejected {
-		c.logger(ctx).Debug().Strs("rejections", pushResponse[0].Rejections).Msg("whisparr release/push rejected")
+	// rejected is false when every rejection is temporary, and a temporarily rejected release
+	// waits in the pending queue instead of being grabbed, so both flags have to be reported
+	if pushResponse[0].Rejected || pushResponse[0].TempRejected {
+		c.logger(ctx).Debug().Bool("temporary", pushResponse[0].TempRejected).Strs("rejections", pushResponse[0].Rejections).Msg("whisparr release/push rejected")
 		return pushResponse[0].Rejections, nil
 	}
 

--- a/pkg/arr/whisparr/whisparr_test.go
+++ b/pkg/arr/whisparr/whisparr_test.go
@@ -209,3 +209,35 @@ func TestClient_Push(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"Unknown Movie. Unable to match to existing movie in Library using release title."}, rejections)
 }
+
+// A temporarily rejected release comes back with rejected false and temporarilyRejected
+// true, and waits in Whisparr's pending queue instead of being grabbed, so its rejections
+// still have to reach the caller.
+func TestClient_Push_temporarilyRejected(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/release/push", func(w http.ResponseWriter, r *http.Request) {
+		payload, err := os.ReadFile("testdata/release_push_temporarily_rejected_response.json")
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(payload)
+	})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	rejections, err := newTestClient(ts.URL, VersionV3).Push(context.Background(), ReleasePushRequest{
+		Title:            "Brazzers.Goes.Black.2018.1080p.BluRay.x264-GROUP",
+		DownloadUrl:      ts.URL + "/download",
+		Size:             1073741824,
+		Indexer:          "autobrr",
+		Protocol:         "torrent",
+		DownloadProtocol: "torrent",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Waiting for a better quality release"}, rejections)
+}


### PR DESCRIPTION
# Description

Pushes that an *arr rejects only *temporarily* were reported as successful, so the release looked grabbed when it was actually parked in the *arr's pending queue.

`DownloadDecision.Rejected` is `Rejections.Any(r => r.Type == Permanent)`, so a rejection set that is entirely temporary comes back as:

```json
{ "approved": false, "rejected": false, "temporarilyRejected": true, "rejections": ["..."] }
```

Every `pkg/arr` client declared `TempRejected` but branched only on `Rejected`, returned no rejections, and the action logged `release successfully added to client`. The most common trigger is a Delay Profile.

* `Push` now returns the rejections when `Rejected || TempRejected`, in `readarr`, `lidarr`, `radarr`, `sonarr`, `sportarr` and `whisparr`
* the debug log gains `temporary` so the two cases are distinguishable
* `radarr` and `sonarr` gained the `len(pushResponse) == 0` guard that `sportarr` and `whisparr` already had, so an empty `200` array no longer panics on `pushResponse[0]`
* replaced the `// log and return if rejected` narration with why both flags matter, since the condition otherwise reads like something to simplify away

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* new `Test_client_Push_temporarilyRejected` per client (`TestClient_Push_temporarilyRejected` in `whisparr`, matching that file's naming and its `newTestClient` harness), each with a `release_push_temporarily_rejected_response.json` fixture
* the tests were verified to actually catch the bug: reverting the condition to `Rejected` alone in all six clients makes all six fail, restoring it makes them pass again
* `go test -tags=integration ./pkg/arr/...` passes
* `go test $(go list ./... | grep -v test/integration)` passes
* `go build ./...`, `go vet ./pkg/arr/...` and `go fmt` clean

Not covered: no test drives a real *arr instance, so the fixtures encode the response shape rather than proving it against a live Sonarr/Radarr. The shape is the documented `ReleaseResource` contract and matches the existing fixtures in each package.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Written with Claude Code (Opus 5), reviewed by me.

The bug was found while investigating an unrelated *arr integration, where a push that reported success left the release permanently pending. The model traced it to the `Rejected`/`TempRejected` split in the upstream decision engine, applied the fix across all six clients, wrote the fixtures and tests, and verified the tests fail without the fix. The `len(pushResponse) == 0` guard on `radarr`/`sonarr` was a defect it noticed in the same function while editing.
