### PR TITLE
feat(dashboard): refine stats customization

### DIFF
--- a/web/src/i18n/locales/en/common.json
+++ b/web/src/i18n/locales/en/common.json
@@ -180,7 +180,8 @@
     "customize": "Customize",
     "done": "Done",
     "reset": "Reset",
-    "hint": "Drag widgets to reorder them. Use the eye toggle to show or hide a widget.",
+    "hint": "Drag the handle to reorder widgets of the same size. Use the eye toggle to show or hide a widget.",
+    "move": "Move widget",
     "show": "Show widget",
     "hide": "Hide widget"
   },

--- a/web/src/screens/dashboard/ActivityChart.tsx
+++ b/web/src/screens/dashboard/ActivityChart.tsx
@@ -110,7 +110,6 @@ export const ActivityChart = () => {
   return (
     <ChartCard
       title={t("dashboardCharts.activityTitle")}
-      className="mt-5"
       action={
         <RangeSelect
           options={RANGES.map((r) => ({ value: r.value, label: t(`dashboardCharts.range_${r.value}`) }))}

--- a/web/src/screens/dashboard/ActivityTable.tsx
+++ b/web/src/screens/dashboard/ActivityTable.tsx
@@ -3,15 +3,14 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import React, { useState, useEffect } from "react";
+import { useMemo } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import {
   useReactTable,
   getCoreRowModel,
   flexRender,
-  ColumnDef
+  type ColumnDef
 } from "@tanstack/react-table";
-import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/solid";
 import { useTranslation } from "react-i18next";
 
 import { EmptyListState } from "@components/emptystates";
@@ -36,8 +35,7 @@ function Table({ columns, data }: TableProps) {
 
   if (data.length === 0) {
     return (
-      <div
-        className="mt-4 mb-2 bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-table rounded-md overflow-auto">
+      <div className="mb-2 mt-4 overflow-auto rounded-md border border-gray-250 bg-white shadow-table dark:border-gray-775 dark:bg-gray-800">
         <div className="flex items-center justify-center py-16">
           <EmptyListState text={t("activityTable.noRecentActivity")}/>
         </div>
@@ -46,58 +44,56 @@ function Table({ columns, data }: TableProps) {
   }
 
   return (
-    <div className="inline-block min-w-full mt-4 mb-2 align-middle">
-      <div className="bg-white dark:bg-gray-800 border border-gray-250 dark:border-gray-775 shadow-table rounded-md overflow-auto">
-        <table className="min-w-full rounded-md divide-y divide-gray-200 dark:divide-gray-750">
-          <thead className="bg-gray-100 dark:bg-gray-850">
-            {tableInstance.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <th
-                    key={header.id}
-                    scope="col"
-                    className="first:pl-5 first:rounded-tl-md last:rounded-tr-md pl-3 pr-3 py-3 text-xs font-medium tracking-wider text-left uppercase group text-gray-600 dark:text-gray-400"
-                    colSpan={header.colSpan}
-                  >
-                    <div className="flex items-center justify-between">
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
-                    </div>
-                  </th>
-                  )
-                )}
-              </tr>
-            ))}
-          </thead>
+    <div className="mb-2 mt-4 min-w-0 flex-1 overflow-auto rounded-md border border-gray-250 bg-white align-middle shadow-table dark:border-gray-775 dark:bg-gray-800">
+      <table className="min-w-full divide-y divide-gray-200 rounded-md dark:divide-gray-750">
+        <thead className="bg-gray-100 dark:bg-gray-850">
+          {tableInstance.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th
+                  key={header.id}
+                  scope="col"
+                  className="first:pl-5 first:rounded-tl-md last:rounded-tr-md pl-3 pr-3 py-3 text-xs font-medium tracking-wider text-left uppercase group text-gray-600 dark:text-gray-400"
+                  colSpan={header.colSpan}
+                >
+                  <div className="flex items-center justify-between">
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                  </div>
+                </th>
+                )
+              )}
+            </tr>
+          ))}
+        </thead>
 
-          <tbody className="divide-y divide-gray-150 dark:divide-gray-750">
-            {tableInstance.getRowModel().rows.map((row) => (
-              <tr key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <td
-                    key={cell.id}
-                    className="first:pl-5 pl-3 pr-3 whitespace-nowrap"
-                    role="cell"
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+        <tbody className="divide-y divide-gray-150 dark:divide-gray-750">
+          {tableInstance.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td
+                  key={cell.id}
+                  className="first:pl-5 pl-3 pr-3 whitespace-nowrap"
+                  role="cell"
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
 
 export const ActivityTable = () => {
   const { t } = useTranslation("common");
-  const columns = React.useMemo<ColumnDef<Release>[]>(() => [
+  const columns = useMemo<ColumnDef<Release>[]>(() => [
     {
       header: t("activityTable.columns.age"),
       accessorKey: "timestamp",
@@ -120,37 +116,35 @@ export const ActivityTable = () => {
     }
   ], [t]);
 
-  const { isLoading, data, dataUpdatedAt } = useSuspenseQuery(ReleasesLatestQueryOptions());
+  const { isLoading, data } = useSuspenseQuery(ReleasesLatestQueryOptions());
 
-  const [modifiedData, setModifiedData] = useState<Release[]>([]);
-  const [settings, setSettings] = SettingsContext.use();
-
-  useEffect(() => {
-    if (settings.incognitoMode && data?.data) {
-      const randomIsoNames = RandomLinuxIsos(data.data.length);
-      const randomTorrentSiteNames = RandomIsoTracker(data.data.length);
-      const newData: Release[] = data.data.map((item, index) => {
-        const siteName = randomTorrentSiteNames[index % randomTorrentSiteNames.length];
-        return {
-          ...item,
-          name: randomIsoNames[index],
-          indexer: {
-            id: 0,
-            name: siteName,
-            identifier: siteName,
-            identifier_external: siteName,
-          },
-        };
-      });
-      setModifiedData(newData);
-    } else {
-      setModifiedData([]);
+  const settings = SettingsContext.useValue();
+  const displayData = useMemo(() => {
+    const releases = data?.data ?? [];
+    if (!settings.incognitoMode) {
+      return releases;
     }
-  }, [settings.incognitoMode, data?.data, dataUpdatedAt]);
+
+    const randomIsoNames = RandomLinuxIsos(releases.length);
+    const randomTorrentSiteNames = RandomIsoTracker(releases.length);
+    return releases.map((item, index) => {
+      const siteName = randomTorrentSiteNames[index % randomTorrentSiteNames.length];
+      return {
+        ...item,
+        name: randomIsoNames[index],
+        indexer: {
+          id: 0,
+          name: siteName,
+          identifier: siteName,
+          identifier_external: siteName,
+        },
+      };
+    });
+  }, [settings.incognitoMode, data?.data]);
 
   if (isLoading) {
     return (
-      <div className="flex flex-col">
+      <div className="flex h-full min-w-0 flex-col">
         <h3 className="text-2xl font-medium leading-6 text-gray-900 dark:text-gray-200">
           {t("activityTable.title")}
         </h3>
@@ -161,32 +155,12 @@ export const ActivityTable = () => {
     );
   }
 
-  const toggleReleaseNames = () => {
-    setSettings(prev => ({ ...prev, incognitoMode: !prev.incognitoMode }));
-  };
-
-  const displayData = settings.incognitoMode ? modifiedData : [...(data?.data ?? [])];
-
   return (
-    <div className="flex flex-col relative">
+    <div className="flex h-full min-w-0 flex-col">
       <h3 className="text-2xl font-medium leading-6 text-black dark:text-white">
         {t("activityTable.title")}
       </h3>
-
       <Table columns={columns} data={displayData}/>
-
-      <button
-        onClick={toggleReleaseNames}
-        className="p-2 absolute -bottom-8 right-0 bg-gray-750 text-white rounded-full opacity-10 hover:opacity-100 transition-opacity duration-300"
-        aria-label={t("releaseTable.toggleView")}
-        title={t("releaseTable.goIncognito")}
-      >
-        {settings.incognitoMode ? (
-          <EyeIcon className="h-4 w-4"/>
-        ) : (
-          <EyeSlashIcon className="h-4 w-4"/>
-        )}
-      </button>
     </div>
   );
 };

--- a/web/src/screens/dashboard/DashboardGrid.tsx
+++ b/web/src/screens/dashboard/DashboardGrid.tsx
@@ -3,16 +3,21 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useMemo, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   DndContext,
+  DragOverlay,
   KeyboardSensor,
   PointerSensor,
   closestCenter,
+  pointerWithin,
   useSensor,
   useSensors,
-  type DragEndEvent
+  type CollisionDetection,
+  type DropAnimation,
+  type DragEndEvent,
+  type DragStartEvent
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -22,10 +27,11 @@ import {
   useSortable
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { EyeIcon, EyeSlashIcon, Squares2X2Icon } from "@heroicons/react/24/outline";
+import { Bars3Icon, EyeIcon, EyeSlashIcon, Squares2X2Icon } from "@heroicons/react/24/outline";
+import { EyeIcon as SolidEyeIcon, EyeSlashIcon as SolidEyeSlashIcon } from "@heroicons/react/24/solid";
 
 import { classNames } from "@utils";
-import { DashboardConfigContext } from "@utils/Context";
+import { DashboardConfigContext, SettingsContext } from "@utils/Context";
 import type { DashboardConfigType } from "@utils/Context";
 import { DASHBOARD_WIDGETS } from "./widgets";
 import type { DashboardWidgetDef } from "./widgets";
@@ -40,6 +46,7 @@ const resolveLayout = (config: DashboardConfigType): WidgetLayout[] => {
   const seen = new Set<string>();
   const layout: WidgetLayout[] = [];
 
+  // Preserve the saved order while dropping removed widgets and appending new ones.
   for (const entry of config.widgets) {
     const def = byId.get(entry.id);
     if (def && !seen.has(entry.id)) {
@@ -60,58 +67,189 @@ interface SortableWidgetProps {
   def: DashboardWidgetDef;
   hidden: boolean;
   editing: boolean;
+  committing: boolean;
   onToggle: () => void;
 }
 
-const SortableWidget = ({ def, hidden, editing, onToggle }: SortableWidgetProps) => {
+const dropDuration = 180;
+const dropEasing = "cubic-bezier(0.16, 1, 0.3, 1)";
+
+interface WidgetPosition {
+  left: number;
+  top: number;
+}
+
+interface PendingDrop {
+  activeId: string;
+  order: string;
+  positions: Map<string, WidgetPosition>;
+}
+
+const SortableWidget = ({ def, hidden, editing, committing, onToggle }: SortableWidgetProps) => {
   const { t } = useTranslation("common");
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  const { attributes, listeners, setActivatorNodeRef, setNodeRef, transform, isDragging, isSorting } = useSortable({
     id: def.id,
-    disabled: !editing
+    disabled: !editing,
+    data: { size: def.size },
+    transition: null
   });
 
   return (
     <div
       ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
+      data-widget-id={def.id}
+      style={{ transform: CSS.Translate.toString(transform) }}
       className={classNames(
         def.spanClass,
-        isDragging ? "z-10" : "",
-        editing ? "relative rounded-lg ring-2 ring-blue-400/40 dark:ring-blue-500/30 cursor-grab active:cursor-grabbing touch-none" : ""
+        "h-full min-w-0",
+        isDragging ? "z-10 opacity-30" : "",
+        isSorting && !isDragging && !committing
+          ? "transition-transform duration-200 ease-out motion-reduce:transition-none"
+          : "transition-none",
+        editing ? "flex flex-col rounded-xl border border-blue-400/30 bg-blue-500/5 p-2 will-change-transform dark:border-blue-500/25 dark:bg-blue-500/5" : ""
       )}
-      {...attributes}
-      {...listeners}
     >
-      <div className={classNames("h-full", editing ? "pointer-events-none select-none" : "", hidden ? "opacity-40" : "")}>
+      {editing && (
+        <div className="mb-2 flex h-9 items-center justify-between gap-2">
+          <button
+            ref={setActivatorNodeRef}
+            type="button"
+            className="inline-flex size-9 touch-none cursor-grab items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 ease-in-out hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 active:cursor-grabbing dark:hover:text-gray-200"
+            aria-label={`${t("dashboardCustomize.move")} ${t(def.titleKey)}`}
+            {...attributes}
+            {...listeners}
+          >
+            <Bars3Icon className="size-5" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={onToggle}
+            className="inline-flex size-9 items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 ease-in-out hover:bg-white hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            title={hidden ? t("dashboardCustomize.show") : t("dashboardCustomize.hide")}
+            aria-label={hidden ? t("dashboardCustomize.show") : t("dashboardCustomize.hide")}
+          >
+            {hidden
+              ? <EyeSlashIcon className="size-5" aria-hidden="true" />
+              : <EyeIcon className="size-5" aria-hidden="true" />}
+          </button>
+        </div>
+      )}
+      <div className={classNames("h-full min-h-0 flex-1", editing ? "select-none" : "", hidden ? "opacity-40" : "")}>
         <def.Component />
       </div>
-      {editing && (
-        <button
-          type="button"
-          onClick={onToggle}
-          className="absolute top-2 right-2 z-10 p-1.5 rounded-md bg-white dark:bg-gray-815 border border-gray-250 dark:border-gray-750 shadow text-gray-500 hover:text-gray-800 dark:hover:text-gray-200 transition-colors duration-200 ease-in-out"
-          title={hidden ? t("dashboardCustomize.show") : t("dashboardCustomize.hide")}
-        >
-          {hidden
-            ? <EyeSlashIcon className="h-4 w-4" aria-hidden="true" />
-            : <EyeIcon className="h-4 w-4" aria-hidden="true" />}
-        </button>
-      )}
     </div>
   );
+};
+
+const compatibleWidgetCollisions: CollisionDetection = (args) => {
+  const activeSize = args.active.data.current?.size;
+  // Mixed spans do not share stable grid slots, so only equal-size widgets are valid targets.
+  const droppableContainers = args.droppableContainers.filter(
+    (container) => container.data.current?.size === activeSize
+  );
+  const compatibleArgs = { ...args, droppableContainers };
+  const pointerCollisions = pointerWithin(compatibleArgs);
+
+  return args.pointerCoordinates ? pointerCollisions : closestCenter(compatibleArgs);
 };
 
 export const DashboardGrid = () => {
   const { t } = useTranslation("common");
   const config = DashboardConfigContext.useValue();
+  const [settings, setSettings] = SettingsContext.use();
   const [editing, setEditing] = useState(false);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [committing, setCommitting] = useState(false);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const dropTargetRect = useRef<{ left: number; top: number; width: number; height: number } | null>(null);
+  const pendingDrop = useRef<PendingDrop | null>(null);
 
   const layout = useMemo(() => resolveLayout(config), [config]);
+  const ActiveWidget = layout.find(({ def }) => def.id === activeId)?.def.Component;
+
+  const dropAnimation = useMemo<DropAnimation>(() => async ({ active, dragOverlay, transform }) => {
+    const target = dropTargetRect.current;
+    const view = active.node.ownerDocument.defaultView;
+    if (!target || view?.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      return;
+    }
+
+    // The default overlay returns to its source; the saved target keeps the release continuous.
+    const finalTransform = {
+      x: transform.x - (dragOverlay.rect.left - target.left),
+      y: transform.y - (dragOverlay.rect.top - target.top),
+      scaleX: target.width * transform.scaleX / dragOverlay.rect.width,
+      scaleY: target.height * transform.scaleY / dragOverlay.rect.height
+    };
+    const previousOpacity = active.node.style.opacity;
+    active.node.style.opacity = "0";
+
+    const animation = dragOverlay.node.animate([
+      { transform: CSS.Transform.toString(transform) },
+      { transform: CSS.Transform.toString(finalTransform) }
+    ], {
+      duration: dropDuration,
+      easing: dropEasing,
+      fill: "forwards"
+    });
+
+    await animation.finished.catch(() => undefined);
+    active.node.style.opacity = previousOpacity;
+    dropTargetRect.current = null;
+  }, []);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
+
+  useLayoutEffect(() => {
+    const grid = gridRef.current;
+    const pending = pendingDrop.current;
+    const order = layout.map(({ def }) => def.id).join(",");
+    if (!committing || !grid || !pending || pending.order !== order) {
+      return;
+    }
+
+    const reduceMotion = grid.ownerDocument.defaultView?.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const animations: Animation[] = [];
+
+    if (!reduceMotion) {
+      // Persisting reorders the DOM immediately, so FLIP preserves each displaced widget's visual position.
+      for (const node of grid.querySelectorAll<HTMLElement>("[data-widget-id]")) {
+        const id = node.dataset.widgetId;
+        const previous = id ? pending.positions.get(id) : undefined;
+        if (!id || id === pending.activeId || !previous) {
+          continue;
+        }
+
+        const current = node.getBoundingClientRect();
+        const deltaX = previous.left - current.left;
+        const deltaY = previous.top - current.top;
+        if (deltaX === 0 && deltaY === 0) {
+          continue;
+        }
+
+        animations.push(node.animate([
+          { transform: `translate3d(${deltaX}px, ${deltaY}px, 0)` },
+          { transform: "translate3d(0, 0, 0)" }
+        ], {
+          duration: dropDuration,
+          easing: dropEasing
+        }));
+      }
+    }
+
+    pendingDrop.current = null;
+
+    if (animations.length === 0) {
+      setCommitting(false);
+      return;
+    }
+
+    void Promise.all(animations.map((animation) => animation.finished.catch(() => undefined)))
+      .then(() => setCommitting(false));
+  }, [committing, layout]);
 
   const persist = (next: WidgetLayout[]) => {
     DashboardConfigContext.set({
@@ -120,15 +258,46 @@ export const DashboardGrid = () => {
     });
   };
 
+  const resetDropState = () => {
+    dropTargetRect.current = null;
+    pendingDrop.current = null;
+    setCommitting(false);
+    setActiveId(null);
+  };
+
+  const onDragStart = ({ active }: DragStartEvent) => {
+    resetDropState();
+    setActiveId(String(active.id));
+  };
+
   const onDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
+    setActiveId(null);
     if (!over || active.id === over.id) {
       return;
     }
     const oldIndex = layout.findIndex((l) => l.def.id === active.id);
     const newIndex = layout.findIndex((l) => l.def.id === over.id);
-    if (oldIndex !== -1 && newIndex !== -1) {
-      persist(arrayMove(layout, oldIndex, newIndex));
+    if (oldIndex !== -1 && newIndex !== -1 && layout[oldIndex].def.size === layout[newIndex].def.size) {
+      const nextLayout = arrayMove(layout, oldIndex, newIndex);
+      dropTargetRect.current = {
+        left: over.rect.left,
+        top: over.rect.top,
+        width: over.rect.width,
+        height: over.rect.height
+      };
+      pendingDrop.current = {
+        activeId: String(active.id),
+        order: nextLayout.map(({ def }) => def.id).join(","),
+        positions: new Map(
+          Array.from(gridRef.current?.querySelectorAll<HTMLElement>("[data-widget-id]") ?? []).map((node) => {
+            const rect = node.getBoundingClientRect();
+            return [node.dataset.widgetId ?? "", { left: rect.left, top: rect.top }];
+          })
+        )
+      };
+      setCommitting(true);
+      persist(nextLayout);
     }
   };
 
@@ -138,37 +307,52 @@ export const DashboardGrid = () => {
 
   return (
     <div>
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-3xl font-bold text-black dark:text-white">
           {t("dashboardStats.title")}
         </h1>
-        {editing ? (
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => DashboardConfigContext.set({ version: 1, widgets: [] })}
-              className="px-2.5 py-1.5 rounded-md text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200 ease-in-out"
-            >
-              {t("dashboardCustomize.reset")}
-            </button>
-            <button
-              type="button"
-              onClick={() => setEditing(false)}
-              className="px-3 py-1.5 rounded-md bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium transition-colors duration-200 ease-in-out"
-            >
-              {t("dashboardCustomize.done")}
-            </button>
-          </div>
-        ) : (
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <button
             type="button"
-            onClick={() => setEditing(true)}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200 ease-in-out"
+            onClick={() => setSettings((current) => ({ ...current, incognitoMode: !current.incognitoMode }))}
+            className="inline-flex size-9 items-center justify-center rounded-md text-gray-500 transition-colors duration-200 ease-in-out hover:bg-gray-100 hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            aria-label={t("releaseTable.goIncognito")}
+            title={t("releaseTable.goIncognito")}
           >
-            <Squares2X2Icon className="h-4 w-4" aria-hidden="true" />
-            {t("dashboardCustomize.customize")}
+            {settings.incognitoMode ? (
+              <SolidEyeIcon className="size-4" aria-hidden="true" />
+            ) : (
+              <SolidEyeSlashIcon className="size-4" aria-hidden="true" />
+            )}
           </button>
-        )}
+          {editing ? (
+            <>
+              <button
+                type="button"
+                onClick={() => DashboardConfigContext.set({ version: 1, widgets: [] })}
+                className="min-h-9 rounded-md px-2.5 py-1.5 text-sm text-gray-500 transition-colors duration-200 ease-in-out hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+              >
+                {t("dashboardCustomize.reset")}
+              </button>
+              <button
+                type="button"
+                onClick={() => setEditing(false)}
+                className="min-h-9 rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors duration-200 ease-in-out hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+              >
+                {t("dashboardCustomize.done")}
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              className="flex min-h-9 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-gray-500 transition-colors duration-200 ease-in-out hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+            >
+              <Squares2X2Icon className="h-4 w-4" aria-hidden="true" />
+              {t("dashboardCustomize.customize")}
+            </button>
+          )}
+        </div>
       </div>
       {editing && (
         <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
@@ -176,9 +360,15 @@ export const DashboardGrid = () => {
         </p>
       )}
 
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={compatibleWidgetCollisions}
+        onDragStart={onDragStart}
+        onDragCancel={resetDropState}
+        onDragEnd={onDragEnd}
+      >
         <SortableContext items={layout.map((l) => l.def.id)} strategy={rectSortingStrategy}>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-5 mt-5">
+          <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-5 mt-5">
             {layout.map(({ def, hidden }) =>
               (editing || !hidden) && (
                 <SortableWidget
@@ -186,12 +376,20 @@ export const DashboardGrid = () => {
                   def={def}
                   hidden={hidden}
                   editing={editing}
+                  committing={committing}
                   onToggle={() => toggleWidget(def.id)}
                 />
               )
             )}
           </div>
         </SortableContext>
+        <DragOverlay dropAnimation={dropAnimation}>
+          {ActiveWidget && (
+            <div className="pointer-events-none h-full w-full overflow-hidden rounded-lg shadow-2xl ring-2 ring-blue-500/50">
+              <ActiveWidget />
+            </div>
+          )}
+        </DragOverlay>
       </DndContext>
     </div>
   );

--- a/web/src/screens/dashboard/HourHeatmap.tsx
+++ b/web/src/screens/dashboard/HourHeatmap.tsx
@@ -19,6 +19,8 @@ interface HeatmapDatum {
   count: number;
 }
 
+const squareCellChartAspectRatio = 3.15;
+
 const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const DISPLAY_DOWS = [1, 2, 3, 4, 5, 6, 0];
 
@@ -116,10 +118,10 @@ export const HourHeatmap = () => {
           <Chart
             definition={definition}
             ariaLabel={t("dashboardCharts.heatmapTitle")}
-            height={210}
+            aspectRatio={squareCellChartAspectRatio}
             className="mt-2 w-full"
           />
-          <div className="flex items-center justify-end gap-1 mt-1 text-xs text-gray-500 dark:text-gray-400">
+          <div className="mt-auto flex items-center justify-end gap-1 pt-1 text-xs text-gray-500 dark:text-gray-400">
             {t("dashboardCharts.heatmapLess")}
             <span className="inline-block w-3 h-3 rounded-xs" style={{ backgroundColor: zeroFill }} aria-hidden="true" />
             {ramp.map((color) => (

--- a/web/src/screens/dashboard/TopLists.tsx
+++ b/web/src/screens/dashboard/TopLists.tsx
@@ -39,33 +39,35 @@ const BreakdownTable = ({ title, nameHeader, rows, isLoading, isError }: Breakdo
       ) : isError ? (
         <ChartError heightClass="h-56" />
       ) : (
-        <table className="min-w-full mt-2">
-          <thead>
-            <tr>
-              <th className="py-2 pr-3 text-xs font-medium tracking-wider uppercase text-left text-gray-600 dark:text-gray-400">{nameHeader}</th>
-              <th className="py-2 px-3 text-xs font-medium tracking-wider uppercase text-right text-gray-600 dark:text-gray-400">{t("dashboardCharts.matches")}</th>
-              <th className="py-2 px-3 text-xs font-medium tracking-wider uppercase text-right text-gray-600 dark:text-gray-400">{t("dashboardCharts.approved")}</th>
-              <th className="py-2 pl-3 w-28"><span className="sr-only">{t("dashboardCharts.approved")}</span></th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-150 dark:divide-gray-750">
-            {rows.map((row) => (
-              <tr key={row.name}>
-                <td className="py-2 pr-3 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-300 truncate max-w-40">{row.name}</td>
-                <td className="py-2 px-3 text-sm text-right tabular-nums text-gray-600 dark:text-gray-400">{row.matched.toLocaleString()}</td>
-                <td className="py-2 px-3 text-sm text-right tabular-nums text-gray-900 dark:text-gray-300">{row.approved.toLocaleString()}</td>
-                <td className="py-2 pl-3">
-                  <div className="h-1.5 w-full rounded-full" style={{ backgroundColor: trackColor }}>
-                    <div
-                      className="h-1.5 rounded-full"
-                      style={{ backgroundColor: barColor, width: `${Math.max((row.approved / maxApproved) * 100, 2)}%` }}
-                    />
-                  </div>
-                </td>
+        <div className="mt-2 min-h-56 min-w-0 flex-1">
+          <table className="w-full table-fixed">
+            <thead>
+              <tr>
+                <th className="py-2 pr-3 text-xs font-medium tracking-wider uppercase text-left text-gray-600 dark:text-gray-400">{nameHeader}</th>
+                <th className="w-20 px-2 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-600 sm:px-3 dark:text-gray-400">{t("dashboardCharts.matches")}</th>
+                <th className="w-20 px-2 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-600 sm:px-3 dark:text-gray-400">{t("dashboardCharts.approved")}</th>
+                <th className="hidden w-28 py-2 pl-3 sm:table-cell"><span className="sr-only">{t("dashboardCharts.approved")}</span></th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="divide-y divide-gray-150 dark:divide-gray-750">
+              {rows.map((row) => (
+                <tr key={row.name}>
+                  <td className="max-w-0 truncate whitespace-nowrap py-2 pr-3 text-sm font-medium text-gray-900 dark:text-gray-300">{row.name}</td>
+                  <td className="px-2 py-2 text-right text-sm tabular-nums text-gray-600 sm:px-3 dark:text-gray-400">{row.matched.toLocaleString()}</td>
+                  <td className="px-2 py-2 text-right text-sm tabular-nums text-gray-900 sm:px-3 dark:text-gray-300">{row.approved.toLocaleString()}</td>
+                  <td className="hidden py-2 pl-3 sm:table-cell">
+                    <div className="h-1.5 w-full rounded-full" style={{ backgroundColor: trackColor }}>
+                      <div
+                        className="h-1.5 rounded-full"
+                        style={{ backgroundColor: barColor, width: `${Math.max((row.approved / maxApproved) * 100, 2)}%` }}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </ChartCard>
   );

--- a/web/src/screens/dashboard/charts.tsx
+++ b/web/src/screens/dashboard/charts.tsx
@@ -57,9 +57,9 @@ interface ChartCardProps {
 }
 
 export const ChartCard = ({ title, className, action, children }: ChartCardProps) => (
-  <div className={classNames("px-4 py-3 overflow-hidden rounded-lg shadow-lg bg-white dark:bg-gray-800", className ?? "")}>
-    <div className="flex items-center justify-between gap-2">
-      <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">{title}</h3>
+  <div className={classNames("flex h-full min-w-0 flex-col overflow-hidden rounded-lg bg-white px-4 py-3 shadow-lg dark:bg-gray-800", className ?? "")}>
+    <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
+      <h3 className="min-w-0 flex-1 truncate text-sm font-medium text-gray-500 dark:text-gray-400">{title}</h3>
       {action}
     </div>
     {children}
@@ -81,7 +81,7 @@ export const RangeSelect = <T extends string>({ options, value, onChange }: Rang
         aria-pressed={option.value === value}
         onClick={() => onChange(option.value)}
         className={classNames(
-          "px-2 py-0.5 rounded-md text-xs transition-colors duration-200 ease-in-out",
+          "inline-flex min-h-9 items-center rounded-md px-2.5 text-xs transition-colors duration-200 ease-in-out focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500",
           option.value === value
             ? "bg-gray-150 dark:bg-gray-750 font-medium text-gray-900 dark:text-gray-200"
             : "text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 cursor-pointer"

--- a/web/src/screens/dashboard/widgets.ts
+++ b/web/src/screens/dashboard/widgets.ts
@@ -12,22 +12,81 @@ import { ActivityTable } from "./ActivityTable";
 
 export interface DashboardWidgetDef {
   id: string;
+  size: "compact" | "half" | "full";
   spanClass: string;
+  titleKey: string;
   Component: React.ComponentType;
 }
 
-// Registry order is the default layout. Adding a widget here is enough:
-// stored configs are reconciled against the registry, unknown ids dropped
-// and new ones appended.
 export const DASHBOARD_WIDGETS: DashboardWidgetDef[] = [
-  { id: "stat-filtered", spanClass: "sm:col-span-1", Component: FilteredTile },
-  { id: "stat-approved", spanClass: "sm:col-span-1", Component: ApprovedTile },
-  { id: "stat-rejected", spanClass: "sm:col-span-1", Component: RejectedTile },
-  { id: "stat-errored", spanClass: "sm:col-span-1", Component: ErroredTile },
-  { id: "activity", spanClass: "sm:col-span-2 lg:col-span-4", Component: ActivityChart },
-  { id: "volume", spanClass: "sm:col-span-2 lg:col-span-2", Component: VolumeChart },
-  { id: "heatmap", spanClass: "sm:col-span-2 lg:col-span-2", Component: HourHeatmap },
-  { id: "top-indexers", spanClass: "sm:col-span-2 lg:col-span-2", Component: TopIndexers },
-  { id: "top-filters", spanClass: "sm:col-span-2 lg:col-span-2", Component: TopFilters },
-  { id: "recent-activity", spanClass: "sm:col-span-2 lg:col-span-4", Component: ActivityTable }
+  {
+    id: "stat-filtered",
+    size: "compact",
+    spanClass: "sm:col-span-1",
+    titleKey: "dashboardStats.filteredReleases",
+    Component: FilteredTile
+  },
+  {
+    id: "stat-approved",
+    size: "compact",
+    spanClass: "sm:col-span-1",
+    titleKey: "dashboardStats.approvedPushes",
+    Component: ApprovedTile
+  },
+  {
+    id: "stat-rejected",
+    size: "compact",
+    spanClass: "sm:col-span-1",
+    titleKey: "dashboardStats.rejectedPushes",
+    Component: RejectedTile
+  },
+  {
+    id: "stat-errored",
+    size: "compact",
+    spanClass: "sm:col-span-1",
+    titleKey: "dashboardStats.erroredPushes",
+    Component: ErroredTile
+  },
+  {
+    id: "activity",
+    size: "full",
+    spanClass: "sm:col-span-2 lg:col-span-4",
+    titleKey: "dashboardCharts.activityTitle",
+    Component: ActivityChart
+  },
+  {
+    id: "volume",
+    size: "half",
+    spanClass: "sm:col-span-2 lg:col-span-2",
+    titleKey: "dashboardCharts.volumeTitle",
+    Component: VolumeChart
+  },
+  {
+    id: "heatmap",
+    size: "half",
+    spanClass: "sm:col-span-2 lg:col-span-2",
+    titleKey: "dashboardCharts.heatmapTitle",
+    Component: HourHeatmap
+  },
+  {
+    id: "top-indexers",
+    size: "half",
+    spanClass: "sm:col-span-2 lg:col-span-2",
+    titleKey: "dashboardCharts.topIndexersTitle",
+    Component: TopIndexers
+  },
+  {
+    id: "top-filters",
+    size: "half",
+    spanClass: "sm:col-span-2 lg:col-span-2",
+    titleKey: "dashboardCharts.topFiltersTitle",
+    Component: TopFilters
+  },
+  {
+    id: "recent-activity",
+    size: "full",
+    spanClass: "sm:col-span-2 lg:col-span-4",
+    titleKey: "activityTable.title",
+    Component: ActivityTable
+  }
 ];


### PR DESCRIPTION
# Description

Refine the Stats dashboard layout and customization flow so widgets align consistently and drag-and-drop behavior is predictable.

The dashboard now uses dedicated drag handles, size-compatible drop targets, stable release animations, equal-height ranking cards, square heatmap cells, and a page-level incognito control. Saved layouts still preserve user order while safely reconciling added or removed widgets.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

- `pnpm --dir web build`
- `pnpm --dir web exec eslint src/screens/dashboard/DashboardGrid.tsx src/screens/dashboard/ActivityTable.tsx src/screens/dashboard/HourHeatmap.tsx`
- Live browser checks for pointer reordering, saved order, displaced-card release rendering, unequal ranking lengths, and incognito table masking

## Screenshots (for UI changes)

### Normal
Before
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ae0491d8-0e7c-401c-9fe3-96bac785edcb" />
After
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/48727011-7f73-42e3-9702-0532f6df0945" />

### Edit mode
Before
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/15263c62-7256-4b71-890a-1a183fa09cfc" />
After
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/d1281b8c-8bd3-4502-95e1-eafc659ad012" />


## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Frontend lint and build pass locally
- [x] No database schema or documentation changes are required

## AI disclosure

Yes. Most of the implementation was authored and iteratively refined with OpenAI Codex (GPT-5.6 Sol) under user direction. The changes were reviewed and verified with the local frontend build, ESLint, and browser interaction.
