### PR TITLE
fix(irc): do not log unmonitored bouncer traffic as errors

### DIFF
--- a/internal/irc/handler.go
+++ b/internal/irc/handler.go
@@ -1182,6 +1182,11 @@ func (h *Handler) onPrivMessage(msg ircmsg.Message) {
 
 	ircChannel, found := h.channels.Get(channel)
 	if !found {
+		if h.usesBouncer() {
+			h.log.Trace().Str("channel", channel).Msg("ignoring message from unmonitored bouncer channel")
+			return
+		}
+
 		h.log.Error().Str("channel", channel).Msg("channel not found")
 		return
 	}


### PR DESCRIPTION
# Description

<!--- Summarize the change and the motivation. Link any related issue or discussion. --->

Bouncers will PRIVMSG for all channels, even ones where autobrr is not listening, causing harmless but confusing errors

## Type of change

<!--- Delete options that are not relevant. --->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] I ran `go fmt` and the test suite passes locally
- [X] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [X] I have linked any related issue and updated docs if needed

## AI disclosure

<!--- Please do not lie about the AI usage in this PR. --->

AI was not used