### PR TITLE
fix(actions): preserve parsed metadata for retrying

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -642,7 +642,56 @@ func (repo *ReleaseRepo) GetActionStatusByReleaseID(ctx context.Context, release
 
 func (repo *ReleaseRepo) Get(ctx context.Context, req *domain.GetReleaseRequest) (*domain.Release, error) {
 	queryBuilder := repo.db.squirrel.
-		Select("r.id", "r.filter_status", "r.rejections", "r.indexer", "r.filter", "r.filter_id", "r.protocol", "r.implementation", "r.announce_type", "r.info_url", "r.download_url", "r.title", "r.sub_title", "r.torrent_name", "r.category", "r.size", "r.group_id", "r.torrent_id", "r.uploader", "r.timestamp").
+		Select(
+			"r.id",
+			"r.filter_status",
+			"r.rejections",
+			"r.indexer",
+			"r.filter",
+			"r.filter_id",
+			"r.protocol",
+			"r.implementation",
+			"r.announce_type",
+			"r.info_url",
+			"r.download_url",
+			"r.title",
+			"r.sub_title",
+			"r.torrent_name",
+			"r.normalized_hash",
+			"r.category",
+			"r.size",
+			"r.group_id",
+			"r.torrent_id",
+			"r.season",
+			"r.episode",
+			"r.year",
+			"r.month",
+			"r.day",
+			"r.resolution",
+			"r.source",
+			"r.codec",
+			"r.container",
+			"r.hdr",
+			"r.audio",
+			"r.audio_channels",
+			"r.release_group",
+			"r.proper",
+			"r.repack",
+			"r.region",
+			"r.language",
+			"r.cut",
+			"r.edition",
+			"r.hybrid",
+			"r.media_processing",
+			"r.website",
+			"r.type",
+			"r.origin",
+			"r.tags",
+			"r.uploader",
+			"r.pre_time",
+			"r.other",
+			"r.timestamp",
+		).
 		From("release r").
 		OrderBy("r.id DESC").
 		Where(sq.Eq{"r.id": req.Id})
@@ -661,10 +710,61 @@ func (repo *ReleaseRepo) Get(ctx context.Context, req *domain.GetReleaseRequest)
 
 	var rls domain.Release
 
-	var indexerName, filterName, announceType, infoUrl, downloadUrl, subTitle, groupId, torrentId, category, uploader sql.NullString
+	var indexerName, filterName, announceType, infoUrl, downloadUrl, subTitle, normalizedHash, groupId, torrentId, category, resolution, source, codec, container, hdr, audio, audioChannels, releaseGroup, region, language, cut, edition, mediaProcessing, website, releaseType, origin, uploader, preTime sql.NullString
 	var filterId sql.NullInt64
+	var season, episode, year, month, day sql.NullInt64
+	var proper, repack, hybrid sql.NullBool
 
-	if err := row.Scan(&rls.ID, &rls.FilterStatus, pq.Array(&rls.Rejections), &indexerName, &filterName, &filterId, &rls.Protocol, &rls.Implementation, &announceType, &infoUrl, &downloadUrl, &rls.Title, &subTitle, &rls.TorrentName, &category, &rls.Size, &groupId, &torrentId, &uploader, &rls.Timestamp); err != nil {
+	if err := row.Scan(
+		&rls.ID,
+		&rls.FilterStatus,
+		pq.Array(&rls.Rejections),
+		&indexerName,
+		&filterName,
+		&filterId,
+		&rls.Protocol,
+		&rls.Implementation,
+		&announceType,
+		&infoUrl,
+		&downloadUrl,
+		&rls.Title,
+		&subTitle,
+		&rls.TorrentName,
+		&normalizedHash,
+		&category,
+		&rls.Size,
+		&groupId,
+		&torrentId,
+		&season,
+		&episode,
+		&year,
+		&month,
+		&day,
+		&resolution,
+		&source,
+		&codec,
+		&container,
+		&hdr,
+		&audio,
+		&audioChannels,
+		&releaseGroup,
+		&proper,
+		&repack,
+		&region,
+		&language,
+		&cut,
+		&edition,
+		&hybrid,
+		&mediaProcessing,
+		&website,
+		&releaseType,
+		&origin,
+		pq.Array(&rls.Tags),
+		&uploader,
+		&preTime,
+		pq.Array(&rls.Other),
+		&rls.Timestamp,
+	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, domain.ErrRecordNotFound
 		}
@@ -680,10 +780,50 @@ func (repo *ReleaseRepo) Get(ctx context.Context, req *domain.GetReleaseRequest)
 	rls.InfoURL = infoUrl.String
 	rls.DownloadURL = downloadUrl.String
 	rls.SubTitle = subTitle.String
+	rls.NormalizedHash = normalizedHash.String
 	rls.Category = category.String
 	rls.GroupID = groupId.String
 	rls.TorrentID = torrentId.String
+	rls.Season = int(season.Int64)
+	rls.Episode = int(episode.Int64)
+	rls.Year = int(year.Int64)
+	rls.Month = int(month.Int64)
+	rls.Day = int(day.Int64)
+	rls.Resolution = resolution.String
+	rls.Source = source.String
+	if codec.String != "" {
+		rls.Codec = strings.Split(codec.String, ",")
+	}
+	rls.Container = container.String
+	if hdr.String != "" {
+		rls.HDR = strings.Split(hdr.String, ",")
+	}
+	if audio.String != "" {
+		rls.Audio = strings.Split(audio.String, ",")
+	}
+	rls.AudioChannels = audioChannels.String
+	rls.Group = releaseGroup.String
+	rls.Proper = proper.Bool
+	rls.Repack = repack.Bool
+	rls.Region = region.String
+	if language.String != "" {
+		rls.Language = strings.Split(language.String, ",")
+	}
+	if cut.String != "" {
+		rls.Cut = strings.Split(cut.String, ",")
+	}
+	if edition.String != "" {
+		rls.Edition = strings.Split(edition.String, ",")
+	}
+	rls.Hybrid = hybrid.Bool
+	rls.MediaProcessing = mediaProcessing.String
+	rls.Website = website.String
+	if releaseType.Valid {
+		rls.ParseType(releaseType.String)
+	}
+	rls.Origin = origin.String
 	rls.Uploader = uploader.String
+	rls.PreTime = preTime.String
 
 	return &rls, nil
 }

--- a/internal/database/release_test.go
+++ b/internal/database/release_test.go
@@ -440,6 +440,21 @@ func TestReleaseRepo_Get(t *testing.T) {
 		repo := NewReleaseRepo(log, db)
 
 		mockData := getMockRelease()
+		mockData.Title = "Troy"
+		mockData.NormalizedHash = "troy-2004"
+		mockData.Year = 2004
+		mockData.Month = 5
+		mockData.Day = 14
+		mockData.Audio = []string{"DTS-HD MA", "Atmos"}
+		mockData.AudioChannels = "7.1"
+		mockData.Region = "US"
+		mockData.Language = []string{"English", "French"}
+		mockData.Cut = []string{"Director's Cut"}
+		mockData.Edition = []string{"Extended"}
+		mockData.Hybrid = true
+		mockData.Repack = true
+		mockData.MediaProcessing = "Remux"
+		mockData.Other = []string{"Remastered"}
 		releaseActionMockData := getMockReleaseActionStatus()
 		actionMockData := getMockAction()
 
@@ -480,6 +495,92 @@ func TestReleaseRepo_Get(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, release)
 			assert.Equal(t, mockData.ID, release.ID)
+			assert.Equal(t, mockData.Title, release.Title)
+			assert.Equal(t, mockData.NormalizedHash, release.NormalizedHash)
+			assert.Equal(t, mockData.Season, release.Season)
+			assert.Equal(t, mockData.Episode, release.Episode)
+			assert.Equal(t, mockData.Year, release.Year)
+			assert.Equal(t, mockData.Month, release.Month)
+			assert.Equal(t, mockData.Day, release.Day)
+			assert.Equal(t, mockData.Resolution, release.Resolution)
+			assert.Equal(t, mockData.Source, release.Source)
+			assert.Equal(t, mockData.Codec, release.Codec)
+			assert.Equal(t, mockData.Container, release.Container)
+			assert.Equal(t, mockData.HDR, release.HDR)
+			assert.Equal(t, mockData.Audio, release.Audio)
+			assert.Equal(t, mockData.AudioChannels, release.AudioChannels)
+			assert.Equal(t, mockData.Group, release.Group)
+			assert.Equal(t, mockData.Region, release.Region)
+			assert.Equal(t, mockData.Language, release.Language)
+			assert.Equal(t, mockData.Cut, release.Cut)
+			assert.Equal(t, mockData.Edition, release.Edition)
+			assert.Equal(t, mockData.Hybrid, release.Hybrid)
+			assert.Equal(t, mockData.Proper, release.Proper)
+			assert.Equal(t, mockData.Repack, release.Repack)
+			assert.Equal(t, mockData.Website, release.Website)
+			assert.Equal(t, mockData.MediaProcessing, release.MediaProcessing)
+			assert.Equal(t, mockData.Type, release.Type)
+			assert.Equal(t, mockData.Origin, release.Origin)
+			assert.Equal(t, mockData.Tags, release.Tags)
+			assert.Equal(t, mockData.PreTime, release.PreTime)
+			assert.Equal(t, mockData.Other, release.Other)
+
+			episode := &domain.Release{
+				Rejections: []string{},
+				Timestamp:  time.Now(),
+				Title:      "Example Show",
+				Season:     4,
+				Episode:    7,
+				Type:       rls.Episode,
+				Tags:       []string{},
+				Other:      []string{},
+				FilterID:   createdFilters[0].ID,
+			}
+
+			err = repo.Store(context.Background(), episode)
+			assert.NoError(t, err)
+
+			_, err = db.squirrel.
+				Update("release").
+				Set("year", nil).
+				Set("resolution", nil).
+				Set("codec", nil).
+				Set("hdr", nil).
+				Set("audio", nil).
+				Set("language", nil).
+				Set("cut", nil).
+				Set("edition", nil).
+				Set("proper", nil).
+				Set("repack", nil).
+				Set("hybrid", nil).
+				Where("id = ?", episode.ID).
+				RunWith(db.Handler).
+				ExecContext(context.Background())
+			assert.NoError(t, err)
+
+			storedEpisode, err := repo.Get(context.Background(), &domain.GetReleaseRequest{Id: int(episode.ID)})
+			assert.NoError(t, err)
+			assert.NotNil(t, storedEpisode)
+			assert.Equal(t, episode.Season, storedEpisode.Season)
+			assert.Equal(t, episode.Episode, storedEpisode.Episode)
+			assert.Equal(t, episode.Type, storedEpisode.Type)
+			assert.Zero(t, storedEpisode.Year)
+			assert.Empty(t, storedEpisode.Resolution)
+			assert.Empty(t, storedEpisode.Codec)
+			assert.Empty(t, storedEpisode.HDR)
+			assert.Empty(t, storedEpisode.Audio)
+			assert.Empty(t, storedEpisode.Language)
+			assert.Empty(t, storedEpisode.Cut)
+			assert.Empty(t, storedEpisode.Edition)
+			assert.False(t, storedEpisode.Proper)
+			assert.False(t, storedEpisode.Repack)
+			assert.False(t, storedEpisode.Hybrid)
+			assert.Empty(t, storedEpisode.Tags)
+			assert.Empty(t, storedEpisode.Other)
+
+			missing, err := repo.Get(context.Background(), &domain.GetReleaseRequest{Id: -1})
+			assert.Nil(t, missing)
+			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 
 			// Cleanup
 			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})


### PR DESCRIPTION
# Description

Expand `ReleaseRepo.Get` to select, scan, and reconstruct the persisted release fields needed by action macros, following the nullable-value and comma-separated slice handling already used by `findReleases`. Keep `Service.Retry` and action dispatch unchanged: they already pass the object returned by `Get` into the normal action runner, so completing that repository object restores the production wiring without adding a retry-only abstraction. Use the stored parsed values rather than reparsing `TorrentName`, ensuring a retry reflects the metadata used by the original action even if parsing behavior later changes.

Action retries reconstruct a release through `ReleaseRepo.Get`, but that query currently loads only a narrow subset of the columns written by `ReleaseRepo.Store`. As a result, persisted parsed metadata such as `Year`, `Season`, and `Episode` is left at its zero value before webhook and download-client templates are rendered. The original action receives the complete in-memory release, so the same templates produce different output on retry. The reporter and maintainer clarified that unstored external metadata such as `MetaIMDB` and `MetaTMDB` is outside this issue's scope.

Fixes #2565

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Store and retrieve a movie release with a non-zero year, then verify `Title` and `Year` are unchanged so a retry template can render `Troy 2004`.
Store and retrieve an episode release with non-zero season and episode values, then verify both survive reconstruction for `SxxExx` action macros.
Round-trip the other persisted macro-bearing metadata loaded by the expanded query, including resolution/source, codec/HDR/audio and language-style slices, group, proper/repack/hybrid flags, edition/cut, type, origin, tags, and date fields.
Store nullable or empty optional metadata and verify retrieval returns safe zero or empty values without scan errors on both SQLite and PostgreSQL.
Request a missing release ID and retain the existing `domain.ErrRecordNotFound` behavior.

## Screenshots (for UI changes)

No user-visible surface changes in this PR, so there is nothing to show.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Was any AI used in this PR? Roughly how much of the code was AI-written, and what model/tool?

AI was used for assistance.
