### PR TITLE
refactor(database): use embedded PG for all tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,16 +77,6 @@ jobs:
   test:
     name: Test ubuntu-latest
     runs-on: ubuntu-latest
-    services:
-      test_postgres:
-        image: postgres:12.10
-        ports:
-          - "5437:5432"
-        env:
-          POSTGRES_USER: testdb
-          POSTGRES_PASSWORD: testdb
-          POSTGRES_DB: autobrr
-        options: --health-cmd pg_isready --health-interval 1s --health-timeout 5s --health-retries 60
     env:
       CGO_ENABLED: 0
     steps:

--- a/internal/action/exec_test.go
+++ b/internal/action/exec_test.go
@@ -4,7 +4,6 @@
 package action
 
 import (
-	"context"
 	"testing"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -106,7 +105,7 @@ func Test_service_execCmd(t *testing.T) {
 				clientSvc: nil,
 				bus:       nil,
 			}
-			s.execCmd(context.TODO(), tt.args.action, &tt.args.release)
+			s.execCmd(t.Context(), tt.args.action, &tt.args.release)
 		})
 	}
 }

--- a/internal/action/run_test.go
+++ b/internal/action/run_test.go
@@ -58,7 +58,7 @@ func TestCheckActionPreconditions_DownloadsOncePerRelease(t *testing.T) {
 	}
 
 	for _, action := range actions {
-		err := svc.CheckActionPreconditions(context.Background(), action, release)
+		err := svc.CheckActionPreconditions(t.Context(), action, release)
 		assert.NoError(t, err)
 	}
 
@@ -79,7 +79,7 @@ func TestCheckActionPreconditions_SkipsDownloadForMagnet(t *testing.T) {
 		MagnetURI:   "magnet:?xt=urn:btih:abc123",
 	}
 
-	err := svc.CheckActionPreconditions(context.Background(), &domain.Action{Type: domain.ActionTypeQbittorrent}, release)
+	err := svc.CheckActionPreconditions(t.Context(), &domain.Action{Type: domain.ActionTypeQbittorrent}, release)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, dl.fetches, "magnet releases must not trigger a torrent download")
@@ -94,7 +94,7 @@ func TestCheckActionPreconditions_SkipsDownloadForArrActions(t *testing.T) {
 
 	release := &domain.Release{TorrentName: "Test.Release-GRP", Protocol: domain.ReleaseProtocolTorrent}
 
-	err := svc.CheckActionPreconditions(context.Background(), &domain.Action{Type: domain.ActionTypeRadarr}, release)
+	err := svc.CheckActionPreconditions(t.Context(), &domain.Action{Type: domain.ActionTypeRadarr}, release)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, dl.fetches)
@@ -110,7 +110,7 @@ func TestCheckActionPreconditions_WritesTmpFileForPathMacro(t *testing.T) {
 	release := &domain.Release{TorrentName: "Test.Release-GRP", Protocol: domain.ReleaseProtocolTorrent}
 	action := &domain.Action{Type: domain.ActionTypeExec, ExecArgs: "--torrent {{.TorrentPathName}}"}
 
-	err := svc.CheckActionPreconditions(context.Background(), action, release)
+	err := svc.CheckActionPreconditions(t.Context(), action, release)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, dl.fetches)
@@ -131,7 +131,7 @@ func TestCheckActionPreconditions_SkipsDownloadForPlainExec(t *testing.T) {
 	release := &domain.Release{TorrentName: "Test.Release-GRP", Protocol: domain.ReleaseProtocolTorrent}
 	action := &domain.Action{Type: domain.ActionTypeExec, ExecArgs: "--name {{.TorrentName}}"}
 
-	err := svc.CheckActionPreconditions(context.Background(), action, release)
+	err := svc.CheckActionPreconditions(t.Context(), action, release)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, dl.fetches)

--- a/internal/action/watchfolder_test.go
+++ b/internal/action/watchfolder_test.go
@@ -4,7 +4,6 @@
 package action
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +33,7 @@ func TestWatchFolder_WritesTorrentNamedAfterInfoHash(t *testing.T) {
 	dir := t.TempDir()
 	release := testTorrentRelease()
 
-	err := (&Service{}).watchFolder(context.Background(), &domain.Action{WatchFolder: dir}, release)
+	err := (&Service{}).watchFolder(t.Context(), &domain.Action{WatchFolder: dir}, release)
 	require.NoError(t, err)
 
 	want := filepath.Join(dir, "autobrr-"+testInfoHash+".torrent")
@@ -52,7 +51,7 @@ func TestWatchFolder_HonoursExplicitFileName(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "nested", "chosen-name.torrent")
 
-	err := (&Service{}).watchFolder(context.Background(), &domain.Action{WatchFolder: target}, testTorrentRelease())
+	err := (&Service{}).watchFolder(t.Context(), &domain.Action{WatchFolder: target}, testTorrentRelease())
 	require.NoError(t, err)
 
 	assert.FileExists(t, target)
@@ -64,7 +63,7 @@ func TestWatchFolder_RejectsMagnet(t *testing.T) {
 	release := testTorrentRelease()
 	release.MagnetURI = "magnet:?xt=urn:btih:" + testInfoHash
 
-	err := (&Service{}).watchFolder(context.Background(), &domain.Action{WatchFolder: t.TempDir()}, release)
+	err := (&Service{}).watchFolder(t.Context(), &domain.Action{WatchFolder: t.TempDir()}, release)
 
 	assert.Error(t, err, "watch folder cannot write a magnet link")
 }
@@ -79,7 +78,7 @@ func TestWatchFolder_RejectsMissingTorrent(t *testing.T) {
 	release := testTorrentRelease()
 	release.TorrentDataRawBytes = nil
 
-	err := (&Service{}).watchFolder(context.Background(), &domain.Action{WatchFolder: dir}, release)
+	err := (&Service{}).watchFolder(t.Context(), &domain.Action{WatchFolder: dir}, release)
 	require.Error(t, err)
 
 	entries, readErr := os.ReadDir(dir)

--- a/internal/database/action_test.go
+++ b/internal/database/action_test.go
@@ -54,7 +54,8 @@ func getMockAction() *domain.Action {
 }
 
 func TestActionRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		downloadClientRepo := NewDownloadClientRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
@@ -64,14 +65,14 @@ func TestActionRepo_Store(t *testing.T) {
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -79,36 +80,36 @@ func TestActionRepo_Store(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Actual test for Store
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockData)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: mockData.ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: mockData.ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("Store_Succeeds_With_Missing_or_empty_fields [%s]", dbType), func(t *testing.T) {
 			mockData := &domain.Action{}
-			err := repo.Store(context.Background(), mockData)
+			err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: mockData.ID})
+			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: mockData.ID})
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Invalid_ClientID [%s]", dbType), func(t *testing.T) {
 			mockData := getMockAction()
 			mockData.ClientID = 9999
-			err := repo.Store(context.Background(), mockData)
+			err := repo.Store(t.Context(), mockData)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
 			mockData := getMockAction()
 
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
 			err := repo.Store(ctx, mockData)
@@ -118,7 +119,8 @@ func TestActionRepo_Store(t *testing.T) {
 }
 
 func TestActionRepo_StoreFilterActions(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		downloadClientRepo := NewDownloadClientRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
@@ -128,14 +130,14 @@ func TestActionRepo_StoreFilterActions(t *testing.T) {
 		t.Run(fmt.Sprintf("StoreFilterActions_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -143,47 +145,47 @@ func TestActionRepo_StoreFilterActions(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Actual test for StoreFilterActions
-			createdActions, err := repo.StoreFilterActions(context.Background(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
 
 			assert.NoError(t, err)
 			assert.NotNil(t, createdActions)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("StoreFilterActions_Fails_Invalid_FilterID [%s]", dbType), func(t *testing.T) {
-			_, err := repo.StoreFilterActions(context.Background(), 9999, []*domain.Action{mockData})
+			_, err := repo.StoreFilterActions(t.Context(), 9999, []*domain.Action{mockData})
 			assert.NoError(t, err)
 		})
 
 		t.Run(fmt.Sprintf("StoreFilterActions_Fails_Empty_Actions_Array [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := filterRepo.Store(context.Background(), getMockFilter())
+			err := filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
-			_, err = repo.StoreFilterActions(context.Background(), int64(createdFilters[0].ID), []*domain.Action{})
+			_, err = repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{})
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("StoreFilterActions_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
-			err := filterRepo.Store(context.Background(), getMockFilter())
+			err := filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -191,13 +193,14 @@ func TestActionRepo_StoreFilterActions(t *testing.T) {
 			assert.Error(t, err)
 
 			// Cleanup
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
 		})
 	}
 }
 
 func TestActionRepo_FindByFilterID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		downloadClientRepo := NewDownloadClientRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
@@ -207,61 +210,61 @@ func TestActionRepo_FindByFilterID(t *testing.T) {
 		t.Run(fmt.Sprintf("FindByFilterID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(context.Background(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for FindByFilterID
-			actions, err := repo.FindByFilterID(context.Background(), createdFilters[0].ID, nil, false)
+			actions, err := repo.FindByFilterID(t.Context(), createdFilters[0].ID, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, actions)
 			assert.Equal(t, 1, len(actions))
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByFilterID_Fails_No_Actions [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := filterRepo.Store(context.Background(), getMockFilter())
+			err := filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			// Actual test for FindByFilterID
-			actions, err := repo.FindByFilterID(context.Background(), createdFilters[0].ID, nil, false)
+			actions, err := repo.FindByFilterID(t.Context(), createdFilters[0].ID, nil, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(actions))
 
 			// Cleanup
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByFilterID_Succeeds_With_Invalid_FilterID [%s]", dbType), func(t *testing.T) {
-			actions, err := repo.FindByFilterID(context.Background(), 9999, nil, false) // 9999 is an invalid filter ID
+			actions, err := repo.FindByFilterID(t.Context(), 9999, nil, false) // 9999 is an invalid filter ID
 			assert.NoError(t, err)
 			assert.NotNil(t, actions)
 			assert.Equal(t, 0, len(actions))
 		})
 
 		t.Run(fmt.Sprintf("FindByFilterID_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
 			actions, err := repo.FindByFilterID(ctx, 1, nil, false)
@@ -272,7 +275,8 @@ func TestActionRepo_FindByFilterID(t *testing.T) {
 }
 
 func TestActionRepo_List(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		downloadClientRepo := NewDownloadClientRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
@@ -282,36 +286,36 @@ func TestActionRepo_List(t *testing.T) {
 		t.Run(fmt.Sprintf("List_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(context.Background(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for List
-			actions, err := repo.List(context.Background())
+			actions, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, actions)
 			assert.GreaterOrEqual(t, len(actions), 1)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
 			actions, err := repo.List(ctx)
@@ -322,7 +326,8 @@ func TestActionRepo_List(t *testing.T) {
 }
 
 func TestActionRepo_Get(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		downloadClientRepo := NewDownloadClientRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
@@ -332,43 +337,43 @@ func TestActionRepo_Get(t *testing.T) {
 		t.Run(fmt.Sprintf("Get_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(context.Background(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for Get
-			action, err := repo.Get(context.Background(), &domain.GetActionRequest{Id: createdActions[0].ID})
+			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: createdActions[0].ID})
 			assert.NoError(t, err)
 			assert.NotNil(t, action)
 			assert.Equal(t, createdActions[0].ID, action.ID)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("Get_Fails_No_Record [%s]", dbType), func(t *testing.T) {
-			action, err := repo.Get(context.Background(), &domain.GetActionRequest{Id: 9999})
+			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: 9999})
 			assert.Error(t, err)
 			assert.Equal(t, domain.ErrRecordNotFound, err)
 			assert.Nil(t, action)
 		})
 
 		t.Run(fmt.Sprintf("Get_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
 			action, err := repo.Get(ctx, &domain.GetActionRequest{Id: 1})
@@ -379,7 +384,8 @@ func TestActionRepo_Get(t *testing.T) {
 }
 
 func TestActionRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		downloadClientRepo := NewDownloadClientRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
@@ -389,40 +395,40 @@ func TestActionRepo_Delete(t *testing.T) {
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(context.Background(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for Delete
-			err = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			err = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
 			assert.NoError(t, err)
 
 			// Verify that the record was actually deleted
-			action, err := repo.Get(context.Background(), &domain.GetActionRequest{Id: createdActions[0].ID})
+			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: createdActions[0].ID})
 			assert.Error(t, err)
 			assert.Equal(t, domain.ErrRecordNotFound, err)
 			assert.Nil(t, action)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
 			err := repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: 1})
@@ -433,7 +439,8 @@ func TestActionRepo_Delete(t *testing.T) {
 }
 
 func TestActionRepo_DeleteByFilterID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		downloadClientRepo := NewDownloadClientRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
@@ -443,39 +450,39 @@ func TestActionRepo_DeleteByFilterID(t *testing.T) {
 		t.Run(fmt.Sprintf("DeleteByFilterID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(context.Background(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
-			err = repo.DeleteByFilterID(context.Background(), mockData.FilterID)
+			err = repo.DeleteByFilterID(t.Context(), mockData.FilterID)
 			assert.NoError(t, err)
 
 			// Verify that actions with the given filterID are actually deleted
-			action, err := repo.Get(context.Background(), &domain.GetActionRequest{Id: createdActions[0].ID})
+			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: createdActions[0].ID})
 			assert.Error(t, err)
 			assert.Equal(t, domain.ErrRecordNotFound, err)
 			assert.Nil(t, action)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("DeleteByFilterID_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
 			err := repo.DeleteByFilterID(ctx, mockData.FilterID)
@@ -485,7 +492,8 @@ func TestActionRepo_DeleteByFilterID(t *testing.T) {
 }
 
 func TestActionRepo_ToggleEnabled(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		downloadClientRepo := NewDownloadClientRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
@@ -495,21 +503,21 @@ func TestActionRepo_ToggleEnabled(t *testing.T) {
 		t.Run(fmt.Sprintf("ToggleEnabled_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 			mockData.Enabled = false
-			createdActions, err := repo.StoreFilterActions(context.Background(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for ToggleEnabled
@@ -517,14 +525,14 @@ func TestActionRepo_ToggleEnabled(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Verify that the record was actually updated
-			action, err := repo.Get(context.Background(), &domain.GetActionRequest{Id: createdActions[0].ID})
+			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: createdActions[0].ID})
 			assert.NoError(t, err)
 			assert.Equal(t, true, action.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Fails_No_Record [%s]", dbType), func(t *testing.T) {

--- a/internal/database/action_test.go
+++ b/internal/database/action_test.go
@@ -54,6 +54,8 @@ func getMockAction() *domain.Action {
 }
 
 func TestActionRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -65,14 +67,14 @@ func TestActionRepo_Store(t *testing.T) {
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -80,45 +82,47 @@ func TestActionRepo_Store(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Actual test for Store
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockData)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: mockData.ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: mockData.ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("Store_Succeeds_With_Missing_or_empty_fields [%s]", dbType), func(t *testing.T) {
 			mockData := &domain.Action{}
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: mockData.ID})
+			_ = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: mockData.ID})
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Invalid_ClientID [%s]", dbType), func(t *testing.T) {
 			mockData := getMockAction()
 			mockData.ClientID = 9999
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
 			mockData := getMockAction()
 
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			err := repo.Store(ctx, mockData)
+			err := repo.Store(timeoutCtx, mockData)
 			assert.Error(t, err)
 		})
 	}
 }
 
 func TestActionRepo_StoreFilterActions(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -130,14 +134,14 @@ func TestActionRepo_StoreFilterActions(t *testing.T) {
 		t.Run(fmt.Sprintf("StoreFilterActions_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -145,60 +149,62 @@ func TestActionRepo_StoreFilterActions(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Actual test for StoreFilterActions
-			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(ctx, int64(createdFilters[0].ID), []*domain.Action{mockData})
 
 			assert.NoError(t, err)
 			assert.NotNil(t, createdActions)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("StoreFilterActions_Fails_Invalid_FilterID [%s]", dbType), func(t *testing.T) {
-			_, err := repo.StoreFilterActions(t.Context(), 9999, []*domain.Action{mockData})
+			_, err := repo.StoreFilterActions(ctx, 9999, []*domain.Action{mockData})
 			assert.NoError(t, err)
 		})
 
 		t.Run(fmt.Sprintf("StoreFilterActions_Fails_Empty_Actions_Array [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := filterRepo.Store(t.Context(), getMockFilter())
+			err := filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
-			_, err = repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{})
+			_, err = repo.StoreFilterActions(ctx, int64(createdFilters[0].ID), []*domain.Action{})
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("StoreFilterActions_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			err := filterRepo.Store(t.Context(), getMockFilter())
+			err := filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
-			_, err = repo.StoreFilterActions(ctx, int64(createdFilters[0].ID), []*domain.Action{mockData})
+			_, err = repo.StoreFilterActions(timeoutCtx, int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.Error(t, err)
 
 			// Cleanup
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
 		})
 	}
 }
 
 func TestActionRepo_FindByFilterID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -210,64 +216,64 @@ func TestActionRepo_FindByFilterID(t *testing.T) {
 		t.Run(fmt.Sprintf("FindByFilterID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(ctx, int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for FindByFilterID
-			actions, err := repo.FindByFilterID(t.Context(), createdFilters[0].ID, nil, false)
+			actions, err := repo.FindByFilterID(ctx, createdFilters[0].ID, nil, false)
 			assert.NoError(t, err)
 			assert.NotNil(t, actions)
 			assert.Equal(t, 1, len(actions))
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByFilterID_Fails_No_Actions [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := filterRepo.Store(t.Context(), getMockFilter())
+			err := filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			// Actual test for FindByFilterID
-			actions, err := repo.FindByFilterID(t.Context(), createdFilters[0].ID, nil, false)
+			actions, err := repo.FindByFilterID(ctx, createdFilters[0].ID, nil, false)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(actions))
 
 			// Cleanup
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByFilterID_Succeeds_With_Invalid_FilterID [%s]", dbType), func(t *testing.T) {
-			actions, err := repo.FindByFilterID(t.Context(), 9999, nil, false) // 9999 is an invalid filter ID
+			actions, err := repo.FindByFilterID(ctx, 9999, nil, false) // 9999 is an invalid filter ID
 			assert.NoError(t, err)
 			assert.NotNil(t, actions)
 			assert.Equal(t, 0, len(actions))
 		})
 
 		t.Run(fmt.Sprintf("FindByFilterID_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			actions, err := repo.FindByFilterID(ctx, 1, nil, false)
+			actions, err := repo.FindByFilterID(timeoutCtx, 1, nil, false)
 			assert.Error(t, err)
 			assert.Nil(t, actions)
 		})
@@ -275,6 +281,8 @@ func TestActionRepo_FindByFilterID(t *testing.T) {
 }
 
 func TestActionRepo_List(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -286,39 +294,39 @@ func TestActionRepo_List(t *testing.T) {
 		t.Run(fmt.Sprintf("List_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(ctx, int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for List
-			actions, err := repo.List(t.Context())
+			actions, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, actions)
 			assert.GreaterOrEqual(t, len(actions), 1)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			actions, err := repo.List(ctx)
+			actions, err := repo.List(timeoutCtx)
 			assert.Error(t, err)
 			assert.Nil(t, actions)
 		})
@@ -326,6 +334,8 @@ func TestActionRepo_List(t *testing.T) {
 }
 
 func TestActionRepo_Get(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -337,46 +347,46 @@ func TestActionRepo_Get(t *testing.T) {
 		t.Run(fmt.Sprintf("Get_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(ctx, int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for Get
-			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: createdActions[0].ID})
+			action, err := repo.Get(ctx, &domain.GetActionRequest{Id: createdActions[0].ID})
 			assert.NoError(t, err)
 			assert.NotNil(t, action)
 			assert.Equal(t, createdActions[0].ID, action.ID)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("Get_Fails_No_Record [%s]", dbType), func(t *testing.T) {
-			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: 9999})
+			action, err := repo.Get(ctx, &domain.GetActionRequest{Id: 9999})
 			assert.Error(t, err)
 			assert.Equal(t, domain.ErrRecordNotFound, err)
 			assert.Nil(t, action)
 		})
 
 		t.Run(fmt.Sprintf("Get_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			action, err := repo.Get(ctx, &domain.GetActionRequest{Id: 1})
+			action, err := repo.Get(timeoutCtx, &domain.GetActionRequest{Id: 1})
 			assert.Error(t, err)
 			assert.Nil(t, action)
 		})
@@ -384,6 +394,8 @@ func TestActionRepo_Get(t *testing.T) {
 }
 
 func TestActionRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -395,43 +407,43 @@ func TestActionRepo_Delete(t *testing.T) {
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(ctx, int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for Delete
-			err = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			err = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
 			assert.NoError(t, err)
 
 			// Verify that the record was actually deleted
-			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: createdActions[0].ID})
+			action, err := repo.Get(ctx, &domain.GetActionRequest{Id: createdActions[0].ID})
 			assert.Error(t, err)
 			assert.Equal(t, domain.ErrRecordNotFound, err)
 			assert.Nil(t, action)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			err := repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: 1})
+			err := repo.Delete(timeoutCtx, &domain.DeleteActionRequest{ActionId: 1})
 			assert.Error(t, err)
 		})
 
@@ -439,6 +451,8 @@ func TestActionRepo_Delete(t *testing.T) {
 }
 
 func TestActionRepo_DeleteByFilterID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -450,48 +464,50 @@ func TestActionRepo_DeleteByFilterID(t *testing.T) {
 		t.Run(fmt.Sprintf("DeleteByFilterID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
-			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(ctx, int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
-			err = repo.DeleteByFilterID(t.Context(), mockData.FilterID)
+			err = repo.DeleteByFilterID(ctx, mockData.FilterID)
 			assert.NoError(t, err)
 
 			// Verify that actions with the given filterID are actually deleted
-			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: createdActions[0].ID})
+			action, err := repo.Get(ctx, &domain.GetActionRequest{Id: createdActions[0].ID})
 			assert.Error(t, err)
 			assert.Equal(t, domain.ErrRecordNotFound, err)
 			assert.Nil(t, action)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("DeleteByFilterID_Fails_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			err := repo.DeleteByFilterID(ctx, mockData.FilterID)
+			err := repo.DeleteByFilterID(timeoutCtx, mockData.FilterID)
 			assert.Error(t, err)
 		})
 	}
 }
 
 func TestActionRepo_ToggleEnabled(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -503,21 +519,21 @@ func TestActionRepo_ToggleEnabled(t *testing.T) {
 		t.Run(fmt.Sprintf("ToggleEnabled_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			mockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 			mockData.Enabled = false
-			createdActions, err := repo.StoreFilterActions(t.Context(), int64(createdFilters[0].ID), []*domain.Action{mockData})
+			createdActions, err := repo.StoreFilterActions(ctx, int64(createdFilters[0].ID), []*domain.Action{mockData})
 			assert.NoError(t, err)
 
 			// Actual test for ToggleEnabled
@@ -525,14 +541,14 @@ func TestActionRepo_ToggleEnabled(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Verify that the record was actually updated
-			action, err := repo.Get(t.Context(), &domain.GetActionRequest{Id: createdActions[0].ID})
+			action, err := repo.Get(ctx, &domain.GetActionRequest{Id: createdActions[0].ID})
 			assert.NoError(t, err)
 			assert.Equal(t, true, action.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteActionRequest{ActionId: createdActions[0].ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Fails_No_Record [%s]", dbType), func(t *testing.T) {

--- a/internal/database/api_test.go
+++ b/internal/database/api_test.go
@@ -6,7 +6,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -16,53 +15,55 @@ import (
 )
 
 func TestAPIRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewAPIRepo(log, db)
 
 		t.Run(fmt.Sprintf("Store_Succeeds_With_Valid_Key [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Name: "TestKey", Key: "123", Scopes: []string{"read", "write"}}
-			err := repo.Store(context.Background(), key)
+			err := repo.Store(t.Context(), key)
 			assert.NoError(t, err)
 			assert.NotZero(t, key.CreatedAt)
 			// Cleanup
-			_ = repo.Delete(context.Background(), key.Key)
+			_ = repo.Delete(t.Context(), key.Key)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_If_No_Name_Or_Scopes [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Key: "456"}
-			err := repo.Store(context.Background(), key)
+			err := repo.Store(t.Context(), key)
 			assert.Error(t, err) // Should fail when trying to insert a key without scopes (null constraint)
 			// Cleanup
-			_ = repo.Delete(context.Background(), key.Key)
+			_ = repo.Delete(t.Context(), key.Key)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_If_Duplicate_Key [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Key: "789", Scopes: []string{}}
-			err1 := repo.Store(context.Background(), key)
-			err2 := repo.Store(context.Background(), key)
+			err1 := repo.Store(t.Context(), key)
+			err2 := repo.Store(t.Context(), key)
 			assert.NoError(t, err1)
 			assert.Error(t, err2) // Should fail when trying to insert a duplicate key
 			// Cleanup
-			_ = repo.Delete(context.Background(), key.Key)
+			_ = repo.Delete(t.Context(), key.Key)
 		})
 	}
 }
 
 func TestAPIRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewAPIRepo(log, db)
 
 		t.Run(fmt.Sprintf("Delete_Succeeds_With_Existing_Key [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Name: "TestKey", Key: "123", Scopes: []string{"read", "write"}}
-			_ = repo.Store(context.Background(), key)
-			err := repo.Delete(context.Background(), key.Key)
+			_ = repo.Store(t.Context(), key)
+			err := repo.Delete(t.Context(), key.Key)
 			assert.NoError(t, err)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Succeeds_If_Key_Does_Not_Exist [%s]", dbType), func(t *testing.T) {
-			err := repo.Delete(context.Background(), "nonexistent")
+			err := repo.Delete(t.Context(), "nonexistent")
 			assert.NoError(t, err)
 		})
 	}
@@ -70,22 +71,23 @@ func TestAPIRepo_Delete(t *testing.T) {
 }
 
 func TestAPIRepo_GetAllAPIKeys(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewAPIRepo(log, db)
 
 		t.Run(fmt.Sprintf("GetKeys_Returns_Keys_If_Exists [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Name: "TestKey", Key: "123", Scopes: []string{"read", "write"}}
-			_ = repo.Store(context.Background(), key)
-			keys, err := repo.GetAllAPIKeys(context.Background())
+			_ = repo.Store(t.Context(), key)
+			keys, err := repo.GetAllAPIKeys(t.Context())
 			assert.NoError(t, err)
 			assert.Greater(t, len(keys), 0)
 			// Cleanup
-			_ = repo.Delete(context.Background(), key.Key)
+			_ = repo.Delete(t.Context(), key.Key)
 		})
 
 		t.Run(fmt.Sprintf("GetKeys_Returns_Empty_If_No_Keys [%s]", dbType), func(t *testing.T) {
-			keys, err := repo.GetAllAPIKeys(context.Background())
+			keys, err := repo.GetAllAPIKeys(t.Context())
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(keys))
 		})
@@ -93,22 +95,23 @@ func TestAPIRepo_GetAllAPIKeys(t *testing.T) {
 }
 
 func TestAPIRepo_GetKey(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewAPIRepo(log, db)
 
 		t.Run(fmt.Sprintf("GetKey_Returns_Key_If_Exists [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Name: "TestKey", Key: "123", Scopes: []string{"read", "write"}}
-			_ = repo.Store(context.Background(), key)
-			apiKey, err := repo.GetKey(context.Background(), key.Key)
+			_ = repo.Store(t.Context(), key)
+			apiKey, err := repo.GetKey(t.Context(), key.Key)
 			assert.NoError(t, err)
 			assert.NotNil(t, apiKey)
 			// Cleanup
-			_ = repo.Delete(context.Background(), key.Key)
+			_ = repo.Delete(t.Context(), key.Key)
 		})
 
 		t.Run(fmt.Sprintf("GetKeys_Returns_Empty_If_No_Keys [%s]", dbType), func(t *testing.T) {
-			key, err := repo.GetKey(context.Background(), "nonexistent")
+			key, err := repo.GetKey(t.Context(), "nonexistent")
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 			assert.Nil(t, key)
 		})

--- a/internal/database/api_test.go
+++ b/internal/database/api_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestAPIRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -22,34 +24,36 @@ func TestAPIRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Store_Succeeds_With_Valid_Key [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Name: "TestKey", Key: "123", Scopes: []string{"read", "write"}}
-			err := repo.Store(t.Context(), key)
+			err := repo.Store(ctx, key)
 			assert.NoError(t, err)
 			assert.NotZero(t, key.CreatedAt)
 			// Cleanup
-			_ = repo.Delete(t.Context(), key.Key)
+			_ = repo.Delete(ctx, key.Key)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_If_No_Name_Or_Scopes [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Key: "456"}
-			err := repo.Store(t.Context(), key)
+			err := repo.Store(ctx, key)
 			assert.Error(t, err) // Should fail when trying to insert a key without scopes (null constraint)
 			// Cleanup
-			_ = repo.Delete(t.Context(), key.Key)
+			_ = repo.Delete(ctx, key.Key)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_If_Duplicate_Key [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Key: "789", Scopes: []string{}}
-			err1 := repo.Store(t.Context(), key)
-			err2 := repo.Store(t.Context(), key)
+			err1 := repo.Store(ctx, key)
+			err2 := repo.Store(ctx, key)
 			assert.NoError(t, err1)
 			assert.Error(t, err2) // Should fail when trying to insert a duplicate key
 			// Cleanup
-			_ = repo.Delete(t.Context(), key.Key)
+			_ = repo.Delete(ctx, key.Key)
 		})
 	}
 }
 
 func TestAPIRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -57,13 +61,13 @@ func TestAPIRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds_With_Existing_Key [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Name: "TestKey", Key: "123", Scopes: []string{"read", "write"}}
-			_ = repo.Store(t.Context(), key)
-			err := repo.Delete(t.Context(), key.Key)
+			_ = repo.Store(ctx, key)
+			err := repo.Delete(ctx, key.Key)
 			assert.NoError(t, err)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Succeeds_If_Key_Does_Not_Exist [%s]", dbType), func(t *testing.T) {
-			err := repo.Delete(t.Context(), "nonexistent")
+			err := repo.Delete(ctx, "nonexistent")
 			assert.NoError(t, err)
 		})
 	}
@@ -71,6 +75,8 @@ func TestAPIRepo_Delete(t *testing.T) {
 }
 
 func TestAPIRepo_GetAllAPIKeys(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -78,16 +84,16 @@ func TestAPIRepo_GetAllAPIKeys(t *testing.T) {
 
 		t.Run(fmt.Sprintf("GetKeys_Returns_Keys_If_Exists [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Name: "TestKey", Key: "123", Scopes: []string{"read", "write"}}
-			_ = repo.Store(t.Context(), key)
-			keys, err := repo.GetAllAPIKeys(t.Context())
+			_ = repo.Store(ctx, key)
+			keys, err := repo.GetAllAPIKeys(ctx)
 			assert.NoError(t, err)
 			assert.Greater(t, len(keys), 0)
 			// Cleanup
-			_ = repo.Delete(t.Context(), key.Key)
+			_ = repo.Delete(ctx, key.Key)
 		})
 
 		t.Run(fmt.Sprintf("GetKeys_Returns_Empty_If_No_Keys [%s]", dbType), func(t *testing.T) {
-			keys, err := repo.GetAllAPIKeys(t.Context())
+			keys, err := repo.GetAllAPIKeys(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(keys))
 		})
@@ -95,6 +101,8 @@ func TestAPIRepo_GetAllAPIKeys(t *testing.T) {
 }
 
 func TestAPIRepo_GetKey(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -102,16 +110,16 @@ func TestAPIRepo_GetKey(t *testing.T) {
 
 		t.Run(fmt.Sprintf("GetKey_Returns_Key_If_Exists [%s]", dbType), func(t *testing.T) {
 			key := &domain.APIKey{Name: "TestKey", Key: "123", Scopes: []string{"read", "write"}}
-			_ = repo.Store(t.Context(), key)
-			apiKey, err := repo.GetKey(t.Context(), key.Key)
+			_ = repo.Store(ctx, key)
+			apiKey, err := repo.GetKey(ctx, key.Key)
 			assert.NoError(t, err)
 			assert.NotNil(t, apiKey)
 			// Cleanup
-			_ = repo.Delete(t.Context(), key.Key)
+			_ = repo.Delete(ctx, key.Key)
 		})
 
 		t.Run(fmt.Sprintf("GetKeys_Returns_Empty_If_No_Keys [%s]", dbType), func(t *testing.T) {
-			key, err := repo.GetKey(t.Context(), "nonexistent")
+			key, err := repo.GetKey(ctx, "nonexistent")
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 			assert.Nil(t, key)
 		})

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -6,60 +6,111 @@
 package database
 
 import (
-	"database/sql"
+	"bytes"
 	"fmt"
 	"log"
+	"net"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/logger"
 
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
 
-func getDbs() []string {
-	return []string{"sqlite", "postgres"}
+type testDB struct {
+	db      *DB
+	cleanup cleanupFunc
 }
 
-var testDBs map[string]*DB
+type cleanupFunc func()
 
-func setupPostgresForTest() *DB {
-	dbType := "postgres"
-	if d, ok := testDBs[dbType]; ok {
-		return d
+var testDBs map[string]*testDB
+
+// embeddedPGBinariesPath returns the directory the Postgres binaries are extracted to.
+// embedded-postgres wipes its runtime path on every Start, so instances get their own
+// while the binaries are extracted once here and reused. The path is package specific
+// so a cold start can never have two test binaries extracting into the same directory.
+func embeddedPGBinariesPath() string {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		cacheDir = os.TempDir()
+	}
+
+	return filepath.Join(cacheDir, "autobrr", "embedded-postgres", "v17-database")
+}
+
+// GetFreePort asks the kernel for a free open port that is ready to use.
+func GetFreePort() (port int, err error) {
+	var a *net.TCPAddr
+	if a, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
+		var l *net.TCPListener
+		if l, err = net.ListenTCP("tcp", a); err == nil {
+			defer l.Close()
+			return l.Addr().(*net.TCPAddr).Port, nil
+		}
+	}
+	return
+}
+
+// startEmbeddedPG boots an embedded Postgres on a random port and returns
+// an open *database.DB plus a cleanup that stops the server. Used so the per-migration
+// test in this file can boot Postgres once and reuse it across sub-tests.
+func startEmbeddedPG() (*DB, cleanupFunc) {
+	freePort, err := GetFreePort()
+	if err != nil {
+		log.Fatalf("Could not start embedded postgres: %q", err)
 	}
 
 	cfg := &domain.Config{
-		LogLevel:         "INFO",
-		DatabaseType:     dbType,
-		PostgresHost:     "localhost",
-		PostgresPort:     5437,
-		PostgresDatabase: "autobrr",
-		PostgresUser:     "testdb",
-		PostgresPass:     "testdb",
-		PostgresSSLMode:  "disable",
+		LogLevel:            "ERROR",
+		LogPath:             "",
+		DatabaseType:        "postgres",
+		DatabaseDSN:         "",
+		PostgresHost:        "localhost",
+		PostgresPort:        freePort,
+		PostgresDatabase:    "autobrr",
+		PostgresUser:        "testdb",
+		PostgresPass:        "testdb",
+		DatabaseAutoMigrate: false,
 	}
 
-	// Init a new logger
-	dbLogger := logger.New(cfg, nil)
+	cfg.DatabaseDSN = fmt.Sprintf("postgres://%s:%s@localhost:%d/%s?sslmode=disable", cfg.PostgresUser, cfg.PostgresPass, cfg.PostgresPort, cfg.PostgresDatabase)
 
-	dbLogger.With().Str("type", "postgres").Logger()
+	runtimePath, err := os.MkdirTemp("", "autobrr-pg-runtime-")
+	if err != nil {
+		log.Fatalf("Could not create embedded postgres runtime dir: %q", err)
+	}
 
-	// Initialize a new DB connection
-	db, err := NewDB(cfg, dbLogger)
+	pgLogger := &bytes.Buffer{}
+	pg := embeddedpostgres.NewDatabase(embeddedpostgres.DefaultConfig().
+		Username(cfg.PostgresUser).
+		Password(cfg.PostgresPass).
+		Database(cfg.PostgresDatabase).
+		Port(uint32(cfg.PostgresPort)).
+		Version(embeddedpostgres.V17).
+		BinariesPath(embeddedPGBinariesPath()).
+		RuntimePath(runtimePath).
+		StartTimeout(45 * time.Second).
+		StartParameters(map[string]string{"max_connections": "200"}).
+		Logger(pgLogger))
+	if err := pg.Start(); err != nil {
+		log.Fatalf("Could not start embedded postgres database: %q", err)
+	}
+
+	l := logger.New(cfg, nil)
+	db, err := NewDB(cfg, l)
 	if err != nil {
 		log.Fatalf("Could not create database: %q", err)
 	}
 
-	// Open the database connection
-	if db.Handler, err = sql.Open("postgres", db.DSN); err != nil {
-		log.Fatalf("could not open postgres connection: %q", err)
-	}
-
-	if err = db.Handler.Ping(); err != nil {
-		log.Fatalf("could not ping postgres database: %q", err)
+	if err := db.Open(); err != nil {
+		log.Fatalf("Could not open database: %q", err)
 	}
 
 	// drop tables before migrate to always have a clean state
@@ -79,21 +130,28 @@ GRANT ALL ON SCHEMA public TO public;
 		log.Fatalf("Could not migrate postgres database: %q", err)
 	}
 
-	testDBs[dbType] = db
-
-	return db
-}
-
-func setupSqliteForTest() *DB {
-	dbType := "sqlite"
-
-	if d, ok := testDBs[dbType]; ok {
-		return d
+	cleanup := func() {
+		_ = db.Close()
+		if err := pg.Stop(); err != nil {
+			log.Printf("failed to stop embedded postgres: %v\npg log:\n%s", err, pgLogger.String())
+		}
+		_ = os.RemoveAll(runtimePath)
 	}
 
+	testDBInstance := &testDB{
+		db:      db,
+		cleanup: cleanup,
+	}
+
+	testDBs[cfg.DatabaseType] = testDBInstance
+
+	return db, cleanup
+}
+
+func setupSqliteForTest() (*DB, cleanupFunc) {
 	cfg := &domain.Config{
 		LogLevel:     "ERROR",
-		DatabaseType: dbType,
+		DatabaseType: "sqlite",
 		DatabaseDSN:  ":memory:",
 	}
 
@@ -116,9 +174,18 @@ func setupSqliteForTest() *DB {
 		log.Fatalf("Could not migrate postgres database: %q", err)
 	}
 
-	testDBs[dbType] = db
+	cleanup := func() {
+		_ = db.Close()
+	}
 
-	return db
+	testDBInstance := &testDB{
+		db:      db,
+		cleanup: cleanup,
+	}
+
+	testDBs[cfg.DatabaseType] = testDBInstance
+
+	return db, cleanup
 }
 
 func setupLoggerForTest() zerolog.Logger {
@@ -127,12 +194,12 @@ func setupLoggerForTest() zerolog.Logger {
 
 func TestPingDatabase(t *testing.T) {
 	// Setup database
-	for _, db := range testDBs {
-
-		// Call the Ping method
-		err := db.Ping()
-
-		assert.NoError(t, err, "Database should be reachable")
+	for dbType, testDb := range testDBs {
+		db := testDb.db
+		t.Run(fmt.Sprintf("Test_db_ping [%s]", dbType), func(t *testing.T) {
+			err := db.Ping()
+			assert.NoError(t, err, "Database should be reachable")
+		})
 	}
 }
 
@@ -141,11 +208,11 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not set env variable: %v", err)
 	}
 
-	testDBs = make(map[string]*DB)
+	testDBs = make(map[string]*testDB)
 
 	fmt.Println("setup")
 
-	setupPostgresForTest()
+	startEmbeddedPG()
 	setupSqliteForTest()
 
 	fmt.Println("running tests")
@@ -154,11 +221,8 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	fmt.Println("teardown")
-
 	for _, d := range testDBs {
-		if err := d.Close(); err != nil {
-			log.Fatalf("Could not close db connection: %v", err)
-		}
+		d.cleanup()
 	}
 
 	if err := os.Setenv("IS_TEST_ENV", "false"); err != nil {

--- a/internal/database/download_client_test.go
+++ b/internal/database/download_client_test.go
@@ -73,7 +73,8 @@ func getMockArrList(filterID int, clientID int32) *domain.List {
 }
 
 func TestDownloadClientRepo_List(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewDownloadClientRepo(log, db)
 		mockData := getMockDownloadClient()
@@ -81,23 +82,23 @@ func TestDownloadClientRepo_List(t *testing.T) {
 		t.Run(fmt.Sprintf("List_Succeeds_With_No_Filters [%s]", dbType), func(t *testing.T) {
 			// Insert mock data
 			mock := &mockData
-			err := repo.Store(context.Background(), mock)
-			clients, err := repo.List(context.Background())
+			err := repo.Store(t.Context(), mock)
+			clients, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.NotEmpty(t, clients)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Empty_Database [%s]", dbType), func(t *testing.T) {
-			clients, err := repo.List(context.Background())
+			clients, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.Empty(t, clients)
 		})
 
 		t.Run(fmt.Sprintf("List_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 			_, err := repo.List(ctx)
 			assert.Error(t, err)
@@ -105,86 +106,87 @@ func TestDownloadClientRepo_List(t *testing.T) {
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Data_Integrity [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			err := repo.Store(context.Background(), mock)
-			clients, err := repo.List(context.Background())
+			err := repo.Store(t.Context(), mock)
+			clients, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(clients))
 			assert.Equal(t, mock.Name, clients[0].Name)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Boundary_Value_For_Port [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
 			mock.Port = 65535
-			err := repo.Store(context.Background(), mock)
-			clients, err := repo.List(context.Background())
+			err := repo.Store(t.Context(), mock)
+			clients, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.Equal(t, 65535, clients[0].Port)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Boolean_Flags_Set_To_False [%s]", dbType), func(t *testing.T) {
 			mockData.Enabled = false
 			mockData.TLS = false
 			mockData.TLSSkipVerify = false
-			err := repo.Store(context.Background(), &mockData)
-			clients, err := repo.List(context.Background())
+			err := repo.Store(t.Context(), &mockData)
+			clients, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.Equal(t, false, clients[0].Enabled)
 			assert.Equal(t, false, clients[0].TLS)
 			assert.Equal(t, false, clients[0].TLSSkipVerify)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
+			_ = repo.Delete(t.Context(), mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Special_Characters_In_Name [%s]", dbType), func(t *testing.T) {
 			mockData.Name = "Special$Name"
-			err := repo.Store(context.Background(), &mockData)
-			clients, err := repo.List(context.Background())
+			err := repo.Store(t.Context(), &mockData)
+			clients, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.Equal(t, "Special$Name", clients[0].Name)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
+			_ = repo.Delete(t.Context(), mockData.ID)
 		})
 	}
 }
 
 func TestDownloadClientRepo_FindByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewDownloadClientRepo(log, db)
 		mockData := getMockDownloadClient()
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			_ = repo.Store(context.Background(), mock)
-			foundClient, err := repo.FindByID(context.Background(), mock.ID)
+			_ = repo.Store(t.Context(), mock)
+			foundClient, err := repo.FindByID(t.Context(), mock.ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, foundClient)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_With_Nonexistent_ID [%s]", dbType), func(t *testing.T) {
-			_, err := repo.FindByID(context.Background(), 9999)
+			_, err := repo.FindByID(t.Context(), 9999)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_With_Negative_ID [%s]", dbType), func(t *testing.T) {
-			_, err := repo.FindByID(context.Background(), -1)
+			_, err := repo.FindByID(t.Context(), -1)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
 			_, err := repo.FindByID(ctx, 1)
@@ -193,54 +195,55 @@ func TestDownloadClientRepo_FindByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByID_Fails_After_Client_Deleted [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			_ = repo.Store(context.Background(), mock)
-			_ = repo.Delete(context.Background(), mock.ID)
-			_, err := repo.FindByID(context.Background(), mock.ID)
+			_ = repo.Store(t.Context(), mock)
+			_ = repo.Delete(t.Context(), mock.ID)
+			_, err := repo.FindByID(t.Context(), mock.ID)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds_With_Data_Integrity [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			_ = repo.Store(context.Background(), mock)
-			foundClient, err := repo.FindByID(context.Background(), mock.ID)
+			_ = repo.Store(t.Context(), mock)
+			foundClient, err := repo.FindByID(t.Context(), mock.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, mock.Name, foundClient.Name)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds_From_Cache [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			_ = repo.Store(context.Background(), mock)
-			foundClient1, _ := repo.FindByID(context.Background(), mock.ID)
-			foundClient2, err := repo.FindByID(context.Background(), mock.ID)
+			_ = repo.Store(t.Context(), mock)
+			foundClient1, _ := repo.FindByID(t.Context(), mock.ID)
+			foundClient2, err := repo.FindByID(t.Context(), mock.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, foundClient1, foundClient2)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestDownloadClientRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewDownloadClientRepo(log, db)
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			mockData := getMockDownloadClient()
-			err := repo.Store(context.Background(), &mockData)
+			err := repo.Store(t.Context(), &mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockData)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
+			_ = repo.Delete(t.Context(), mockData.ID)
 		})
 
 		//TODO: Is this okay? Should we be able to store a client with no name (empty string)?
@@ -256,16 +259,16 @@ func TestDownloadClientRepo_Store(t *testing.T) {
 				Password:      "",
 				Settings:      domain.DownloadClientSettings{},
 			}
-			err := repo.Store(context.Background(), badMockData)
+			err := repo.Store(t.Context(), badMockData)
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), badMockData.ID)
+			_ = repo.Delete(t.Context(), badMockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
 			mockData := getMockDownloadClient()
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 			err := repo.Store(ctx, &mockData)
 			assert.Error(t, err)
@@ -273,41 +276,42 @@ func TestDownloadClientRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Store_Succeeds_And_Caches [%s]", dbType), func(t *testing.T) {
 			mockData := getMockDownloadClient()
-			_ = repo.Store(context.Background(), &mockData)
+			_ = repo.Store(t.Context(), &mockData)
 
-			cachedClient, _ := repo.FindByID(context.Background(), mockData.ID)
+			cachedClient, _ := repo.FindByID(t.Context(), mockData.ID)
 			assert.Equal(t, &mockData, cachedClient)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
+			_ = repo.Delete(t.Context(), mockData.ID)
 		})
 	}
 }
 
 func TestDownloadClientRepo_Update(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewDownloadClientRepo(log, db)
 
 		t.Run(fmt.Sprintf("Update_Successfully_Updates_Record [%s]", dbType), func(t *testing.T) {
 			mockClient := getMockDownloadClient()
 
-			_ = repo.Store(context.Background(), &mockClient)
+			_ = repo.Store(t.Context(), &mockClient)
 			mockClient.Name = "updatedName"
-			err := repo.Update(context.Background(), &mockClient)
+			err := repo.Update(t.Context(), &mockClient)
 
 			assert.NoError(t, err)
 			assert.Equal(t, "updatedName", mockClient.Name)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockClient.ID)
+			_ = repo.Delete(t.Context(), mockClient.ID)
 		})
 
 		t.Run(fmt.Sprintf("Update_Fails_With_Missing_ID [%s]", dbType), func(t *testing.T) {
 			badMockData := getMockDownloadClient()
 			badMockData.ID = 0
 
-			err := repo.Update(context.Background(), &badMockData)
+			err := repo.Update(t.Context(), &badMockData)
 
 			assert.Error(t, err)
 
@@ -317,7 +321,7 @@ func TestDownloadClientRepo_Update(t *testing.T) {
 			badMockData := getMockDownloadClient()
 			badMockData.ID = 9999
 
-			err := repo.Update(context.Background(), &badMockData)
+			err := repo.Update(t.Context(), &badMockData)
 
 			assert.Error(t, err)
 		})
@@ -325,7 +329,7 @@ func TestDownloadClientRepo_Update(t *testing.T) {
 		t.Run(fmt.Sprintf("Update_Fails_With_Missing_Required_Fields [%s]", dbType), func(t *testing.T) {
 			badMockData := domain.DownloadClient{}
 
-			err := repo.Update(context.Background(), &badMockData)
+			err := repo.Update(t.Context(), &badMockData)
 
 			assert.Error(t, err)
 		})
@@ -333,39 +337,40 @@ func TestDownloadClientRepo_Update(t *testing.T) {
 }
 
 func TestDownloadClientRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewDownloadClientRepo(log, db)
 
 		t.Run(fmt.Sprintf("Delete_Successfully_Deletes_Client [%s]", dbType), func(t *testing.T) {
 			mockClient := getMockDownloadClient()
-			_ = repo.Store(context.Background(), &mockClient)
+			_ = repo.Store(t.Context(), &mockClient)
 
-			err := repo.Delete(context.Background(), mockClient.ID)
+			err := repo.Delete(t.Context(), mockClient.ID)
 			assert.NoError(t, err)
 
 			// Verify client was deleted
-			_, err = repo.FindByID(context.Background(), mockClient.ID)
+			_, err = repo.FindByID(t.Context(), mockClient.ID)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_With_Nonexistent_Client_ID [%s]", dbType), func(t *testing.T) {
-			err := repo.Delete(context.Background(), 9999)
+			err := repo.Delete(t.Context(), 9999)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
 			mockClient := getMockDownloadClient()
-			_ = repo.Store(context.Background(), &mockClient)
+			_ = repo.Store(t.Context(), &mockClient)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
 			err := repo.Delete(ctx, mockClient.ID)
 			assert.Error(t, err)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockClient.ID)
+			_ = repo.Delete(t.Context(), mockClient.ID)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Clears_Client_From_Actions [%s]", dbType), func(t *testing.T) {
@@ -373,11 +378,11 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 			filterRepo := NewFilterRepo(log, db)
 
 			mockClient := getMockDownloadClient()
-			err := repo.Store(context.Background(), &mockClient)
+			err := repo.Store(t.Context(), &mockClient)
 			assert.NoError(t, err)
 
 			filter := getMockFilter()
-			err = filterRepo.Store(context.Background(), filter)
+			err = filterRepo.Store(t.Context(), filter)
 			assert.NoError(t, err)
 
 			actionWithoutFilter := getMockAction()
@@ -385,7 +390,7 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 			actionWithoutFilter.FilterID = 0
 			actionWithoutFilter.Name = "action-without-filter"
 
-			err = actionRepo.Store(context.Background(), actionWithoutFilter)
+			err = actionRepo.Store(t.Context(), actionWithoutFilter)
 			assert.NoError(t, err)
 
 			actionWithFilter := getMockAction()
@@ -393,31 +398,31 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 			actionWithFilter.FilterID = filter.ID
 			actionWithFilter.Name = "action-with-filter"
 
-			err = actionRepo.Store(context.Background(), actionWithFilter)
+			err = actionRepo.Store(t.Context(), actionWithFilter)
 			assert.NoError(t, err)
 
-			err = repo.Delete(context.Background(), mockClient.ID)
+			err = repo.Delete(t.Context(), mockClient.ID)
 			assert.NoError(t, err)
 
-			updatedActionWithoutFilter, err := actionRepo.Get(context.Background(), &domain.GetActionRequest{Id: actionWithoutFilter.ID})
+			updatedActionWithoutFilter, err := actionRepo.Get(t.Context(), &domain.GetActionRequest{Id: actionWithoutFilter.ID})
 			assert.NoError(t, err)
 			assert.False(t, updatedActionWithoutFilter.Enabled)
 			assert.Zero(t, updatedActionWithoutFilter.ClientID)
 			assert.Zero(t, updatedActionWithoutFilter.FilterID)
 
-			updatedActionWithFilter, err := actionRepo.Get(context.Background(), &domain.GetActionRequest{Id: actionWithFilter.ID})
+			updatedActionWithFilter, err := actionRepo.Get(t.Context(), &domain.GetActionRequest{Id: actionWithFilter.ID})
 			assert.NoError(t, err)
 			assert.False(t, updatedActionWithFilter.Enabled)
 			assert.Zero(t, updatedActionWithFilter.ClientID)
 			assert.Equal(t, filter.ID, updatedActionWithFilter.FilterID)
 
-			_, err = repo.FindByID(context.Background(), mockClient.ID)
+			_, err = repo.FindByID(t.Context(), mockClient.ID)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionWithoutFilter.ID})
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionWithFilter.ID})
-			_ = filterRepo.Delete(context.Background(), filter.ID)
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionWithoutFilter.ID})
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionWithFilter.ID})
+			_ = filterRepo.Delete(t.Context(), filter.ID)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Clears_Client_From_Lists [%s]", dbType), func(t *testing.T) {
@@ -425,21 +430,21 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 			listRepo := NewListRepo(log, db)
 
 			mockClient := getMockDownloadClient()
-			err := repo.Store(context.Background(), &mockClient)
+			err := repo.Store(t.Context(), &mockClient)
 			assert.NoError(t, err)
 
 			filter := getMockFilter()
-			err = filterRepo.Store(context.Background(), filter)
+			err = filterRepo.Store(t.Context(), filter)
 			assert.NoError(t, err)
 
 			list := getMockArrList(filter.ID, mockClient.ID)
-			err = listRepo.Store(context.Background(), list)
+			err = listRepo.Store(t.Context(), list)
 			assert.NoError(t, err)
 
-			err = repo.Delete(context.Background(), mockClient.ID)
+			err = repo.Delete(t.Context(), mockClient.ID)
 			assert.NoError(t, err)
 
-			lists, err := listRepo.List(context.Background())
+			lists, err := listRepo.List(t.Context())
 			assert.NoError(t, err)
 
 			var updatedList *domain.List
@@ -455,12 +460,12 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 				assert.Zero(t, updatedList.ClientID)
 			}
 
-			_, err = repo.FindByID(context.Background(), mockClient.ID)
+			_, err = repo.FindByID(t.Context(), mockClient.ID)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 
-			_ = listRepo.Delete(context.Background(), list.ID)
-			_ = filterRepo.Delete(context.Background(), filter.ID)
+			_ = listRepo.Delete(t.Context(), list.ID)
+			_ = filterRepo.Delete(t.Context(), filter.ID)
 		})
 	}
 }

--- a/internal/database/download_client_test.go
+++ b/internal/database/download_client_test.go
@@ -73,6 +73,8 @@ func getMockArrList(filterID int, clientID int32) *domain.List {
 }
 
 func TestDownloadClientRepo_List(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -82,81 +84,83 @@ func TestDownloadClientRepo_List(t *testing.T) {
 		t.Run(fmt.Sprintf("List_Succeeds_With_No_Filters [%s]", dbType), func(t *testing.T) {
 			// Insert mock data
 			mock := &mockData
-			err := repo.Store(t.Context(), mock)
-			clients, err := repo.List(t.Context())
+			err := repo.Store(ctx, mock)
+			clients, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.NotEmpty(t, clients)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Empty_Database [%s]", dbType), func(t *testing.T) {
-			clients, err := repo.List(t.Context())
+			clients, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.Empty(t, clients)
 		})
 
 		t.Run(fmt.Sprintf("List_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
-			_, err := repo.List(ctx)
+			_, err := repo.List(timeoutCtx)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Data_Integrity [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			err := repo.Store(t.Context(), mock)
-			clients, err := repo.List(t.Context())
+			err := repo.Store(ctx, mock)
+			clients, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(clients))
 			assert.Equal(t, mock.Name, clients[0].Name)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Boundary_Value_For_Port [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
 			mock.Port = 65535
-			err := repo.Store(t.Context(), mock)
-			clients, err := repo.List(t.Context())
+			err := repo.Store(ctx, mock)
+			clients, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, 65535, clients[0].Port)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Boolean_Flags_Set_To_False [%s]", dbType), func(t *testing.T) {
 			mockData.Enabled = false
 			mockData.TLS = false
 			mockData.TLSSkipVerify = false
-			err := repo.Store(t.Context(), &mockData)
-			clients, err := repo.List(t.Context())
+			err := repo.Store(ctx, &mockData)
+			clients, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, false, clients[0].Enabled)
 			assert.Equal(t, false, clients[0].TLS)
 			assert.Equal(t, false, clients[0].TLSSkipVerify)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Succeeds_With_Special_Characters_In_Name [%s]", dbType), func(t *testing.T) {
 			mockData.Name = "Special$Name"
-			err := repo.Store(t.Context(), &mockData)
-			clients, err := repo.List(t.Context())
+			err := repo.Store(ctx, &mockData)
+			clients, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, "Special$Name", clients[0].Name)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 	}
 }
 
 func TestDownloadClientRepo_FindByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -165,72 +169,74 @@ func TestDownloadClientRepo_FindByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			_ = repo.Store(t.Context(), mock)
-			foundClient, err := repo.FindByID(t.Context(), mock.ID)
+			_ = repo.Store(ctx, mock)
+			foundClient, err := repo.FindByID(ctx, mock.ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, foundClient)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_With_Nonexistent_ID [%s]", dbType), func(t *testing.T) {
-			_, err := repo.FindByID(t.Context(), 9999)
+			_, err := repo.FindByID(ctx, 9999)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_With_Negative_ID [%s]", dbType), func(t *testing.T) {
-			_, err := repo.FindByID(t.Context(), -1)
+			_, err := repo.FindByID(ctx, -1)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			_, err := repo.FindByID(ctx, 1)
+			_, err := repo.FindByID(timeoutCtx, 1)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_After_Client_Deleted [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			_ = repo.Store(t.Context(), mock)
-			_ = repo.Delete(t.Context(), mock.ID)
-			_, err := repo.FindByID(t.Context(), mock.ID)
+			_ = repo.Store(ctx, mock)
+			_ = repo.Delete(ctx, mock.ID)
+			_, err := repo.FindByID(ctx, mock.ID)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds_With_Data_Integrity [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			_ = repo.Store(t.Context(), mock)
-			foundClient, err := repo.FindByID(t.Context(), mock.ID)
+			_ = repo.Store(ctx, mock)
+			foundClient, err := repo.FindByID(ctx, mock.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, mock.Name, foundClient.Name)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, mock.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds_From_Cache [%s]", dbType), func(t *testing.T) {
 			mock := &mockData
-			_ = repo.Store(t.Context(), mock)
-			foundClient1, _ := repo.FindByID(t.Context(), mock.ID)
-			foundClient2, err := repo.FindByID(t.Context(), mock.ID)
+			_ = repo.Store(ctx, mock)
+			foundClient1, _ := repo.FindByID(ctx, mock.ID)
+			foundClient2, err := repo.FindByID(ctx, mock.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, foundClient1, foundClient2)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestDownloadClientRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -238,12 +244,12 @@ func TestDownloadClientRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			mockData := getMockDownloadClient()
-			err := repo.Store(t.Context(), &mockData)
+			err := repo.Store(ctx, &mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockData)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		//TODO: Is this okay? Should we be able to store a client with no name (empty string)?
@@ -259,35 +265,37 @@ func TestDownloadClientRepo_Store(t *testing.T) {
 				Password:      "",
 				Settings:      domain.DownloadClientSettings{},
 			}
-			err := repo.Store(t.Context(), badMockData)
+			err := repo.Store(ctx, badMockData)
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), badMockData.ID)
+			_ = repo.Delete(ctx, badMockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
 			mockData := getMockDownloadClient()
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
-			err := repo.Store(ctx, &mockData)
+			err := repo.Store(timeoutCtx, &mockData)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("Store_Succeeds_And_Caches [%s]", dbType), func(t *testing.T) {
 			mockData := getMockDownloadClient()
-			_ = repo.Store(t.Context(), &mockData)
+			_ = repo.Store(ctx, &mockData)
 
-			cachedClient, _ := repo.FindByID(t.Context(), mockData.ID)
+			cachedClient, _ := repo.FindByID(ctx, mockData.ID)
 			assert.Equal(t, &mockData, cachedClient)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 	}
 }
 
 func TestDownloadClientRepo_Update(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -296,22 +304,22 @@ func TestDownloadClientRepo_Update(t *testing.T) {
 		t.Run(fmt.Sprintf("Update_Successfully_Updates_Record [%s]", dbType), func(t *testing.T) {
 			mockClient := getMockDownloadClient()
 
-			_ = repo.Store(t.Context(), &mockClient)
+			_ = repo.Store(ctx, &mockClient)
 			mockClient.Name = "updatedName"
-			err := repo.Update(t.Context(), &mockClient)
+			err := repo.Update(ctx, &mockClient)
 
 			assert.NoError(t, err)
 			assert.Equal(t, "updatedName", mockClient.Name)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockClient.ID)
+			_ = repo.Delete(ctx, mockClient.ID)
 		})
 
 		t.Run(fmt.Sprintf("Update_Fails_With_Missing_ID [%s]", dbType), func(t *testing.T) {
 			badMockData := getMockDownloadClient()
 			badMockData.ID = 0
 
-			err := repo.Update(t.Context(), &badMockData)
+			err := repo.Update(ctx, &badMockData)
 
 			assert.Error(t, err)
 
@@ -321,7 +329,7 @@ func TestDownloadClientRepo_Update(t *testing.T) {
 			badMockData := getMockDownloadClient()
 			badMockData.ID = 9999
 
-			err := repo.Update(t.Context(), &badMockData)
+			err := repo.Update(ctx, &badMockData)
 
 			assert.Error(t, err)
 		})
@@ -329,7 +337,7 @@ func TestDownloadClientRepo_Update(t *testing.T) {
 		t.Run(fmt.Sprintf("Update_Fails_With_Missing_Required_Fields [%s]", dbType), func(t *testing.T) {
 			badMockData := domain.DownloadClient{}
 
-			err := repo.Update(t.Context(), &badMockData)
+			err := repo.Update(ctx, &badMockData)
 
 			assert.Error(t, err)
 		})
@@ -337,6 +345,8 @@ func TestDownloadClientRepo_Update(t *testing.T) {
 }
 
 func TestDownloadClientRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -344,33 +354,33 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Successfully_Deletes_Client [%s]", dbType), func(t *testing.T) {
 			mockClient := getMockDownloadClient()
-			_ = repo.Store(t.Context(), &mockClient)
+			_ = repo.Store(ctx, &mockClient)
 
-			err := repo.Delete(t.Context(), mockClient.ID)
+			err := repo.Delete(ctx, mockClient.ID)
 			assert.NoError(t, err)
 
 			// Verify client was deleted
-			_, err = repo.FindByID(t.Context(), mockClient.ID)
+			_, err = repo.FindByID(ctx, mockClient.ID)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_With_Nonexistent_Client_ID [%s]", dbType), func(t *testing.T) {
-			err := repo.Delete(t.Context(), 9999)
+			err := repo.Delete(ctx, 9999)
 			assert.Error(t, err)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
 			mockClient := getMockDownloadClient()
-			_ = repo.Store(t.Context(), &mockClient)
+			_ = repo.Store(ctx, &mockClient)
 
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			err := repo.Delete(ctx, mockClient.ID)
+			err := repo.Delete(timeoutCtx, mockClient.ID)
 			assert.Error(t, err)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockClient.ID)
+			_ = repo.Delete(ctx, mockClient.ID)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Clears_Client_From_Actions [%s]", dbType), func(t *testing.T) {
@@ -378,11 +388,11 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 			filterRepo := NewFilterRepo(log, db)
 
 			mockClient := getMockDownloadClient()
-			err := repo.Store(t.Context(), &mockClient)
+			err := repo.Store(ctx, &mockClient)
 			assert.NoError(t, err)
 
 			filter := getMockFilter()
-			err = filterRepo.Store(t.Context(), filter)
+			err = filterRepo.Store(ctx, filter)
 			assert.NoError(t, err)
 
 			actionWithoutFilter := getMockAction()
@@ -390,7 +400,7 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 			actionWithoutFilter.FilterID = 0
 			actionWithoutFilter.Name = "action-without-filter"
 
-			err = actionRepo.Store(t.Context(), actionWithoutFilter)
+			err = actionRepo.Store(ctx, actionWithoutFilter)
 			assert.NoError(t, err)
 
 			actionWithFilter := getMockAction()
@@ -398,31 +408,31 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 			actionWithFilter.FilterID = filter.ID
 			actionWithFilter.Name = "action-with-filter"
 
-			err = actionRepo.Store(t.Context(), actionWithFilter)
+			err = actionRepo.Store(ctx, actionWithFilter)
 			assert.NoError(t, err)
 
-			err = repo.Delete(t.Context(), mockClient.ID)
+			err = repo.Delete(ctx, mockClient.ID)
 			assert.NoError(t, err)
 
-			updatedActionWithoutFilter, err := actionRepo.Get(t.Context(), &domain.GetActionRequest{Id: actionWithoutFilter.ID})
+			updatedActionWithoutFilter, err := actionRepo.Get(ctx, &domain.GetActionRequest{Id: actionWithoutFilter.ID})
 			assert.NoError(t, err)
 			assert.False(t, updatedActionWithoutFilter.Enabled)
 			assert.Zero(t, updatedActionWithoutFilter.ClientID)
 			assert.Zero(t, updatedActionWithoutFilter.FilterID)
 
-			updatedActionWithFilter, err := actionRepo.Get(t.Context(), &domain.GetActionRequest{Id: actionWithFilter.ID})
+			updatedActionWithFilter, err := actionRepo.Get(ctx, &domain.GetActionRequest{Id: actionWithFilter.ID})
 			assert.NoError(t, err)
 			assert.False(t, updatedActionWithFilter.Enabled)
 			assert.Zero(t, updatedActionWithFilter.ClientID)
 			assert.Equal(t, filter.ID, updatedActionWithFilter.FilterID)
 
-			_, err = repo.FindByID(t.Context(), mockClient.ID)
+			_, err = repo.FindByID(ctx, mockClient.ID)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionWithoutFilter.ID})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionWithFilter.ID})
-			_ = filterRepo.Delete(t.Context(), filter.ID)
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionWithoutFilter.ID})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionWithFilter.ID})
+			_ = filterRepo.Delete(ctx, filter.ID)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Clears_Client_From_Lists [%s]", dbType), func(t *testing.T) {
@@ -430,21 +440,21 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 			listRepo := NewListRepo(log, db)
 
 			mockClient := getMockDownloadClient()
-			err := repo.Store(t.Context(), &mockClient)
+			err := repo.Store(ctx, &mockClient)
 			assert.NoError(t, err)
 
 			filter := getMockFilter()
-			err = filterRepo.Store(t.Context(), filter)
+			err = filterRepo.Store(ctx, filter)
 			assert.NoError(t, err)
 
 			list := getMockArrList(filter.ID, mockClient.ID)
-			err = listRepo.Store(t.Context(), list)
+			err = listRepo.Store(ctx, list)
 			assert.NoError(t, err)
 
-			err = repo.Delete(t.Context(), mockClient.ID)
+			err = repo.Delete(ctx, mockClient.ID)
 			assert.NoError(t, err)
 
-			lists, err := listRepo.List(t.Context())
+			lists, err := listRepo.List(ctx)
 			assert.NoError(t, err)
 
 			var updatedList *domain.List
@@ -460,12 +470,12 @@ func TestDownloadClientRepo_Delete(t *testing.T) {
 				assert.Zero(t, updatedList.ClientID)
 			}
 
-			_, err = repo.FindByID(t.Context(), mockClient.ID)
+			_, err = repo.FindByID(ctx, mockClient.ID)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 
-			_ = listRepo.Delete(t.Context(), list.ID)
-			_ = filterRepo.Delete(t.Context(), filter.ID)
+			_ = listRepo.Delete(ctx, list.ID)
+			_ = filterRepo.Delete(ctx, filter.ID)
 		})
 	}
 }

--- a/internal/database/feed_cache_test.go
+++ b/internal/database/feed_cache_test.go
@@ -6,7 +6,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -17,7 +16,8 @@ import (
 )
 
 func TestFeedCacheRepo_Get(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 
 		log := setupLoggerForTest()
 		repo := NewFeedCacheRepo(log, db)
@@ -28,11 +28,11 @@ func TestFeedCacheRepo_Get(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Get_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(context.Background(), mockData)
+			err = feedRepo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
@@ -44,9 +44,9 @@ func TestFeedCacheRepo_Get(t *testing.T) {
 			assert.Equal(t, []byte("test_value"), value)
 
 			// Cleanup
-			_ = feedRepo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
-			_ = repo.Delete(context.Background(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("Get_Fails_NoRows [%s]", dbType), func(t *testing.T) {
@@ -70,7 +70,8 @@ func TestFeedCacheRepo_Get(t *testing.T) {
 }
 
 func TestFeedCacheRepo_GetByFeed(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 
 		log := setupLoggerForTest()
 		repo := NewFeedCacheRepo(log, db)
@@ -81,32 +82,32 @@ func TestFeedCacheRepo_GetByFeed(t *testing.T) {
 
 		t.Run(fmt.Sprintf("GetByFeed_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(context.Background(), mockData)
+			err = feedRepo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
 			assert.NoError(t, err)
 
 			// Execute
-			items, err := repo.GetByFeed(context.Background(), mockData.ID)
+			items, err := repo.GetByFeed(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 			assert.Len(t, items, 1)
 			assert.Equal(t, "test_key", items[0].Key)
 			assert.Equal(t, []byte("test_value"), items[0].Value)
 
 			// Cleanup
-			_ = feedRepo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
-			_ = repo.Delete(context.Background(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("GetByFeed_Empty [%s]", dbType), func(t *testing.T) {
 			// Execute
-			items, err := repo.GetByFeed(context.Background(), -1)
+			items, err := repo.GetByFeed(t.Context(), -1)
 			assert.NoError(t, err)
 			assert.Empty(t, items)
 		})
@@ -114,7 +115,8 @@ func TestFeedCacheRepo_GetByFeed(t *testing.T) {
 }
 
 func TestFeedCacheRepo_Exists(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 
 		log := setupLoggerForTest()
 		repo := NewFeedCacheRepo(log, db)
@@ -125,11 +127,11 @@ func TestFeedCacheRepo_Exists(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Exists_True [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(context.Background(), mockData)
+			err = feedRepo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
@@ -141,9 +143,9 @@ func TestFeedCacheRepo_Exists(t *testing.T) {
 			assert.True(t, exists)
 
 			// Cleanup
-			_ = feedRepo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
-			_ = repo.Delete(context.Background(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("Exists_False [%s]", dbType), func(t *testing.T) {
@@ -156,7 +158,8 @@ func TestFeedCacheRepo_Exists(t *testing.T) {
 }
 
 func TestFeedCacheRepo_ExistingItems(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 
 		log := setupLoggerForTest()
 		repo := NewFeedCacheRepo(log, db)
@@ -257,7 +260,8 @@ func TestFeedCacheRepo_ExistingItems(t *testing.T) {
 }
 
 func TestFeedCacheRepo_Put(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedCacheRepo(log, db)
 		feedRepo := NewFeedRepo(log, db)
@@ -267,11 +271,11 @@ func TestFeedCacheRepo_Put(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Put_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(context.Background(), mockData)
+			err = feedRepo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Execute
@@ -284,9 +288,9 @@ func TestFeedCacheRepo_Put(t *testing.T) {
 			assert.Equal(t, []byte("test_value"), value)
 
 			// Cleanup
-			_ = feedRepo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
-			_ = repo.Delete(context.Background(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("Put_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
@@ -300,7 +304,8 @@ func TestFeedCacheRepo_Put(t *testing.T) {
 }
 
 func TestFeedCacheRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 
 		log := setupLoggerForTest()
 		repo := NewFeedCacheRepo(log, db)
@@ -311,18 +316,18 @@ func TestFeedCacheRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(context.Background(), mockData)
+			err = feedRepo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.Delete(context.Background(), mockData.ID, "test_key")
+			err = repo.Delete(t.Context(), mockData.ID, "test_key")
 			assert.NoError(t, err)
 
 			// Verify
@@ -331,13 +336,13 @@ func TestFeedCacheRepo_Delete(t *testing.T) {
 			assert.False(t, exists)
 
 			// Cleanup
-			_ = feedRepo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = feedRepo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_NoRecord [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Delete(context.Background(), -1, "nonexistent_key")
+			err := repo.Delete(t.Context(), -1, "nonexistent_key")
 
 			// Verify
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
@@ -346,7 +351,8 @@ func TestFeedCacheRepo_Delete(t *testing.T) {
 }
 
 func TestFeedCacheRepo_DeleteByFeed(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedCacheRepo(log, db)
 		feedRepo := NewFeedRepo(log, db)
@@ -356,18 +362,18 @@ func TestFeedCacheRepo_DeleteByFeed(t *testing.T) {
 
 		t.Run(fmt.Sprintf("DeleteByFeed_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(context.Background(), mockData)
+			err = feedRepo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.DeleteByFeed(context.Background(), mockData.ID)
+			err = repo.DeleteByFeed(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
@@ -376,13 +382,13 @@ func TestFeedCacheRepo_DeleteByFeed(t *testing.T) {
 			assert.False(t, exists)
 
 			// Cleanup
-			_ = feedRepo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = feedRepo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("DeleteByFeed_Fails_NoRecords [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.DeleteByFeed(context.Background(), -1)
+			err := repo.DeleteByFeed(t.Context(), -1)
 
 			// Verify
 			assert.NoError(t, err)
@@ -391,7 +397,8 @@ func TestFeedCacheRepo_DeleteByFeed(t *testing.T) {
 }
 
 func TestFeedCacheRepo_DeleteStale(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 
 		log := setupLoggerForTest()
 		repo := NewFeedCacheRepo(log, db)
@@ -402,11 +409,11 @@ func TestFeedCacheRepo_DeleteStale(t *testing.T) {
 
 		t.Run(fmt.Sprintf("DeleteStale_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(context.Background(), mockData)
+			err = feedRepo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Adding a stale record (older than 30 days)
@@ -414,7 +421,7 @@ func TestFeedCacheRepo_DeleteStale(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.DeleteStale(context.Background())
+			err = repo.DeleteStale(t.Context())
 			assert.NoError(t, err)
 
 			// Verify
@@ -423,13 +430,13 @@ func TestFeedCacheRepo_DeleteStale(t *testing.T) {
 			assert.False(t, exists)
 
 			// Cleanup
-			_ = feedRepo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = feedRepo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("DeleteStale_Fails_NoRecords [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.DeleteStale(context.Background())
+			err := repo.DeleteStale(t.Context())
 
 			// Verify
 			assert.NoError(t, err)

--- a/internal/database/feed_cache_test.go
+++ b/internal/database/feed_cache_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestFeedCacheRepo_Get(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 
@@ -28,11 +30,11 @@ func TestFeedCacheRepo_Get(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Get_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
@@ -44,9 +46,9 @@ func TestFeedCacheRepo_Get(t *testing.T) {
 			assert.Equal(t, []byte("test_value"), value)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("Get_Fails_NoRows [%s]", dbType), func(t *testing.T) {
@@ -70,6 +72,8 @@ func TestFeedCacheRepo_Get(t *testing.T) {
 }
 
 func TestFeedCacheRepo_GetByFeed(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 
@@ -82,32 +86,32 @@ func TestFeedCacheRepo_GetByFeed(t *testing.T) {
 
 		t.Run(fmt.Sprintf("GetByFeed_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
 			assert.NoError(t, err)
 
 			// Execute
-			items, err := repo.GetByFeed(t.Context(), mockData.ID)
+			items, err := repo.GetByFeed(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.Len(t, items, 1)
 			assert.Equal(t, "test_key", items[0].Key)
 			assert.Equal(t, []byte("test_value"), items[0].Value)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("GetByFeed_Empty [%s]", dbType), func(t *testing.T) {
 			// Execute
-			items, err := repo.GetByFeed(t.Context(), -1)
+			items, err := repo.GetByFeed(ctx, -1)
 			assert.NoError(t, err)
 			assert.Empty(t, items)
 		})
@@ -115,6 +119,8 @@ func TestFeedCacheRepo_GetByFeed(t *testing.T) {
 }
 
 func TestFeedCacheRepo_Exists(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 
@@ -127,11 +133,11 @@ func TestFeedCacheRepo_Exists(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Exists_True [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
@@ -143,9 +149,9 @@ func TestFeedCacheRepo_Exists(t *testing.T) {
 			assert.True(t, exists)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("Exists_False [%s]", dbType), func(t *testing.T) {
@@ -158,6 +164,8 @@ func TestFeedCacheRepo_Exists(t *testing.T) {
 }
 
 func TestFeedCacheRepo_ExistingItems(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 
@@ -170,11 +178,11 @@ func TestFeedCacheRepo_ExistingItems(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ExistingItems_SingleItem_Multi_Keys [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
@@ -183,24 +191,24 @@ func TestFeedCacheRepo_ExistingItems(t *testing.T) {
 			keys := []string{"test_key", "test_key_2"}
 
 			// Execute
-			items, err := repo.ExistingItems(t.Context(), mockData.ID, keys)
+			items, err := repo.ExistingItems(ctx, mockData.ID, keys)
 			assert.NoError(t, err)
 			assert.Len(t, items, 1)
 			//assert.True(t, exists)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("ExistingItems_MultipleItems [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
@@ -212,23 +220,23 @@ func TestFeedCacheRepo_ExistingItems(t *testing.T) {
 			keys := []string{"test_key", "test_key_2"}
 
 			// Execute
-			items, err := repo.ExistingItems(t.Context(), mockData.ID, keys)
+			items, err := repo.ExistingItems(ctx, mockData.ID, keys)
 			assert.NoError(t, err)
 			assert.Len(t, items, 2)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("ExistingItems_MultipleItems_Single_Key [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
@@ -240,14 +248,14 @@ func TestFeedCacheRepo_ExistingItems(t *testing.T) {
 			keys := []string{"test_key"}
 
 			// Execute
-			items, err := repo.ExistingItems(t.Context(), mockData.ID, keys)
+			items, err := repo.ExistingItems(ctx, mockData.ID, keys)
 			assert.NoError(t, err)
 			assert.Len(t, items, 1)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("ExistsItems_Nonexistent_Key [%s]", dbType), func(t *testing.T) {
@@ -260,6 +268,8 @@ func TestFeedCacheRepo_ExistingItems(t *testing.T) {
 }
 
 func TestFeedCacheRepo_Put(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -271,11 +281,11 @@ func TestFeedCacheRepo_Put(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Put_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Execute
@@ -288,9 +298,9 @@ func TestFeedCacheRepo_Put(t *testing.T) {
 			assert.Equal(t, []byte("test_value"), value)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), mockData.ID, "test_key")
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID, "test_key")
 		})
 
 		t.Run(fmt.Sprintf("Put_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
@@ -304,6 +314,8 @@ func TestFeedCacheRepo_Put(t *testing.T) {
 }
 
 func TestFeedCacheRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 
@@ -316,18 +328,18 @@ func TestFeedCacheRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.Delete(t.Context(), mockData.ID, "test_key")
+			err = repo.Delete(ctx, mockData.ID, "test_key")
 			assert.NoError(t, err)
 
 			// Verify
@@ -336,13 +348,13 @@ func TestFeedCacheRepo_Delete(t *testing.T) {
 			assert.False(t, exists)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_NoRecord [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Delete(t.Context(), -1, "nonexistent_key")
+			err := repo.Delete(ctx, -1, "nonexistent_key")
 
 			// Verify
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
@@ -351,6 +363,8 @@ func TestFeedCacheRepo_Delete(t *testing.T) {
 }
 
 func TestFeedCacheRepo_DeleteByFeed(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -362,18 +376,18 @@ func TestFeedCacheRepo_DeleteByFeed(t *testing.T) {
 
 		t.Run(fmt.Sprintf("DeleteByFeed_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			err = repo.Put(mockData.ID, "test_key", []byte("test_value"), time.Now().Add(time.Hour))
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.DeleteByFeed(t.Context(), mockData.ID)
+			err = repo.DeleteByFeed(ctx, mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
@@ -382,13 +396,13 @@ func TestFeedCacheRepo_DeleteByFeed(t *testing.T) {
 			assert.False(t, exists)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("DeleteByFeed_Fails_NoRecords [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.DeleteByFeed(t.Context(), -1)
+			err := repo.DeleteByFeed(ctx, -1)
 
 			// Verify
 			assert.NoError(t, err)
@@ -397,6 +411,8 @@ func TestFeedCacheRepo_DeleteByFeed(t *testing.T) {
 }
 
 func TestFeedCacheRepo_DeleteStale(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 
@@ -409,11 +425,11 @@ func TestFeedCacheRepo_DeleteStale(t *testing.T) {
 
 		t.Run(fmt.Sprintf("DeleteStale_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
-			err = feedRepo.Store(t.Context(), mockData)
+			err = feedRepo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Adding a stale record (older than 30 days)
@@ -421,7 +437,7 @@ func TestFeedCacheRepo_DeleteStale(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.DeleteStale(t.Context())
+			err = repo.DeleteStale(ctx)
 			assert.NoError(t, err)
 
 			// Verify
@@ -430,13 +446,13 @@ func TestFeedCacheRepo_DeleteStale(t *testing.T) {
 			assert.False(t, exists)
 
 			// Cleanup
-			_ = feedRepo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = feedRepo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("DeleteStale_Fails_NoRecords [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.DeleteStale(t.Context())
+			err := repo.DeleteStale(ctx)
 
 			// Verify
 			assert.NoError(t, err)

--- a/internal/database/feed_test.go
+++ b/internal/database/feed_test.go
@@ -6,7 +6,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -35,7 +34,8 @@ func getMockFeed() *domain.Feed {
 }
 
 func TestFeedRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -44,16 +44,16 @@ func TestFeedRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
 			// Execute
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			feed, err := repo.FindByID(context.Background(), mockData.ID)
+			feed, err := repo.FindByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, mockData.Name, feed.Name)
 			assert.Equal(t, mockData.Type, feed.Type)
@@ -62,23 +62,24 @@ func TestFeedRepo_Store(t *testing.T) {
 			assert.Equal(t, mockData.Interval, feed.Interval)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_Missing_Wrong_Foreign_Key [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Store(context.Background(), mockData)
+			err := repo.Store(t.Context(), mockData)
 			assert.Error(t, err)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
+			_ = repo.Delete(t.Context(), mockData.ID)
 		})
 	}
 }
 
 func TestFeedRepo_Update(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -87,10 +88,10 @@ func TestFeedRepo_Update(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Update data
@@ -98,18 +99,18 @@ func TestFeedRepo_Update(t *testing.T) {
 			mockData.Type = "NewType"
 
 			// Execute
-			err = repo.Update(context.Background(), mockData)
+			err = repo.Update(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedFeed, err := repo.FindByID(context.Background(), mockData.ID)
+			updatedFeed, err := repo.FindByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, "NewName", updatedFeed.Name)
 			assert.Equal(t, "NewType", updatedFeed.Type)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Update_Fails_Non_Existing_Feed [%s]", dbType), func(t *testing.T) {
@@ -118,7 +119,7 @@ func TestFeedRepo_Update(t *testing.T) {
 			nonExistingFeed.ID = 9999
 
 			// Execute
-			err := repo.Update(context.Background(), nonExistingFeed)
+			err := repo.Update(t.Context(), nonExistingFeed)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "sql: no rows in result set")
 		})
@@ -127,7 +128,8 @@ func TestFeedRepo_Update(t *testing.T) {
 }
 
 func TestFeedRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -136,27 +138,27 @@ func TestFeedRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.Delete(context.Background(), mockData.ID)
+			err = repo.Delete(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
-			_, err = repo.FindByID(context.Background(), mockData.ID)
+			_, err = repo.FindByID(t.Context(), mockData.ID)
 			assert.Error(t, err)
 
 			// Cleanup
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_Non_Existing_Feed [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Delete(context.Background(), 9999)
+			err := repo.Delete(t.Context(), 9999)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "sql: no rows in result set")
 		})
@@ -164,7 +166,8 @@ func TestFeedRepo_Delete(t *testing.T) {
 }
 
 func TestFeedRepo_FindByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -173,14 +176,14 @@ func TestFeedRepo_FindByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			feed, err := repo.FindByID(context.Background(), mockData.ID)
+			feed, err := repo.FindByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
@@ -191,13 +194,13 @@ func TestFeedRepo_FindByID(t *testing.T) {
 			assert.Equal(t, mockData.Interval, feed.Interval)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_Wrong_ID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			feed, err := repo.FindByID(context.Background(), -1)
+			feed, err := repo.FindByID(t.Context(), -1)
 			assert.Error(t, err)
 			assert.Nil(t, feed)
 		})
@@ -206,7 +209,8 @@ func TestFeedRepo_FindByID(t *testing.T) {
 }
 
 func TestFeedRepo_FindOne(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -215,14 +219,14 @@ func TestFeedRepo_FindOne(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByIndexerIdentifier_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			feed, err := repo.FindOne(context.Background(), domain.FindOneParams{IndexerIdentifier: indexer.Identifier})
+			feed, err := repo.FindOne(t.Context(), domain.FindOneParams{IndexerIdentifier: indexer.Identifier})
 			assert.NoError(t, err)
 
 			// Verify
@@ -234,13 +238,13 @@ func TestFeedRepo_FindOne(t *testing.T) {
 			assert.Equal(t, mockData.Interval, feed.Interval)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("FindByIndexerIdentifier_Fails_Wrong_Identifier [%s]", dbType), func(t *testing.T) {
 			// Execute
-			feed, err := repo.FindOne(context.Background(), domain.FindOneParams{IndexerIdentifier: "wrong-identifier"})
+			feed, err := repo.FindOne(t.Context(), domain.FindOneParams{IndexerIdentifier: "wrong-identifier"})
 			assert.Error(t, err)
 			assert.Nil(t, feed)
 		})
@@ -248,7 +252,8 @@ func TestFeedRepo_FindOne(t *testing.T) {
 }
 
 func TestFeedRepo_Find(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -262,17 +267,17 @@ func TestFeedRepo_Find(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Find_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			feedMockData1.IndexerID = int(indexer.ID)
 			feedMockData2.IndexerID = int(indexer.ID)
-			err = repo.Store(context.Background(), feedMockData1)
+			err = repo.Store(t.Context(), feedMockData1)
 			assert.NoError(t, err)
-			err = repo.Store(context.Background(), feedMockData2)
+			err = repo.Store(t.Context(), feedMockData2)
 			assert.NoError(t, err)
 
 			// Execute
-			feeds, err := repo.Find(context.Background())
+			feeds, err := repo.Find(t.Context())
 			assert.NoError(t, err)
 
 			// Verify
@@ -280,14 +285,14 @@ func TestFeedRepo_Find(t *testing.T) {
 
 			// Cleanup
 			for _, feed := range feeds {
-				_ = repo.Delete(context.Background(), feed.ID)
+				_ = repo.Delete(t.Context(), feed.ID)
 			}
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Find_Fails_EmptyDB [%s]", dbType), func(t *testing.T) {
 			// Execute
-			feeds, err := repo.Find(context.Background())
+			feeds, err := repo.Find(t.Context())
 
 			// Verify
 			assert.NoError(t, err)
@@ -298,7 +303,8 @@ func TestFeedRepo_Find(t *testing.T) {
 }
 
 func TestFeedRepo_GetLastRunDataByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -309,28 +315,28 @@ func TestFeedRepo_GetLastRunDataByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("GetLastRunDataByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
-			err = repo.Store(context.Background(), feedMockData)
+			err = repo.Store(t.Context(), feedMockData)
 			assert.NoError(t, err)
-			err = repo.UpdateLastRunWithData(context.Background(), feedMockData.ID, feedMockData.LastRunData)
+			err = repo.UpdateLastRunWithData(t.Context(), feedMockData.ID, feedMockData.LastRunData)
 			assert.NoError(t, err)
 			// Execute
-			data, err := repo.GetLastRunDataByID(context.Background(), feedMockData.ID)
+			data, err := repo.GetLastRunDataByID(t.Context(), feedMockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.Equal(t, "Some data", data)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), feedMockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), feedMockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("GetLastRunDataByID_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			_, err := repo.GetLastRunDataByID(context.Background(), -1)
+			_, err := repo.GetLastRunDataByID(t.Context(), -1)
 
 			// Verify
 			assert.Error(t, err)
@@ -338,29 +344,30 @@ func TestFeedRepo_GetLastRunDataByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("GetLastRunDataByID_Fails_NullData [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
 			feedMockData.LastRunData = ""
-			err = repo.Store(context.Background(), feedMockData)
+			err = repo.Store(t.Context(), feedMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			data, err := repo.GetLastRunDataByID(context.Background(), feedMockData.ID)
+			data, err := repo.GetLastRunDataByID(t.Context(), feedMockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.Empty(t, data)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), feedMockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), feedMockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 	}
 }
 
 func TestFeedRepo_UpdateLastRun(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -370,30 +377,30 @@ func TestFeedRepo_UpdateLastRun(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdateLastRun_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
-			err = repo.Store(context.Background(), feedMockData)
+			err = repo.Store(t.Context(), feedMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.UpdateLastRun(context.Background(), feedMockData.ID)
+			err = repo.UpdateLastRun(t.Context(), feedMockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedFeed, err := repo.Find(context.Background())
+			updatedFeed, err := repo.Find(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, updatedFeed)
 			assert.True(t, updatedFeed[0].LastRun.After(time.Now().Add(-1*time.Minute)))
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), feedMockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), feedMockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("UpdateLastRun_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.UpdateLastRun(context.Background(), -1)
+			err := repo.UpdateLastRun(t.Context(), -1)
 
 			// Verify
 			assert.Error(t, err)
@@ -402,7 +409,8 @@ func TestFeedRepo_UpdateLastRun(t *testing.T) {
 }
 
 func TestFeedRepo_UpdateLastRunWithData(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -412,30 +420,30 @@ func TestFeedRepo_UpdateLastRunWithData(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdateLastRunWithData_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
-			err = repo.Store(context.Background(), feedMockData)
+			err = repo.Store(t.Context(), feedMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.UpdateLastRunWithData(context.Background(), feedMockData.ID, "newData")
+			err = repo.UpdateLastRunWithData(t.Context(), feedMockData.ID, "newData")
 			assert.NoError(t, err)
 
 			// Verify
-			updatedFeed, err := repo.Find(context.Background())
+			updatedFeed, err := repo.Find(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, updatedFeed)
 			assert.True(t, updatedFeed[0].LastRun.After(time.Now().Add(-1*time.Minute)))
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), feedMockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), feedMockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("UpdateLastRunWithData_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.UpdateLastRunWithData(context.Background(), -1, "data")
+			err := repo.UpdateLastRunWithData(t.Context(), -1, "data")
 
 			// Verify
 			assert.Error(t, err)
@@ -444,7 +452,8 @@ func TestFeedRepo_UpdateLastRunWithData(t *testing.T) {
 }
 
 func TestFeedRepo_ToggleEnabled(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFeedRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -454,28 +463,28 @@ func TestFeedRepo_ToggleEnabled(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(context.Background(), indexerMockData)
+			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
-			err = repo.Store(context.Background(), feedMockData)
+			err = repo.Store(t.Context(), feedMockData)
 			assert.NoError(t, err)
 
 			// Execute & Verify
-			err = repo.ToggleEnabled(context.Background(), feedMockData.ID, false)
+			err = repo.ToggleEnabled(t.Context(), feedMockData.ID, false)
 			assert.NoError(t, err)
-			updatedFeed, err := repo.FindByID(context.Background(), feedMockData.ID)
+			updatedFeed, err := repo.FindByID(t.Context(), feedMockData.ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, updatedFeed)
 			assert.False(t, updatedFeed.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), feedMockData.ID)
-			_ = indexerRepo.Delete(context.Background(), int(indexer.ID))
+			_ = repo.Delete(t.Context(), feedMockData.ID)
+			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.ToggleEnabled(context.Background(), -1, true)
+			err := repo.ToggleEnabled(t.Context(), -1, true)
 
 			// Verify
 			assert.Error(t, err)

--- a/internal/database/feed_test.go
+++ b/internal/database/feed_test.go
@@ -34,6 +34,8 @@ func getMockFeed() *domain.Feed {
 }
 
 func TestFeedRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -44,16 +46,16 @@ func TestFeedRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
 
 			// Execute
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			feed, err := repo.FindByID(t.Context(), mockData.ID)
+			feed, err := repo.FindByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, mockData.Name, feed.Name)
 			assert.Equal(t, mockData.Type, feed.Type)
@@ -62,22 +64,24 @@ func TestFeedRepo_Store(t *testing.T) {
 			assert.Equal(t, mockData.Interval, feed.Interval)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_Missing_Wrong_Foreign_Key [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.Error(t, err)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 	}
 }
 
 func TestFeedRepo_Update(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -88,10 +92,10 @@ func TestFeedRepo_Update(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Update data
@@ -99,18 +103,18 @@ func TestFeedRepo_Update(t *testing.T) {
 			mockData.Type = "NewType"
 
 			// Execute
-			err = repo.Update(t.Context(), mockData)
+			err = repo.Update(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedFeed, err := repo.FindByID(t.Context(), mockData.ID)
+			updatedFeed, err := repo.FindByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, "NewName", updatedFeed.Name)
 			assert.Equal(t, "NewType", updatedFeed.Type)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Update_Fails_Non_Existing_Feed [%s]", dbType), func(t *testing.T) {
@@ -119,7 +123,7 @@ func TestFeedRepo_Update(t *testing.T) {
 			nonExistingFeed.ID = 9999
 
 			// Execute
-			err := repo.Update(t.Context(), nonExistingFeed)
+			err := repo.Update(ctx, nonExistingFeed)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "sql: no rows in result set")
 		})
@@ -128,6 +132,8 @@ func TestFeedRepo_Update(t *testing.T) {
 }
 
 func TestFeedRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -138,27 +144,27 @@ func TestFeedRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.Delete(t.Context(), mockData.ID)
+			err = repo.Delete(ctx, mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
-			_, err = repo.FindByID(t.Context(), mockData.ID)
+			_, err = repo.FindByID(ctx, mockData.ID)
 			assert.Error(t, err)
 
 			// Cleanup
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_Non_Existing_Feed [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Delete(t.Context(), 9999)
+			err := repo.Delete(ctx, 9999)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "sql: no rows in result set")
 		})
@@ -166,6 +172,8 @@ func TestFeedRepo_Delete(t *testing.T) {
 }
 
 func TestFeedRepo_FindByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -176,14 +184,14 @@ func TestFeedRepo_FindByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			feed, err := repo.FindByID(t.Context(), mockData.ID)
+			feed, err := repo.FindByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
@@ -194,13 +202,13 @@ func TestFeedRepo_FindByID(t *testing.T) {
 			assert.Equal(t, mockData.Interval, feed.Interval)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_Wrong_ID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			feed, err := repo.FindByID(t.Context(), -1)
+			feed, err := repo.FindByID(ctx, -1)
 			assert.Error(t, err)
 			assert.Nil(t, feed)
 		})
@@ -209,6 +217,8 @@ func TestFeedRepo_FindByID(t *testing.T) {
 }
 
 func TestFeedRepo_FindOne(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -219,14 +229,14 @@ func TestFeedRepo_FindOne(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByIndexerIdentifier_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			mockData.IndexerID = int(indexer.ID)
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			feed, err := repo.FindOne(t.Context(), domain.FindOneParams{IndexerIdentifier: indexer.Identifier})
+			feed, err := repo.FindOne(ctx, domain.FindOneParams{IndexerIdentifier: indexer.Identifier})
 			assert.NoError(t, err)
 
 			// Verify
@@ -238,13 +248,13 @@ func TestFeedRepo_FindOne(t *testing.T) {
 			assert.Equal(t, mockData.Interval, feed.Interval)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("FindByIndexerIdentifier_Fails_Wrong_Identifier [%s]", dbType), func(t *testing.T) {
 			// Execute
-			feed, err := repo.FindOne(t.Context(), domain.FindOneParams{IndexerIdentifier: "wrong-identifier"})
+			feed, err := repo.FindOne(ctx, domain.FindOneParams{IndexerIdentifier: "wrong-identifier"})
 			assert.Error(t, err)
 			assert.Nil(t, feed)
 		})
@@ -252,6 +262,8 @@ func TestFeedRepo_FindOne(t *testing.T) {
 }
 
 func TestFeedRepo_Find(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -267,17 +279,17 @@ func TestFeedRepo_Find(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Find_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			feedMockData1.IndexerID = int(indexer.ID)
 			feedMockData2.IndexerID = int(indexer.ID)
-			err = repo.Store(t.Context(), feedMockData1)
+			err = repo.Store(ctx, feedMockData1)
 			assert.NoError(t, err)
-			err = repo.Store(t.Context(), feedMockData2)
+			err = repo.Store(ctx, feedMockData2)
 			assert.NoError(t, err)
 
 			// Execute
-			feeds, err := repo.Find(t.Context())
+			feeds, err := repo.Find(ctx)
 			assert.NoError(t, err)
 
 			// Verify
@@ -285,14 +297,14 @@ func TestFeedRepo_Find(t *testing.T) {
 
 			// Cleanup
 			for _, feed := range feeds {
-				_ = repo.Delete(t.Context(), feed.ID)
+				_ = repo.Delete(ctx, feed.ID)
 			}
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("Find_Fails_EmptyDB [%s]", dbType), func(t *testing.T) {
 			// Execute
-			feeds, err := repo.Find(t.Context())
+			feeds, err := repo.Find(ctx)
 
 			// Verify
 			assert.NoError(t, err)
@@ -303,6 +315,8 @@ func TestFeedRepo_Find(t *testing.T) {
 }
 
 func TestFeedRepo_GetLastRunDataByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -315,28 +329,28 @@ func TestFeedRepo_GetLastRunDataByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("GetLastRunDataByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
-			err = repo.Store(t.Context(), feedMockData)
+			err = repo.Store(ctx, feedMockData)
 			assert.NoError(t, err)
-			err = repo.UpdateLastRunWithData(t.Context(), feedMockData.ID, feedMockData.LastRunData)
+			err = repo.UpdateLastRunWithData(ctx, feedMockData.ID, feedMockData.LastRunData)
 			assert.NoError(t, err)
 			// Execute
-			data, err := repo.GetLastRunDataByID(t.Context(), feedMockData.ID)
+			data, err := repo.GetLastRunDataByID(ctx, feedMockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.Equal(t, "Some data", data)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), feedMockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(ctx, feedMockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("GetLastRunDataByID_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			_, err := repo.GetLastRunDataByID(t.Context(), -1)
+			_, err := repo.GetLastRunDataByID(ctx, -1)
 
 			// Verify
 			assert.Error(t, err)
@@ -344,28 +358,30 @@ func TestFeedRepo_GetLastRunDataByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("GetLastRunDataByID_Fails_NullData [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
 			feedMockData.LastRunData = ""
-			err = repo.Store(t.Context(), feedMockData)
+			err = repo.Store(ctx, feedMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			data, err := repo.GetLastRunDataByID(t.Context(), feedMockData.ID)
+			data, err := repo.GetLastRunDataByID(ctx, feedMockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.Empty(t, data)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), feedMockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(ctx, feedMockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 	}
 }
 
 func TestFeedRepo_UpdateLastRun(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -377,30 +393,30 @@ func TestFeedRepo_UpdateLastRun(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdateLastRun_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
-			err = repo.Store(t.Context(), feedMockData)
+			err = repo.Store(ctx, feedMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.UpdateLastRun(t.Context(), feedMockData.ID)
+			err = repo.UpdateLastRun(ctx, feedMockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedFeed, err := repo.Find(t.Context())
+			updatedFeed, err := repo.Find(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, updatedFeed)
 			assert.True(t, updatedFeed[0].LastRun.After(time.Now().Add(-1*time.Minute)))
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), feedMockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(ctx, feedMockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("UpdateLastRun_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.UpdateLastRun(t.Context(), -1)
+			err := repo.UpdateLastRun(ctx, -1)
 
 			// Verify
 			assert.Error(t, err)
@@ -409,6 +425,8 @@ func TestFeedRepo_UpdateLastRun(t *testing.T) {
 }
 
 func TestFeedRepo_UpdateLastRunWithData(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -420,30 +438,30 @@ func TestFeedRepo_UpdateLastRunWithData(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdateLastRunWithData_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
-			err = repo.Store(t.Context(), feedMockData)
+			err = repo.Store(ctx, feedMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.UpdateLastRunWithData(t.Context(), feedMockData.ID, "newData")
+			err = repo.UpdateLastRunWithData(ctx, feedMockData.ID, "newData")
 			assert.NoError(t, err)
 
 			// Verify
-			updatedFeed, err := repo.Find(t.Context())
+			updatedFeed, err := repo.Find(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, updatedFeed)
 			assert.True(t, updatedFeed[0].LastRun.After(time.Now().Add(-1*time.Minute)))
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), feedMockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(ctx, feedMockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("UpdateLastRunWithData_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.UpdateLastRunWithData(t.Context(), -1, "data")
+			err := repo.UpdateLastRunWithData(ctx, -1, "data")
 
 			// Verify
 			assert.Error(t, err)
@@ -452,6 +470,8 @@ func TestFeedRepo_UpdateLastRunWithData(t *testing.T) {
 }
 
 func TestFeedRepo_ToggleEnabled(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -463,28 +483,28 @@ func TestFeedRepo_ToggleEnabled(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			feedMockData.IndexerID = int(indexer.ID)
-			err = repo.Store(t.Context(), feedMockData)
+			err = repo.Store(ctx, feedMockData)
 			assert.NoError(t, err)
 
 			// Execute & Verify
-			err = repo.ToggleEnabled(t.Context(), feedMockData.ID, false)
+			err = repo.ToggleEnabled(ctx, feedMockData.ID, false)
 			assert.NoError(t, err)
-			updatedFeed, err := repo.FindByID(t.Context(), feedMockData.ID)
+			updatedFeed, err := repo.FindByID(ctx, feedMockData.ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, updatedFeed)
 			assert.False(t, updatedFeed.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), feedMockData.ID)
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = repo.Delete(ctx, feedMockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 		})
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Fails_InvalidID [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.ToggleEnabled(t.Context(), -1, true)
+			err := repo.ToggleEnabled(ctx, -1, true)
 
 			// Verify
 			assert.Error(t, err)

--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -108,6 +108,8 @@ func getMockFilterExternal() domain.FilterExternal {
 }
 
 func TestFilterRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -116,24 +118,24 @@ func TestFilterRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			createdFilters, err := repo.ListFilters(t.Context())
+			createdFilters, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 			assert.Equal(t, mockData.Name, createdFilters[0].Name)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Missing_or_empty_fields [%s]", dbType), func(t *testing.T) {
 			mockData := domain.Filter{}
-			err := repo.Store(t.Context(), &mockData)
+			err := repo.Store(ctx, &mockData)
 			assert.Error(t, err)
 
-			createdFilters, err := repo.ListFilters(t.Context())
+			createdFilters, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -142,16 +144,18 @@ func TestFilterRepo_Store(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			err := repo.Store(ctx, mockData)
+			err := repo.Store(timeoutCtx, mockData)
 			assert.Error(t, err)
 		})
 	}
 }
 
 func TestFilterRepo_Update(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -160,7 +164,7 @@ func TestFilterRepo_Update(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Update mockData
@@ -169,28 +173,30 @@ func TestFilterRepo_Update(t *testing.T) {
 			mockData.CreatedAt = time.Now()
 
 			// Execute
-			err = repo.Update(t.Context(), mockData)
+			err = repo.Update(ctx, mockData)
 			assert.NoError(t, err)
 
-			createdFilters, err := repo.ListFilters(t.Context())
+			createdFilters, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 			assert.Equal(t, "Updated Filter", createdFilters[0].Name)
 			assert.Equal(t, false, createdFilters[0].Enabled)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), createdFilters[0].ID)
+			_ = repo.Delete(ctx, createdFilters[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("Update_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
 			mockData.ID = -1
-			err := repo.Update(t.Context(), mockData)
+			err := repo.Update(ctx, mockData)
 			assert.Error(t, err)
 		})
 	}
 }
 
 func TestFilterRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -199,26 +205,26 @@ func TestFilterRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			createdFilters, err := repo.ListFilters(t.Context())
+			createdFilters, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 			assert.Equal(t, mockData.Name, createdFilters[0].Name)
 
 			// Execute
-			err = repo.Delete(t.Context(), createdFilters[0].ID)
+			err = repo.Delete(ctx, createdFilters[0].ID)
 			assert.NoError(t, err)
 
 			// Verify that the filter is deleted and return error ErrRecordNotFound
-			filter, err := repo.FindByID(t.Context(), createdFilters[0].ID)
+			filter, err := repo.FindByID(ctx, createdFilters[0].ID)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 			assert.Nil(t, filter)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_No_Record [%s]", dbType), func(t *testing.T) {
-			err := repo.Delete(t.Context(), 9999)
+			err := repo.Delete(ctx, 9999)
 			assert.Error(t, err)
 		})
 
@@ -226,6 +232,8 @@ func TestFilterRepo_Delete(t *testing.T) {
 }
 
 func TestFilterRepo_UpdatePartial(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -234,40 +242,42 @@ func TestFilterRepo_UpdatePartial(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdatePartial_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 			updatedName := "Updated Name"
 
-			createdFilters, err := repo.ListFilters(t.Context())
+			createdFilters, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			// Execute
 			updateData := domain.FilterUpdate{ID: createdFilters[0].ID, Name: &updatedName}
-			err = repo.UpdatePartial(t.Context(), updateData)
+			err = repo.UpdatePartial(ctx, updateData)
 			assert.NoError(t, err)
 
 			// Verify that the filter is updated
-			filter, err := repo.FindByID(t.Context(), createdFilters[0].ID)
+			filter, err := repo.FindByID(ctx, createdFilters[0].ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, filter)
 			assert.Equal(t, updatedName, filter.Name)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), createdFilters[0].ID)
+			_ = repo.Delete(ctx, createdFilters[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("UpdatePartial_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
 			// Setup
 			updatedName := "Should Fail"
 			updateData := domain.FilterUpdate{ID: -1, Name: &updatedName}
-			err := repo.UpdatePartial(t.Context(), updateData)
+			err := repo.UpdatePartial(ctx, updateData)
 			assert.Error(t, err)
 		})
 	}
 }
 
 func TestFilterRepo_ToggleEnabled(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -276,30 +286,30 @@ func TestFilterRepo_ToggleEnabled(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			createdFilters, err := repo.ListFilters(t.Context())
+			createdFilters, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 			assert.Equal(t, true, createdFilters[0].Enabled)
 
 			// Execute
-			err = repo.ToggleEnabled(t.Context(), mockData.ID, false)
+			err = repo.ToggleEnabled(ctx, mockData.ID, false)
 			assert.NoError(t, err)
 
 			// Verify that the filter is updated
-			filter, err := repo.FindByID(t.Context(), createdFilters[0].ID)
+			filter, err := repo.FindByID(ctx, createdFilters[0].ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, filter)
 			assert.Equal(t, false, filter.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), createdFilters[0].ID)
+			_ = repo.Delete(ctx, createdFilters[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
-			err := repo.ToggleEnabled(t.Context(), -1, false)
+			err := repo.ToggleEnabled(ctx, -1, false)
 			assert.Error(t, err)
 		})
 
@@ -307,6 +317,8 @@ func TestFilterRepo_ToggleEnabled(t *testing.T) {
 }
 
 func TestFilterRepo_ListFilters(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -316,24 +328,24 @@ func TestFilterRepo_ListFilters(t *testing.T) {
 		t.Run(fmt.Sprintf("ListFilters_ReturnsFilters [%s]", dbType), func(t *testing.T) {
 			// Setup
 			for i := 0; i < 10; i++ {
-				err := repo.Store(t.Context(), mockData)
+				err := repo.Store(ctx, mockData)
 				assert.NoError(t, err)
 			}
 
 			// Execute
-			filters, err := repo.ListFilters(t.Context())
+			filters, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, filters)
 			assert.NotEmpty(t, filters)
 
 			// Cleanup
 			for _, filter := range filters {
-				_ = repo.Delete(t.Context(), filter.ID)
+				_ = repo.Delete(ctx, filter.ID)
 			}
 		})
 
 		t.Run(fmt.Sprintf("ListFilters_ReturnsEmptyList [%s]", dbType), func(t *testing.T) {
-			filters, err := repo.ListFilters(t.Context())
+			filters, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.Empty(t, filters)
 		})
@@ -342,6 +354,8 @@ func TestFilterRepo_ListFilters(t *testing.T) {
 }
 
 func TestFilterRepo_Find(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -353,7 +367,7 @@ func TestFilterRepo_Find(t *testing.T) {
 		t.Run(fmt.Sprintf("Find_Basic [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData.Name = "Test Filter"
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			params := domain.FilterQueryParams{
@@ -361,20 +375,20 @@ func TestFilterRepo_Find(t *testing.T) {
 			}
 
 			// Execute
-			filters, err := repo.Find(t.Context(), params)
+			filters, err := repo.Find(ctx, params)
 			assert.NoError(t, err)
 			assert.NotNil(t, filters)
 			assert.NotEmpty(t, filters)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), filters[0].ID)
+			_ = repo.Delete(ctx, filters[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("Find_Sort [%s]", dbType), func(t *testing.T) {
 			// Setup
 			for i := 0; i < 10; i++ {
 				mockData.Name = fmt.Sprintf("Test Filter %d", i)
-				err := repo.Store(t.Context(), mockData)
+				err := repo.Store(ctx, mockData)
 				assert.NoError(t, err)
 			}
 
@@ -385,7 +399,7 @@ func TestFilterRepo_Find(t *testing.T) {
 			}
 
 			// Execute
-			filters, err := repo.Find(t.Context(), params)
+			filters, err := repo.Find(ctx, params)
 			assert.NoError(t, err)
 			assert.NotNil(t, filters)
 			assert.NotEmpty(t, filters)
@@ -394,33 +408,33 @@ func TestFilterRepo_Find(t *testing.T) {
 
 			// Cleanup
 			for _, filter := range filters {
-				_ = repo.Delete(t.Context(), filter.ID)
+				_ = repo.Delete(ctx, filter.ID)
 			}
 		})
 
 		t.Run(fmt.Sprintf("Find_Filters [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData.Name = "New Filter With Filters"
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			allFilter, err := repo.ListFilters(t.Context())
+			allFilter, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, allFilter)
 
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, indexer)
 
 			// Store indexer connection
-			err = repo.StoreIndexerConnection(t.Context(), allFilter[0].ID, int(indexer.ID))
+			err = repo.StoreIndexerConnection(ctx, allFilter[0].ID, int(indexer.ID))
 
 			params := domain.FilterQueryParams{
 				Filters: struct{ Indexers []string }{Indexers: []string{"indexer1"}},
 			}
 
 			// Execute
-			filters, err := repo.Find(t.Context(), params)
+			filters, err := repo.Find(ctx, params)
 			assert.NoError(t, err)
 			assert.NotNil(t, filters)
 			assert.NotEmpty(t, filters)
@@ -428,14 +442,16 @@ func TestFilterRepo_Find(t *testing.T) {
 			assert.Equal(t, 1, len(filters))
 
 			// Cleanup
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), filters[0].ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, filters[0].ID)
 		})
 
 	}
 }
 
 func TestFilterRepo_FindByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -444,26 +460,26 @@ func TestFilterRepo_FindByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			createdFilters, err := repo.ListFilters(t.Context())
+			createdFilters, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
 			// Execute
-			filter, err := repo.FindByID(t.Context(), createdFilters[0].ID)
+			filter, err := repo.FindByID(ctx, createdFilters[0].ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, filter)
 			assert.Equal(t, createdFilters[0].ID, filter.ID)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), createdFilters[0].ID)
+			_ = repo.Delete(ctx, createdFilters[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
 			// Test using an invalid ID
-			filter, err := repo.FindByID(t.Context(), -1)
+			filter, err := repo.FindByID(ctx, -1)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound) // should return an error
 			assert.Nil(t, filter)                            // should be nil
 		})
@@ -472,6 +488,8 @@ func TestFilterRepo_FindByID(t *testing.T) {
 }
 
 func TestFilterRepo_FindByIndexerIdentifier(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -518,25 +536,25 @@ func TestFilterRepo_FindByIndexerIdentifier(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByIndexerIdentifier_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, indexer)
 
 			for _, filter := range filtersData {
 				filter := filter
-				err := repo.Store(t.Context(), filter)
+				err := repo.Store(ctx, filter)
 				assert.NoError(t, err)
 
-				err = repo.StoreIndexerConnection(t.Context(), filter.ID, int(indexer.ID))
+				err = repo.StoreIndexerConnection(ctx, filter.ID, int(indexer.ID))
 				assert.NoError(t, err)
 			}
 
-			filtersList, err := repo.ListFilters(t.Context())
+			filtersList, err := repo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotEmpty(t, filtersList)
 
 			// Execute
-			filters, err := repo.FindByIndexerIdentifier(t.Context(), indexerMockData.Identifier)
+			filters, err := repo.FindByIndexerIdentifier(ctx, indexerMockData.Identifier)
 			assert.NoError(t, err)
 			assert.NotNil(t, filters)
 			assert.NotEmpty(t, filters)
@@ -546,17 +564,17 @@ func TestFilterRepo_FindByIndexerIdentifier(t *testing.T) {
 			assert.Equal(t, filters[2].Priority, int32(20))
 
 			// Cleanup
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
 
 			for _, filter := range filtersData {
 				filter := filter
 
-				_ = repo.Delete(t.Context(), filter.ID)
+				_ = repo.Delete(ctx, filter.ID)
 			}
 		})
 
 		t.Run(fmt.Sprintf("FindByIndexerIdentifier_Fails_Invalid_Identifier [%s]", dbType), func(t *testing.T) {
-			filters, err := repo.FindByIndexerIdentifier(t.Context(), "invalid-identifier")
+			filters, err := repo.FindByIndexerIdentifier(ctx, "invalid-identifier")
 			assert.NoError(t, err) // should return an error??
 			assert.Nil(t, filters)
 		})
@@ -565,6 +583,8 @@ func TestFilterRepo_FindByIndexerIdentifier(t *testing.T) {
 }
 
 func TestFilterRepo_FindExternalFiltersByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -573,25 +593,25 @@ func TestFilterRepo_FindExternalFiltersByID(t *testing.T) {
 		t.Run(fmt.Sprintf("FindExternalFiltersByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData := getMockFilter()
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			mockDataExternal := getMockFilterExternal()
-			err = repo.StoreFilterExternal(t.Context(), mockData.ID, []domain.FilterExternal{mockDataExternal})
+			err = repo.StoreFilterExternal(ctx, mockData.ID, []domain.FilterExternal{mockDataExternal})
 			assert.NoError(t, err)
 
 			// Execute
-			filters, err := repo.FindExternalFiltersByID(t.Context(), mockData.ID)
+			filters, err := repo.FindExternalFiltersByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, filters)
 			assert.NotEmpty(t, filters)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindExternalFiltersByID_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
-			filters, err := repo.FindExternalFiltersByID(t.Context(), -1)
+			filters, err := repo.FindExternalFiltersByID(ctx, -1)
 			assert.NoError(t, err) // should return an error??
 			assert.Nil(t, filters)
 		})
@@ -600,6 +620,8 @@ func TestFilterRepo_FindExternalFiltersByID(t *testing.T) {
 }
 
 func TestFilterRepo_FindExternalFiltersByFilterIDs(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -608,11 +630,11 @@ func TestFilterRepo_FindExternalFiltersByFilterIDs(t *testing.T) {
 		t.Run(fmt.Sprintf("FindExternalFiltersByFilterIDs_Groups_By_Filter [%s]", dbType), func(t *testing.T) {
 			// Setup
 			firstFilter := getMockFilter()
-			err := repo.Store(t.Context(), firstFilter)
+			err := repo.Store(ctx, firstFilter)
 			assert.NoError(t, err)
 
 			secondFilter := getMockFilter()
-			err = repo.Store(t.Context(), secondFilter)
+			err = repo.Store(ctx, secondFilter)
 			assert.NoError(t, err)
 
 			first := getMockFilterExternal()
@@ -621,14 +643,14 @@ func TestFilterRepo_FindExternalFiltersByFilterIDs(t *testing.T) {
 			second.Name = "ExternalFilterTwo"
 			second.Index = 2
 
-			err = repo.StoreFilterExternal(t.Context(), firstFilter.ID, []domain.FilterExternal{first, second})
+			err = repo.StoreFilterExternal(ctx, firstFilter.ID, []domain.FilterExternal{first, second})
 			assert.NoError(t, err)
 
-			err = repo.StoreFilterExternal(t.Context(), secondFilter.ID, []domain.FilterExternal{first})
+			err = repo.StoreFilterExternal(ctx, secondFilter.ID, []domain.FilterExternal{first})
 			assert.NoError(t, err)
 
 			// Execute
-			externalFilters, err := repo.FindExternalFiltersByFilterIDs(t.Context(), []int{firstFilter.ID, secondFilter.ID})
+			externalFilters, err := repo.FindExternalFiltersByFilterIDs(ctx, []int{firstFilter.ID, secondFilter.ID})
 
 			// Verify
 			assert.NoError(t, err)
@@ -641,23 +663,23 @@ func TestFilterRepo_FindExternalFiltersByFilterIDs(t *testing.T) {
 			assert.Equal(t, 1, externalFilters[firstFilter.ID][1].Index)
 
 			// matches what the per-filter lookup returns
-			single, err := repo.FindExternalFiltersByID(t.Context(), firstFilter.ID)
+			single, err := repo.FindExternalFiltersByID(ctx, firstFilter.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, single, externalFilters[firstFilter.ID])
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), firstFilter.ID)
-			_ = repo.Delete(t.Context(), secondFilter.ID)
+			_ = repo.Delete(ctx, firstFilter.ID)
+			_ = repo.Delete(ctx, secondFilter.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindExternalFiltersByFilterIDs_Empty_Input [%s]", dbType), func(t *testing.T) {
-			externalFilters, err := repo.FindExternalFiltersByFilterIDs(t.Context(), []int{})
+			externalFilters, err := repo.FindExternalFiltersByFilterIDs(ctx, []int{})
 			assert.NoError(t, err)
 			assert.Empty(t, externalFilters)
 		})
 
 		t.Run(fmt.Sprintf("FindExternalFiltersByFilterIDs_Unknown_ID [%s]", dbType), func(t *testing.T) {
-			externalFilters, err := repo.FindExternalFiltersByFilterIDs(t.Context(), []int{-1})
+			externalFilters, err := repo.FindExternalFiltersByFilterIDs(ctx, []int{-1})
 			assert.NoError(t, err)
 			assert.Empty(t, externalFilters)
 			assert.Nil(t, externalFilters[-1])
@@ -666,6 +688,8 @@ func TestFilterRepo_FindExternalFiltersByFilterIDs(t *testing.T) {
 }
 
 func TestFilterRepo_StoreIndexerConnection(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -675,26 +699,26 @@ func TestFilterRepo_StoreIndexerConnection(t *testing.T) {
 		t.Run(fmt.Sprintf("StoreIndexerConnection_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData := getMockFilter()
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			indexerMockData := getMockIndexer()
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, indexer)
 
 			// Execute
-			err = repo.StoreIndexerConnection(t.Context(), mockData.ID, int(indexer.ID))
+			err = repo.StoreIndexerConnection(ctx, mockData.ID, int(indexer.ID))
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("StoreIndexerConnection_Fails_Invalid_IDs [%s]", dbType), func(t *testing.T) {
 			// Execute with invalid IDs
-			err := repo.StoreIndexerConnection(t.Context(), -1, -1)
+			err := repo.StoreIndexerConnection(ctx, -1, -1)
 			assert.Error(t, err)
 		})
 
@@ -702,6 +726,8 @@ func TestFilterRepo_StoreIndexerConnection(t *testing.T) {
 }
 
 func TestFilterRepo_StoreIndexerConnections(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -711,7 +737,7 @@ func TestFilterRepo_StoreIndexerConnections(t *testing.T) {
 		t.Run(fmt.Sprintf("StoreIndexerConnections_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData := getMockFilter()
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			indexerMockData := getMockIndexer()
@@ -719,36 +745,38 @@ func TestFilterRepo_StoreIndexerConnections(t *testing.T) {
 			for i := 0; i < 2; i++ {
 				// identifier must be unique
 				indexerMockData.Identifier = fmt.Sprintf("indexer%d", i)
-				indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+				indexer, err := indexerRepo.Store(ctx, indexerMockData)
 				assert.NoError(t, err)
 				indexers = append(indexers, *indexer)
 			}
 
 			// Execute
-			err = repo.StoreIndexerConnections(t.Context(), mockData.ID, indexers)
+			err = repo.StoreIndexerConnections(ctx, mockData.ID, indexers)
 			assert.NoError(t, err)
 
 			// Validate that the connections were successfully stored in the database
-			connections, err := repo.FindByIndexerIdentifier(t.Context(), indexerMockData.Identifier)
+			connections, err := repo.FindByIndexerIdentifier(ctx, indexerMockData.Identifier)
 			assert.NoError(t, err)
 			assert.NotNil(t, connections)
 			assert.NotEmpty(t, connections)
 
 			// Cleanup
 			for _, indexer := range indexers {
-				_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
+				_ = indexerRepo.Delete(ctx, int(indexer.ID))
 			}
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("StoreIndexerConnections_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
-			err := repo.StoreIndexerConnections(t.Context(), -1, []domain.Indexer{})
+			err := repo.StoreIndexerConnections(ctx, -1, []domain.Indexer{})
 			assert.NoError(t, err) //TODO: // this should return an error.
 		})
 	}
 }
 
 func TestFilterRepo_StoreFilterExternal(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -757,26 +785,28 @@ func TestFilterRepo_StoreFilterExternal(t *testing.T) {
 		t.Run(fmt.Sprintf("StoreFilterExternal_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData := getMockFilter()
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Execute
 			mockDataExternal := getMockFilterExternal()
-			err = repo.StoreFilterExternal(t.Context(), mockData.ID, []domain.FilterExternal{mockDataExternal})
+			err = repo.StoreFilterExternal(ctx, mockData.ID, []domain.FilterExternal{mockDataExternal})
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("StoreFilterExternal_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
-			err := repo.StoreFilterExternal(t.Context(), -1, []domain.FilterExternal{})
+			err := repo.StoreFilterExternal(ctx, -1, []domain.FilterExternal{})
 			assert.NoError(t, err) // TODO: this should return an error
 		})
 	}
 }
 
 func TestFilterRepo_DeleteIndexerConnections(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -786,33 +816,33 @@ func TestFilterRepo_DeleteIndexerConnections(t *testing.T) {
 		t.Run(fmt.Sprintf("DeleteIndexerConnections_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData := getMockFilter()
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			indexerMockData := getMockIndexer()
-			indexer, err := indexerRepo.Store(t.Context(), indexerMockData)
+			indexer, err := indexerRepo.Store(ctx, indexerMockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, indexer)
 
-			err = repo.StoreIndexerConnection(t.Context(), mockData.ID, int(indexer.ID))
+			err = repo.StoreIndexerConnection(ctx, mockData.ID, int(indexer.ID))
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.DeleteIndexerConnections(t.Context(), mockData.ID)
+			err = repo.DeleteIndexerConnections(ctx, mockData.ID)
 			assert.NoError(t, err)
 
 			// Validate that the connections were successfully deleted from the database
-			connections, err := repo.FindByIndexerIdentifier(t.Context(), indexerMockData.Identifier)
+			connections, err := repo.FindByIndexerIdentifier(ctx, indexerMockData.Identifier)
 			assert.NoError(t, err)
 			assert.Nil(t, connections)
 
 			// Cleanup
-			_ = indexerRepo.Delete(t.Context(), int(indexer.ID))
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = indexerRepo.Delete(ctx, int(indexer.ID))
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("DeleteIndexerConnections_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
-			err := repo.DeleteIndexerConnections(t.Context(), -1)
+			err := repo.DeleteIndexerConnections(ctx, -1)
 			assert.NoError(t, err) // TODO: this should return an error
 		})
 
@@ -820,6 +850,8 @@ func TestFilterRepo_DeleteIndexerConnections(t *testing.T) {
 }
 
 func TestFilterRepo_DeleteFilterExternal(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -828,28 +860,28 @@ func TestFilterRepo_DeleteFilterExternal(t *testing.T) {
 		t.Run(fmt.Sprintf("DeleteFilterExternal_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData := getMockFilter()
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			mockDataExternal := getMockFilterExternal()
-			err = repo.StoreFilterExternal(t.Context(), mockData.ID, []domain.FilterExternal{mockDataExternal})
+			err = repo.StoreFilterExternal(ctx, mockData.ID, []domain.FilterExternal{mockDataExternal})
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.DeleteFilterExternal(t.Context(), mockData.ID)
+			err = repo.DeleteFilterExternal(ctx, mockData.ID)
 			assert.NoError(t, err)
 
 			// Validate that the connections were successfully deleted from the database
-			connections, err := repo.FindExternalFiltersByID(t.Context(), mockData.ID)
+			connections, err := repo.FindExternalFiltersByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.Nil(t, connections)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("DeleteFilterExternal_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
-			err := repo.DeleteFilterExternal(t.Context(), -1)
+			err := repo.DeleteFilterExternal(ctx, -1)
 			assert.NoError(t, err) // TODO: this should return an error
 		})
 
@@ -857,6 +889,8 @@ func TestFilterRepo_DeleteFilterExternal(t *testing.T) {
 }
 
 func TestFilterRepo_GetFilterDownloads(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -868,12 +902,12 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 		t.Run(fmt.Sprintf("GetFilterDownloads_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData := getMockFilter()
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			mockClient := getMockDownloadClient()
 
-			err = downloadClientRepo.Store(t.Context(), &mockClient)
+			err = downloadClientRepo.Store(ctx, &mockClient)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockClient)
 
@@ -881,7 +915,7 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockAction.FilterID = mockData.ID
 			mockAction.ClientID = mockClient.ID
 
-			err = actionRepo.Store(t.Context(), mockAction)
+			err = actionRepo.Store(ctx, mockAction)
 
 			mockReleaseActionStatus := getMockReleaseActionStatus()
 			mockReleaseActionStatus.FilterID = int64(mockData.ID)
@@ -889,17 +923,17 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockRelease := getMockRelease()
 			mockRelease.FilterID = mockData.ID
 
-			err = releaseRepo.Store(t.Context(), mockRelease)
+			err = releaseRepo.Store(ctx, mockRelease)
 			assert.NoError(t, err)
 
 			mockReleaseActionStatus.ActionID = int64(mockAction.ID)
 			mockReleaseActionStatus.ReleaseID = mockRelease.ID
 
-			err = releaseRepo.StoreReleaseActionStatus(t.Context(), mockReleaseActionStatus)
+			err = releaseRepo.StoreReleaseActionStatus(ctx, mockReleaseActionStatus)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.GetFilterDownloadCount(t.Context(), mockData)
+			err = repo.GetFilterDownloadCount(ctx, mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockData.Downloads)
 			assert.Equal(t, mockData.Downloads, &domain.FilterDownloads{
@@ -911,15 +945,15 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			})
 
 			// Cleanup
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: mockAction.ID})
-			_ = repo.Delete(t.Context(), mockData.ID)
-			_ = downloadClientRepo.Delete(t.Context(), mockClient.ID)
-			_ = releaseRepo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: mockAction.ID})
+			_ = repo.Delete(ctx, mockData.ID)
+			_ = downloadClientRepo.Delete(ctx, mockClient.ID)
+			_ = releaseRepo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
 		})
 
 		t.Run(fmt.Sprintf("GetFilterDownloads_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
 			mockFilter := &domain.Filter{ID: -1}
-			err := repo.GetFilterDownloadCount(t.Context(), mockFilter)
+			err := repo.GetFilterDownloadCount(ctx, mockFilter)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockFilter.Downloads)
 			assert.Equal(t, mockFilter.Downloads, &domain.FilterDownloads{
@@ -934,12 +968,12 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 		t.Run(fmt.Sprintf("GetFilterDownloads_Multiple_Actions [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockFilter := getMockFilter()
-			err := repo.Store(t.Context(), mockFilter)
+			err := repo.Store(ctx, mockFilter)
 			assert.NoError(t, err)
 
 			mockClient := getMockDownloadClient()
 
-			err = downloadClientRepo.Store(t.Context(), &mockClient)
+			err = downloadClientRepo.Store(ctx, &mockClient)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockClient)
 
@@ -947,20 +981,20 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockAction1.FilterID = mockFilter.ID
 			mockAction1.ClientID = mockClient.ID
 
-			actionErr := actionRepo.Store(t.Context(), mockAction1)
+			actionErr := actionRepo.Store(ctx, mockAction1)
 			assert.NoError(t, actionErr)
 
 			mockAction2 := getMockAction()
 			mockAction2.FilterID = mockFilter.ID
 			mockAction2.ClientID = mockClient.ID
 
-			action2Err := actionRepo.Store(t.Context(), mockAction2)
+			action2Err := actionRepo.Store(ctx, mockAction2)
 			assert.NoError(t, action2Err)
 
 			mockRelease := getMockRelease()
 			mockRelease.FilterID = mockFilter.ID
 
-			err = releaseRepo.Store(t.Context(), mockRelease)
+			err = releaseRepo.Store(ctx, mockRelease)
 			assert.NoError(t, err)
 
 			mockReleaseActionStatus1 := getMockReleaseActionStatus()
@@ -968,7 +1002,7 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockReleaseActionStatus1.FilterID = int64(mockFilter.ID)
 			mockReleaseActionStatus1.ReleaseID = mockRelease.ID
 
-			err = releaseRepo.StoreReleaseActionStatus(t.Context(), mockReleaseActionStatus1)
+			err = releaseRepo.StoreReleaseActionStatus(ctx, mockReleaseActionStatus1)
 			assert.NoError(t, err)
 
 			mockReleaseActionStatus2 := getMockReleaseActionStatus()
@@ -976,11 +1010,11 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockReleaseActionStatus2.FilterID = int64(mockFilter.ID)
 			mockReleaseActionStatus2.ReleaseID = mockRelease.ID
 
-			err = releaseRepo.StoreReleaseActionStatus(t.Context(), mockReleaseActionStatus2)
+			err = releaseRepo.StoreReleaseActionStatus(ctx, mockReleaseActionStatus2)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.GetFilterDownloadCount(t.Context(), mockFilter)
+			err = repo.GetFilterDownloadCount(ctx, mockFilter)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockFilter.Downloads)
 			assert.Equal(t, mockFilter.Downloads, &domain.FilterDownloads{
@@ -992,23 +1026,23 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			})
 
 			// Cleanup
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: mockAction1.ID})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: mockAction2.ID})
-			_ = repo.Delete(t.Context(), mockFilter.ID)
-			_ = downloadClientRepo.Delete(t.Context(), mockClient.ID)
-			_ = releaseRepo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: mockAction1.ID})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: mockAction2.ID})
+			_ = repo.Delete(ctx, mockFilter.ID)
+			_ = downloadClientRepo.Delete(ctx, mockClient.ID)
+			_ = releaseRepo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
 		})
 
 		t.Run(fmt.Sprintf("GetFilterDownloads_Old_Release [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockFilter := getMockFilter()
 			mockFilter.Shows = "nope"
-			err := repo.Store(t.Context(), mockFilter)
+			err := repo.Store(ctx, mockFilter)
 			assert.NoError(t, err)
 
 			mockClient := getMockDownloadClient()
 
-			err = downloadClientRepo.Store(t.Context(), &mockClient)
+			err = downloadClientRepo.Store(ctx, &mockClient)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockClient)
 
@@ -1016,20 +1050,20 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockAction.FilterID = mockFilter.ID
 			mockAction.ClientID = mockClient.ID
 
-			err = actionRepo.Store(t.Context(), mockAction)
+			err = actionRepo.Store(ctx, mockAction)
 			assert.NoError(t, err)
 
 			mockAction2 := getMockAction()
 			mockAction2.FilterID = mockFilter.ID
 			mockAction2.ClientID = mockClient.ID
 
-			err = actionRepo.Store(t.Context(), mockAction2)
+			err = actionRepo.Store(ctx, mockAction2)
 			assert.NoError(t, err)
 
 			mockRelease := getMockRelease()
 			mockRelease.FilterID = mockFilter.ID
 
-			err = releaseRepo.Store(t.Context(), mockRelease)
+			err = releaseRepo.Store(ctx, mockRelease)
 			assert.NoError(t, err)
 
 			mockReleaseActionStatus := getMockReleaseActionStatus()
@@ -1038,7 +1072,7 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockReleaseActionStatus.ReleaseID = mockRelease.ID
 			mockReleaseActionStatus.Timestamp = mockReleaseActionStatus.Timestamp.Add(-35 * 24 * time.Hour) // use Add instead of AddDate(0, -1, 0) to not cause issues where previous month is shorter than current month.
 
-			err = releaseRepo.StoreReleaseActionStatus(t.Context(), mockReleaseActionStatus)
+			err = releaseRepo.StoreReleaseActionStatus(ctx, mockReleaseActionStatus)
 			assert.NoError(t, err)
 
 			mockReleaseActionStatus2 := getMockReleaseActionStatus()
@@ -1047,11 +1081,11 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			mockReleaseActionStatus2.ReleaseID = mockRelease.ID
 			mockReleaseActionStatus2.Timestamp = mockReleaseActionStatus2.Timestamp.Add(-35 * 24 * time.Hour) // use Add instead of AddDate(0, -1, 0) to not cause issues where previous month is shorter than current month.
 
-			err = releaseRepo.StoreReleaseActionStatus(t.Context(), mockReleaseActionStatus2)
+			err = releaseRepo.StoreReleaseActionStatus(ctx, mockReleaseActionStatus2)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.GetFilterDownloadCount(t.Context(), mockFilter)
+			err = repo.GetFilterDownloadCount(ctx, mockFilter)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockFilter.Downloads)
 			assert.Equal(t, mockFilter.Downloads, &domain.FilterDownloads{
@@ -1063,19 +1097,19 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			})
 
 			// Cleanup
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: mockAction.ID})
-			_ = repo.Delete(t.Context(), mockFilter.ID)
-			_ = downloadClientRepo.Delete(t.Context(), mockClient.ID)
-			_ = releaseRepo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: mockAction.ID})
+			_ = repo.Delete(ctx, mockFilter.ID)
+			_ = downloadClientRepo.Delete(ctx, mockClient.ID)
+			_ = releaseRepo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
 		})
 
 		t.Run(fmt.Sprintf("GetFilterDownloads_No_Releases [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockFilter := getMockFilter()
-			err := repo.Store(t.Context(), mockFilter)
+			err := repo.Store(ctx, mockFilter)
 			assert.NoError(t, err)
 
-			err = repo.GetFilterDownloadCount(t.Context(), mockFilter)
+			err = repo.GetFilterDownloadCount(ctx, mockFilter)
 			assert.NoError(t, err)
 			assert.NotNil(t, mockFilter.Downloads)
 			assert.Equal(t, mockFilter.Downloads, &domain.FilterDownloads{
@@ -1087,7 +1121,7 @@ func TestFilterRepo_GetFilterDownloads(t *testing.T) {
 			})
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockFilter.ID)
+			_ = repo.Delete(ctx, mockFilter.ID)
 		})
 
 	}

--- a/internal/database/filter_test.go
+++ b/internal/database/filter_test.go
@@ -108,7 +108,8 @@ func getMockFilterExternal() domain.FilterExternal {
 }
 
 func TestFilterRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		mockData := getMockFilter()
@@ -151,7 +152,8 @@ func TestFilterRepo_Store(t *testing.T) {
 }
 
 func TestFilterRepo_Update(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		mockData := getMockFilter()
@@ -189,7 +191,8 @@ func TestFilterRepo_Update(t *testing.T) {
 }
 
 func TestFilterRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		mockData := getMockFilter()
@@ -223,7 +226,8 @@ func TestFilterRepo_Delete(t *testing.T) {
 }
 
 func TestFilterRepo_UpdatePartial(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		mockData := getMockFilter()
@@ -264,7 +268,8 @@ func TestFilterRepo_UpdatePartial(t *testing.T) {
 }
 
 func TestFilterRepo_ToggleEnabled(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		mockData := getMockFilter()
@@ -302,7 +307,8 @@ func TestFilterRepo_ToggleEnabled(t *testing.T) {
 }
 
 func TestFilterRepo_ListFilters(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		mockData := getMockFilter()
@@ -336,7 +342,8 @@ func TestFilterRepo_ListFilters(t *testing.T) {
 }
 
 func TestFilterRepo_Find(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -429,7 +436,8 @@ func TestFilterRepo_Find(t *testing.T) {
 }
 
 func TestFilterRepo_FindByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		mockData := getMockFilter()
@@ -464,7 +472,8 @@ func TestFilterRepo_FindByID(t *testing.T) {
 }
 
 func TestFilterRepo_FindByIndexerIdentifier(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -556,7 +565,8 @@ func TestFilterRepo_FindByIndexerIdentifier(t *testing.T) {
 }
 
 func TestFilterRepo_FindExternalFiltersByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 
@@ -590,7 +600,8 @@ func TestFilterRepo_FindExternalFiltersByID(t *testing.T) {
 }
 
 func TestFilterRepo_FindExternalFiltersByFilterIDs(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 
@@ -655,7 +666,8 @@ func TestFilterRepo_FindExternalFiltersByFilterIDs(t *testing.T) {
 }
 
 func TestFilterRepo_StoreIndexerConnection(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -690,7 +702,8 @@ func TestFilterRepo_StoreIndexerConnection(t *testing.T) {
 }
 
 func TestFilterRepo_StoreIndexerConnections(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -736,7 +749,8 @@ func TestFilterRepo_StoreIndexerConnections(t *testing.T) {
 }
 
 func TestFilterRepo_StoreFilterExternal(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 
@@ -763,7 +777,8 @@ func TestFilterRepo_StoreFilterExternal(t *testing.T) {
 }
 
 func TestFilterRepo_DeleteIndexerConnections(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		indexerRepo := NewIndexerRepo(log, db)
@@ -805,7 +820,8 @@ func TestFilterRepo_DeleteIndexerConnections(t *testing.T) {
 }
 
 func TestFilterRepo_DeleteFilterExternal(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 
@@ -841,7 +857,8 @@ func TestFilterRepo_DeleteFilterExternal(t *testing.T) {
 }
 
 func TestFilterRepo_GetFilterDownloads(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewFilterRepo(log, db)
 		releaseRepo := NewReleaseRepo(log, db)

--- a/internal/database/indexer_deprecations_test.go
+++ b/internal/database/indexer_deprecations_test.go
@@ -4,7 +4,6 @@
 package database
 
 import (
-	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -58,7 +57,7 @@ func newDeprecationTestDB(t *testing.T) *DB {
 func TestIndexerRepoReconcileDeprecations(t *testing.T) {
 	db := newDeprecationTestDB(t)
 	repo := NewIndexerRepo(zerolog.Nop(), db)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := db.Handler.ExecContext(ctx, `
 		INSERT INTO indexer (identifier, archived, archived_at)
@@ -93,7 +92,7 @@ func TestIndexerRepoReconcileDeprecations(t *testing.T) {
 func TestIndexerRepoReconcileDeprecationsRollsBack(t *testing.T) {
 	db := newDeprecationTestDB(t)
 	repo := NewIndexerRepo(zerolog.Nop(), db)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := db.Handler.ExecContext(ctx, "INSERT INTO indexer (identifier) VALUES ('first')")
 	require.NoError(t, err)
@@ -116,7 +115,7 @@ func TestIndexerRepoReconcileDeprecationsRollsBack(t *testing.T) {
 func TestDeleteArchivedIndexerConnectionsScope(t *testing.T) {
 	db := newDeprecationTestDB(t)
 	repo := NewFilterRepo(zerolog.Nop(), db)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := db.Handler.ExecContext(ctx, `
 		INSERT INTO indexer (id, identifier, archived)

--- a/internal/database/indexer_test.go
+++ b/internal/database/indexer_test.go
@@ -6,7 +6,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -30,32 +29,34 @@ func getMockIndexer() domain.Indexer {
 }
 
 func TestIndexerRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewIndexerRepo(log, db)
 		mockData := getMockIndexer()
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			createdIndexer, err := repo.Store(context.Background(), mockData)
+			createdIndexer, err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			indexer, err := repo.FindByID(context.Background(), int(createdIndexer.ID))
+			indexer, err := repo.FindByID(t.Context(), int(createdIndexer.ID))
 			assert.NoError(t, err)
 			assert.Equal(t, mockData.Name, createdIndexer.Name)
 			assert.Equal(t, mockData.Identifier, createdIndexer.Identifier)
 			assert.Equal(t, mockData.Enabled, indexer.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), int(createdIndexer.ID))
+			_ = repo.Delete(t.Context(), int(createdIndexer.ID))
 		})
 
 	}
 }
 
 func TestIndexerRepo_Update(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewIndexerRepo(log, db)
 
@@ -63,14 +64,14 @@ func TestIndexerRepo_Update(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			createdIndexer, err := repo.Store(context.Background(), initialData)
+			createdIndexer, err := repo.Store(t.Context(), initialData)
 			assert.NoError(t, err)
 
 			createdIndexer.Name = "UpdatedName"
 			createdIndexer.Enabled = false
 
 			// Execute
-			err = repo.Update(context.Background(), createdIndexer)
+			err = repo.Update(t.Context(), createdIndexer)
 			assert.NoError(t, err)
 
 			// Verify
@@ -79,13 +80,14 @@ func TestIndexerRepo_Update(t *testing.T) {
 			assert.Equal(t, createdIndexer.Enabled, false)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), int(createdIndexer.ID))
+			_ = repo.Delete(t.Context(), int(createdIndexer.ID))
 		})
 	}
 }
 
 func TestIndexerRepo_List(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewIndexerRepo(log, db)
 
@@ -99,13 +101,13 @@ func TestIndexerRepo_List(t *testing.T) {
 			mockData2.Name = "Indexer2"
 			mockData2.Identifier = "Identifier2"
 
-			createdIndexer1, err := repo.Store(context.Background(), mockData1)
+			createdIndexer1, err := repo.Store(t.Context(), mockData1)
 			assert.NoError(t, err)
-			createdIndexer2, err := repo.Store(context.Background(), mockData2)
+			createdIndexer2, err := repo.Store(t.Context(), mockData2)
 			assert.NoError(t, err)
 
 			// Execute
-			indexers, err := repo.List(context.Background())
+			indexers, err := repo.List(t.Context())
 			assert.NoError(t, err)
 
 			// Verify
@@ -115,14 +117,15 @@ func TestIndexerRepo_List(t *testing.T) {
 			assert.Equal(t, 2, len(indexers))
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), int(createdIndexer1.ID))
-			_ = repo.Delete(context.Background(), int(createdIndexer2.ID))
+			_ = repo.Delete(t.Context(), int(createdIndexer1.ID))
+			_ = repo.Delete(t.Context(), int(createdIndexer2.ID))
 		})
 	}
 }
 
 func TestIndexerRepo_FindByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewIndexerRepo(log, db)
 		mockData := getMockIndexer()
@@ -132,11 +135,11 @@ func TestIndexerRepo_FindByID(t *testing.T) {
 			mockData.Name = "TestIndexer"
 			mockData.Identifier = "TestIdentifier"
 
-			createdIndexer, err := repo.Store(context.Background(), mockData)
+			createdIndexer, err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			foundIndexer, err := repo.FindByID(context.Background(), int(createdIndexer.ID))
+			foundIndexer, err := repo.FindByID(t.Context(), int(createdIndexer.ID))
 			assert.NoError(t, err)
 
 			// Verify
@@ -146,13 +149,14 @@ func TestIndexerRepo_FindByID(t *testing.T) {
 			assert.Equal(t, createdIndexer.Enabled, foundIndexer.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), int(createdIndexer.ID))
+			_ = repo.Delete(t.Context(), int(createdIndexer.ID))
 		})
 	}
 }
 
 func TestIndexerRepo_FindByFilterID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIndexerRepo(log, db)
@@ -163,18 +167,18 @@ func TestIndexerRepo_FindByFilterID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByFilterID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := filterRepo.Store(context.Background(), filterMockData)
+			err := filterRepo.Store(t.Context(), filterMockData)
 			assert.NoError(t, err)
 
-			indexer, err := repo.Store(context.Background(), mockData)
+			indexer, err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, indexer)
 
-			err = filterRepo.StoreIndexerConnection(context.Background(), filterMockData.ID, int(indexer.ID))
+			err = filterRepo.StoreIndexerConnection(t.Context(), filterMockData.ID, int(indexer.ID))
 			assert.NoError(t, err)
 
 			// Execute
-			foundIndexers, err := repo.FindByFilterID(context.Background(), filterMockData.ID)
+			foundIndexers, err := repo.FindByFilterID(t.Context(), filterMockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
@@ -183,14 +187,15 @@ func TestIndexerRepo_FindByFilterID(t *testing.T) {
 			assert.Equal(t, indexer.Identifier, foundIndexers[0].Identifier)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), int(indexer.ID))
-			_ = filterRepo.Delete(context.Background(), filterMockData.ID)
+			_ = repo.Delete(t.Context(), int(indexer.ID))
+			_ = filterRepo.Delete(t.Context(), filterMockData.ID)
 		})
 	}
 }
 
 func TestIndexerRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIndexerRepo(log, db)
@@ -198,16 +203,16 @@ func TestIndexerRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			createdIndexer, err := repo.Store(context.Background(), mockData)
+			createdIndexer, err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdIndexer)
 
 			// Execute
-			err = repo.Delete(context.Background(), int(createdIndexer.ID))
+			err = repo.Delete(t.Context(), int(createdIndexer.ID))
 			assert.NoError(t, err)
 
 			// Verify
-			_, err = repo.FindByID(context.Background(), int(createdIndexer.ID))
+			_, err = repo.FindByID(t.Context(), int(createdIndexer.ID))
 			assert.Error(t, err)
 		})
 	}
@@ -217,7 +222,7 @@ func TestIndexerRepo_Delete(t *testing.T) {
 func storeTestIndexer(t *testing.T, repo *IndexerRepo, identifier string) *domain.Indexer {
 	t.Helper()
 
-	indexer, err := repo.Store(context.Background(), domain.Indexer{
+	indexer, err := repo.Store(t.Context(), domain.Indexer{
 		Enabled:        true,
 		Name:           identifier,
 		Identifier:     identifier,
@@ -231,10 +236,11 @@ func storeTestIndexer(t *testing.T, repo *IndexerRepo, identifier string) *domai
 }
 
 func TestIndexerRepo_ArchiveAndDeprecation(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewIndexerRepo(log, db)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		t.Run(fmt.Sprintf("ArchiveAndDeprecation_Succeeds [%s]", dbType), func(t *testing.T) {
 			stored := storeTestIndexer(t, repo, "fnp")
@@ -292,10 +298,11 @@ func TestIndexerRepo_ArchiveAndDeprecation(t *testing.T) {
 // the release list relies on, including the hard-deleted-row case (no indexer row, name still
 // resolved from the deprecation table).
 func TestReleaseNameResolution_Coalesce(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewIndexerRepo(log, db)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		t.Run(fmt.Sprintf("ReleaseNameResolution_Coalesce [%s]", dbType), func(t *testing.T) {
 			storeTestIndexer(t, repo, "activetracker")
@@ -327,11 +334,12 @@ func TestReleaseNameResolution_Coalesce(t *testing.T) {
 }
 
 func TestStoreIndexerConnections_RejectsArchived(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		indexerRepo := NewIndexerRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		t.Run(fmt.Sprintf("StoreIndexerConnections_RejectsArchived [%s]", dbType), func(t *testing.T) {
 			active := storeTestIndexer(t, indexerRepo, "activetracker")

--- a/internal/database/indexer_test.go
+++ b/internal/database/indexer_test.go
@@ -29,6 +29,8 @@ func getMockIndexer() domain.Indexer {
 }
 
 func TestIndexerRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -37,24 +39,26 @@ func TestIndexerRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			createdIndexer, err := repo.Store(t.Context(), mockData)
+			createdIndexer, err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			indexer, err := repo.FindByID(t.Context(), int(createdIndexer.ID))
+			indexer, err := repo.FindByID(ctx, int(createdIndexer.ID))
 			assert.NoError(t, err)
 			assert.Equal(t, mockData.Name, createdIndexer.Name)
 			assert.Equal(t, mockData.Identifier, createdIndexer.Identifier)
 			assert.Equal(t, mockData.Enabled, indexer.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), int(createdIndexer.ID))
+			_ = repo.Delete(ctx, int(createdIndexer.ID))
 		})
 
 	}
 }
 
 func TestIndexerRepo_Update(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -64,14 +68,14 @@ func TestIndexerRepo_Update(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			createdIndexer, err := repo.Store(t.Context(), initialData)
+			createdIndexer, err := repo.Store(ctx, initialData)
 			assert.NoError(t, err)
 
 			createdIndexer.Name = "UpdatedName"
 			createdIndexer.Enabled = false
 
 			// Execute
-			err = repo.Update(t.Context(), createdIndexer)
+			err = repo.Update(ctx, createdIndexer)
 			assert.NoError(t, err)
 
 			// Verify
@@ -80,12 +84,14 @@ func TestIndexerRepo_Update(t *testing.T) {
 			assert.Equal(t, createdIndexer.Enabled, false)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), int(createdIndexer.ID))
+			_ = repo.Delete(ctx, int(createdIndexer.ID))
 		})
 	}
 }
 
 func TestIndexerRepo_List(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -101,13 +107,13 @@ func TestIndexerRepo_List(t *testing.T) {
 			mockData2.Name = "Indexer2"
 			mockData2.Identifier = "Identifier2"
 
-			createdIndexer1, err := repo.Store(t.Context(), mockData1)
+			createdIndexer1, err := repo.Store(ctx, mockData1)
 			assert.NoError(t, err)
-			createdIndexer2, err := repo.Store(t.Context(), mockData2)
+			createdIndexer2, err := repo.Store(ctx, mockData2)
 			assert.NoError(t, err)
 
 			// Execute
-			indexers, err := repo.List(t.Context())
+			indexers, err := repo.List(ctx)
 			assert.NoError(t, err)
 
 			// Verify
@@ -117,13 +123,15 @@ func TestIndexerRepo_List(t *testing.T) {
 			assert.Equal(t, 2, len(indexers))
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), int(createdIndexer1.ID))
-			_ = repo.Delete(t.Context(), int(createdIndexer2.ID))
+			_ = repo.Delete(ctx, int(createdIndexer1.ID))
+			_ = repo.Delete(ctx, int(createdIndexer2.ID))
 		})
 	}
 }
 
 func TestIndexerRepo_FindByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -135,11 +143,11 @@ func TestIndexerRepo_FindByID(t *testing.T) {
 			mockData.Name = "TestIndexer"
 			mockData.Identifier = "TestIdentifier"
 
-			createdIndexer, err := repo.Store(t.Context(), mockData)
+			createdIndexer, err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			foundIndexer, err := repo.FindByID(t.Context(), int(createdIndexer.ID))
+			foundIndexer, err := repo.FindByID(ctx, int(createdIndexer.ID))
 			assert.NoError(t, err)
 
 			// Verify
@@ -149,12 +157,14 @@ func TestIndexerRepo_FindByID(t *testing.T) {
 			assert.Equal(t, createdIndexer.Enabled, foundIndexer.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), int(createdIndexer.ID))
+			_ = repo.Delete(ctx, int(createdIndexer.ID))
 		})
 	}
 }
 
 func TestIndexerRepo_FindByFilterID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -167,18 +177,18 @@ func TestIndexerRepo_FindByFilterID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByFilterID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := filterRepo.Store(t.Context(), filterMockData)
+			err := filterRepo.Store(ctx, filterMockData)
 			assert.NoError(t, err)
 
-			indexer, err := repo.Store(t.Context(), mockData)
+			indexer, err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, indexer)
 
-			err = filterRepo.StoreIndexerConnection(t.Context(), filterMockData.ID, int(indexer.ID))
+			err = filterRepo.StoreIndexerConnection(ctx, filterMockData.ID, int(indexer.ID))
 			assert.NoError(t, err)
 
 			// Execute
-			foundIndexers, err := repo.FindByFilterID(t.Context(), filterMockData.ID)
+			foundIndexers, err := repo.FindByFilterID(ctx, filterMockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
@@ -187,13 +197,15 @@ func TestIndexerRepo_FindByFilterID(t *testing.T) {
 			assert.Equal(t, indexer.Identifier, foundIndexers[0].Identifier)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), int(indexer.ID))
-			_ = filterRepo.Delete(t.Context(), filterMockData.ID)
+			_ = repo.Delete(ctx, int(indexer.ID))
+			_ = filterRepo.Delete(ctx, filterMockData.ID)
 		})
 	}
 }
 
 func TestIndexerRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -203,16 +215,16 @@ func TestIndexerRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			createdIndexer, err := repo.Store(t.Context(), mockData)
+			createdIndexer, err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdIndexer)
 
 			// Execute
-			err = repo.Delete(t.Context(), int(createdIndexer.ID))
+			err = repo.Delete(ctx, int(createdIndexer.ID))
 			assert.NoError(t, err)
 
 			// Verify
-			_, err = repo.FindByID(t.Context(), int(createdIndexer.ID))
+			_, err = repo.FindByID(ctx, int(createdIndexer.ID))
 			assert.Error(t, err)
 		})
 	}
@@ -236,11 +248,12 @@ func storeTestIndexer(t *testing.T, repo *IndexerRepo, identifier string) *domai
 }
 
 func TestIndexerRepo_ArchiveAndDeprecation(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewIndexerRepo(log, db)
-		ctx := t.Context()
 
 		t.Run(fmt.Sprintf("ArchiveAndDeprecation_Succeeds [%s]", dbType), func(t *testing.T) {
 			stored := storeTestIndexer(t, repo, "fnp")
@@ -298,11 +311,12 @@ func TestIndexerRepo_ArchiveAndDeprecation(t *testing.T) {
 // the release list relies on, including the hard-deleted-row case (no indexer row, name still
 // resolved from the deprecation table).
 func TestReleaseNameResolution_Coalesce(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewIndexerRepo(log, db)
-		ctx := t.Context()
 
 		t.Run(fmt.Sprintf("ReleaseNameResolution_Coalesce [%s]", dbType), func(t *testing.T) {
 			storeTestIndexer(t, repo, "activetracker")
@@ -334,12 +348,13 @@ func TestReleaseNameResolution_Coalesce(t *testing.T) {
 }
 
 func TestStoreIndexerConnections_RejectsArchived(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
 		indexerRepo := NewIndexerRepo(log, db)
 		filterRepo := NewFilterRepo(log, db)
-		ctx := t.Context()
 
 		t.Run(fmt.Sprintf("StoreIndexerConnections_RejectsArchived [%s]", dbType), func(t *testing.T) {
 			active := storeTestIndexer(t, indexerRepo, "activetracker")

--- a/internal/database/irc_test.go
+++ b/internal/database/irc_test.go
@@ -55,6 +55,8 @@ func getMockIrcNetwork() domain.IrcNetwork {
 }
 
 func TestIrcRepo_StoreNetwork(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -68,19 +70,21 @@ func TestIrcRepo_StoreNetwork(t *testing.T) {
 			assert.NotNil(t, mockData)
 
 			// Execute
-			err := repo.StoreNetwork(t.Context(), &mockData)
+			err := repo.StoreNetwork(ctx, &mockData)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.NotEqual(t, int64(0), mockData.ID)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), int64(int(mockData.ID)))
+			_ = repo.DeleteNetwork(ctx, int64(int(mockData.ID)))
 		})
 	}
 }
 
 func TestIrcRepo_StoreChannel(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -92,11 +96,11 @@ func TestIrcRepo_StoreChannel(t *testing.T) {
 
 		t.Run(fmt.Sprintf("StoreChannel_Insert_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(t.Context(), &mockNetwork)
+			err := repo.StoreNetwork(ctx, &mockNetwork)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
+			err = repo.StoreChannel(ctx, mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Verify
@@ -107,7 +111,7 @@ func TestIrcRepo_StoreChannel(t *testing.T) {
 
 		t.Run(fmt.Sprintf("StoreChannel_Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
+			err := repo.StoreChannel(ctx, mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Update mockChannel fields
@@ -115,7 +119,7 @@ func TestIrcRepo_StoreChannel(t *testing.T) {
 			mockChannel.Name = "updated_name"
 
 			// Execute
-			err = repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
+			err = repo.StoreChannel(ctx, mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Verify
@@ -125,12 +129,14 @@ func TestIrcRepo_StoreChannel(t *testing.T) {
 			assert.Equal(t, mockChannel.Name, fetchedChannel[0].Name)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(ctx, mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_UpdateNetwork(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -142,7 +148,7 @@ func TestIrcRepo_UpdateNetwork(t *testing.T) {
 		t.Run(fmt.Sprintf("UpdateNetwork_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			assert.NotNil(t, mockData)
-			err := repo.StoreNetwork(t.Context(), &mockData)
+			err := repo.StoreNetwork(ctx, &mockData)
 			assert.NoError(t, err)
 			assert.NotEqual(t, int64(0), mockData.ID)
 
@@ -151,22 +157,24 @@ func TestIrcRepo_UpdateNetwork(t *testing.T) {
 			mockData.Name = "UpdatedNetworkName"
 
 			// Execute
-			err = repo.UpdateNetwork(t.Context(), &mockData)
+			err = repo.UpdateNetwork(ctx, &mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedNetwork, fetchErr := repo.GetNetworkByID(t.Context(), mockData.ID)
+			updatedNetwork, fetchErr := repo.GetNetworkByID(ctx, mockData.ID)
 			assert.NoError(t, fetchErr)
 			assert.Equal(t, mockData.Enabled, updatedNetwork.Enabled)
 			assert.Equal(t, mockData.Name, updatedNetwork.Name)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockData.ID)
+			_ = repo.DeleteNetwork(ctx, mockData.ID)
 		})
 	}
 }
 
 func TestIrcRepo_GetNetworkByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -178,12 +186,12 @@ func TestIrcRepo_GetNetworkByID(t *testing.T) {
 		t.Run(fmt.Sprintf("GetNetworkByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			assert.NotNil(t, mockData)
-			err := repo.StoreNetwork(t.Context(), &mockData)
+			err := repo.StoreNetwork(ctx, &mockData)
 			assert.NoError(t, err)
 			assert.NotEqual(t, int64(0), mockData.ID)
 
 			// Execute
-			fetchedNetwork, err := repo.GetNetworkByID(t.Context(), mockData.ID)
+			fetchedNetwork, err := repo.GetNetworkByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
@@ -193,12 +201,14 @@ func TestIrcRepo_GetNetworkByID(t *testing.T) {
 			assert.Equal(t, mockData.Name, fetchedNetwork.Name)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockData.ID)
+			_ = repo.DeleteNetwork(ctx, mockData.ID)
 		})
 	}
 }
 
 func TestIrcRepo_DeleteNetwork(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -210,16 +220,16 @@ func TestIrcRepo_DeleteNetwork(t *testing.T) {
 		t.Run(fmt.Sprintf("DeleteNetwork_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			assert.NotNil(t, mockData)
-			err := repo.StoreNetwork(t.Context(), &mockData)
+			err := repo.StoreNetwork(ctx, &mockData)
 			assert.NoError(t, err)
 			assert.NotEqual(t, int64(0), mockData.ID)
 
 			// Execute
-			err = repo.DeleteNetwork(t.Context(), mockData.ID)
+			err = repo.DeleteNetwork(ctx, mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
-			fetchedNetwork, fetchErr := repo.GetNetworkByID(t.Context(), mockData.ID)
+			fetchedNetwork, fetchErr := repo.GetNetworkByID(ctx, mockData.ID)
 			assert.Error(t, fetchErr)
 			assert.Nil(t, fetchedNetwork)
 		})
@@ -227,6 +237,8 @@ func TestIrcRepo_DeleteNetwork(t *testing.T) {
 }
 
 func TestIrcRepo_FindActiveNetworks(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -245,13 +257,13 @@ func TestIrcRepo_FindActiveNetworks(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindActiveNetworks_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(t.Context(), &mockData1)
+			err := repo.StoreNetwork(ctx, &mockData1)
 			assert.NoError(t, err)
-			err = repo.StoreNetwork(t.Context(), &mockData2)
+			err = repo.StoreNetwork(ctx, &mockData2)
 			assert.NoError(t, err)
 
 			// Execute
-			activeNetworks, err := repo.FindActiveNetworks(t.Context())
+			activeNetworks, err := repo.FindActiveNetworks(ctx)
 			assert.NoError(t, err)
 
 			// Verify
@@ -260,13 +272,15 @@ func TestIrcRepo_FindActiveNetworks(t *testing.T) {
 			assert.True(t, activeNetworks[0].Enabled)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockData1.ID)
-			_ = repo.DeleteNetwork(t.Context(), mockData2.ID)
+			_ = repo.DeleteNetwork(ctx, mockData1.ID)
+			_ = repo.DeleteNetwork(ctx, mockData2.ID)
 		})
 	}
 }
 
 func TestIrcRepo_ListNetworks(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -284,13 +298,13 @@ func TestIrcRepo_ListNetworks(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ListNetworks_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(t.Context(), &mockData1)
+			err := repo.StoreNetwork(ctx, &mockData1)
 			assert.NoError(t, err)
-			err = repo.StoreNetwork(t.Context(), &mockData2)
+			err = repo.StoreNetwork(ctx, &mockData2)
 			assert.NoError(t, err)
 
 			// Execute
-			listedNetworks, err := repo.ListNetworks(t.Context())
+			listedNetworks, err := repo.ListNetworks(ctx)
 			assert.NoError(t, err)
 
 			// Verify
@@ -302,13 +316,15 @@ func TestIrcRepo_ListNetworks(t *testing.T) {
 			assert.Equal(t, "ZNetwork", listedNetworks[1].Name)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockData1.ID)
-			_ = repo.DeleteNetwork(t.Context(), mockData2.ID)
+			_ = repo.DeleteNetwork(ctx, mockData1.ID)
+			_ = repo.DeleteNetwork(ctx, mockData2.ID)
 		})
 	}
 }
 
 func TestIrcRepo_ListChannels(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -319,10 +335,10 @@ func TestIrcRepo_ListChannels(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ListChannels_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(t.Context(), &mockNetwork)
+			err := repo.StoreNetwork(ctx, &mockNetwork)
 			assert.NoError(t, err)
 
-			err = repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
+			err = repo.StoreChannel(ctx, mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Execute
@@ -334,12 +350,14 @@ func TestIrcRepo_ListChannels(t *testing.T) {
 			assert.Len(t, listedChannels, 1)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(ctx, mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_CheckExistingNetwork(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -349,7 +367,7 @@ func TestIrcRepo_CheckExistingNetwork(t *testing.T) {
 
 		t.Run(fmt.Sprintf("CheckExistingNetwork_NoMatch [%s]", dbType), func(t *testing.T) {
 			// Execute
-			existingNetwork, err := repo.CheckExistingNetwork(t.Context(), &mockNetwork)
+			existingNetwork, err := repo.CheckExistingNetwork(ctx, &mockNetwork)
 			assert.NoError(t, err)
 
 			// Verify
@@ -358,11 +376,11 @@ func TestIrcRepo_CheckExistingNetwork(t *testing.T) {
 
 		t.Run(fmt.Sprintf("CheckExistingNetwork_MatchFound [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(t.Context(), &mockNetwork)
+			err := repo.StoreNetwork(ctx, &mockNetwork)
 			assert.NoError(t, err)
 
 			// Execute
-			existingNetwork, err := repo.CheckExistingNetwork(t.Context(), &mockNetwork)
+			existingNetwork, err := repo.CheckExistingNetwork(ctx, &mockNetwork)
 			assert.NoError(t, err)
 
 			// Verify
@@ -372,12 +390,14 @@ func TestIrcRepo_CheckExistingNetwork(t *testing.T) {
 			assert.Equal(t, mockNetwork.Nick, existingNetwork.Nick)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(ctx, mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_StoreNetworkChannels(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -388,14 +408,14 @@ func TestIrcRepo_StoreNetworkChannels(t *testing.T) {
 
 		t.Run(fmt.Sprintf("StoreNetworkChannels_DeleteOldChannels [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(t.Context(), &mockNetwork)
+			err := repo.StoreNetwork(ctx, &mockNetwork)
 			assert.NoError(t, err)
 
-			err = repo.StoreNetworkChannels(t.Context(), mockNetwork.ID, mockChannels)
+			err = repo.StoreNetworkChannels(ctx, mockNetwork.ID, mockChannels)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.StoreNetworkChannels(t.Context(), mockNetwork.ID, []domain.IrcChannel{})
+			err = repo.StoreNetworkChannels(ctx, mockNetwork.ID, []domain.IrcChannel{})
 			assert.NoError(t, err)
 
 			// Verify
@@ -404,16 +424,16 @@ func TestIrcRepo_StoreNetworkChannels(t *testing.T) {
 			assert.Len(t, existingChannels, 0)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(ctx, mockNetwork.ID)
 		})
 
 		t.Run(fmt.Sprintf("StoreNetworkChannels_InsertNewChannels [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(t.Context(), &mockNetwork)
+			err := repo.StoreNetwork(ctx, &mockNetwork)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.StoreNetworkChannels(t.Context(), mockNetwork.ID, mockChannels)
+			err = repo.StoreNetworkChannels(ctx, mockNetwork.ID, mockChannels)
 			assert.NoError(t, err)
 
 			// Verify
@@ -422,12 +442,14 @@ func TestIrcRepo_StoreNetworkChannels(t *testing.T) {
 			assert.Len(t, existingChannels, len(mockChannels))
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(ctx, mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_UpdateChannel(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -438,10 +460,10 @@ func TestIrcRepo_UpdateChannel(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdateChannel_Success [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(t.Context(), &mockNetwork)
+			err := repo.StoreNetwork(ctx, &mockNetwork)
 			assert.NoError(t, err)
 
-			err = repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
+			err = repo.StoreChannel(ctx, mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Update mockChannel properties
@@ -464,12 +486,14 @@ func TestIrcRepo_UpdateChannel(t *testing.T) {
 			assert.Equal(t, updatedChannel.Password, fetchedChannel.Password)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(ctx, mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_UpdateInviteCommand(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -479,7 +503,7 @@ func TestIrcRepo_UpdateInviteCommand(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdateInviteCommand_Success [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(t.Context(), &mockNetwork)
+			err := repo.StoreNetwork(ctx, &mockNetwork)
 			assert.NoError(t, err)
 
 			// Update invite_command
@@ -488,13 +512,13 @@ func TestIrcRepo_UpdateInviteCommand(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Verify
-			updatedNetwork, err := repo.ListNetworks(t.Context())
+			updatedNetwork, err := repo.ListNetworks(ctx)
 			assert.NoError(t, err)
 
 			assert.Equal(t, newInviteCommand, updatedNetwork[0].InviteCommand)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(ctx, mockNetwork.ID)
 		})
 	}
 }

--- a/internal/database/irc_test.go
+++ b/internal/database/irc_test.go
@@ -6,7 +6,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -56,7 +55,8 @@ func getMockIrcNetwork() domain.IrcNetwork {
 }
 
 func TestIrcRepo_StoreNetwork(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -68,20 +68,21 @@ func TestIrcRepo_StoreNetwork(t *testing.T) {
 			assert.NotNil(t, mockData)
 
 			// Execute
-			err := repo.StoreNetwork(context.Background(), &mockData)
+			err := repo.StoreNetwork(t.Context(), &mockData)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.NotEqual(t, int64(0), mockData.ID)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), int64(int(mockData.ID)))
+			_ = repo.DeleteNetwork(t.Context(), int64(int(mockData.ID)))
 		})
 	}
 }
 
 func TestIrcRepo_StoreChannel(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -91,11 +92,11 @@ func TestIrcRepo_StoreChannel(t *testing.T) {
 
 		t.Run(fmt.Sprintf("StoreChannel_Insert_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(context.Background(), &mockNetwork)
+			err := repo.StoreNetwork(t.Context(), &mockNetwork)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.StoreChannel(context.Background(), mockNetwork.ID, &mockChannel)
+			err = repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Verify
@@ -106,7 +107,7 @@ func TestIrcRepo_StoreChannel(t *testing.T) {
 
 		t.Run(fmt.Sprintf("StoreChannel_Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreChannel(context.Background(), mockNetwork.ID, &mockChannel)
+			err := repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Update mockChannel fields
@@ -114,7 +115,7 @@ func TestIrcRepo_StoreChannel(t *testing.T) {
 			mockChannel.Name = "updated_name"
 
 			// Execute
-			err = repo.StoreChannel(context.Background(), mockNetwork.ID, &mockChannel)
+			err = repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Verify
@@ -124,13 +125,14 @@ func TestIrcRepo_StoreChannel(t *testing.T) {
 			assert.Equal(t, mockChannel.Name, fetchedChannel[0].Name)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_UpdateNetwork(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -140,7 +142,7 @@ func TestIrcRepo_UpdateNetwork(t *testing.T) {
 		t.Run(fmt.Sprintf("UpdateNetwork_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			assert.NotNil(t, mockData)
-			err := repo.StoreNetwork(context.Background(), &mockData)
+			err := repo.StoreNetwork(t.Context(), &mockData)
 			assert.NoError(t, err)
 			assert.NotEqual(t, int64(0), mockData.ID)
 
@@ -149,23 +151,24 @@ func TestIrcRepo_UpdateNetwork(t *testing.T) {
 			mockData.Name = "UpdatedNetworkName"
 
 			// Execute
-			err = repo.UpdateNetwork(context.Background(), &mockData)
+			err = repo.UpdateNetwork(t.Context(), &mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedNetwork, fetchErr := repo.GetNetworkByID(context.Background(), mockData.ID)
+			updatedNetwork, fetchErr := repo.GetNetworkByID(t.Context(), mockData.ID)
 			assert.NoError(t, fetchErr)
 			assert.Equal(t, mockData.Enabled, updatedNetwork.Enabled)
 			assert.Equal(t, mockData.Name, updatedNetwork.Name)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockData.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockData.ID)
 		})
 	}
 }
 
 func TestIrcRepo_GetNetworkByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -175,12 +178,12 @@ func TestIrcRepo_GetNetworkByID(t *testing.T) {
 		t.Run(fmt.Sprintf("GetNetworkByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			assert.NotNil(t, mockData)
-			err := repo.StoreNetwork(context.Background(), &mockData)
+			err := repo.StoreNetwork(t.Context(), &mockData)
 			assert.NoError(t, err)
 			assert.NotEqual(t, int64(0), mockData.ID)
 
 			// Execute
-			fetchedNetwork, err := repo.GetNetworkByID(context.Background(), mockData.ID)
+			fetchedNetwork, err := repo.GetNetworkByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
@@ -190,13 +193,14 @@ func TestIrcRepo_GetNetworkByID(t *testing.T) {
 			assert.Equal(t, mockData.Name, fetchedNetwork.Name)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockData.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockData.ID)
 		})
 	}
 }
 
 func TestIrcRepo_DeleteNetwork(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -206,16 +210,16 @@ func TestIrcRepo_DeleteNetwork(t *testing.T) {
 		t.Run(fmt.Sprintf("DeleteNetwork_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			assert.NotNil(t, mockData)
-			err := repo.StoreNetwork(context.Background(), &mockData)
+			err := repo.StoreNetwork(t.Context(), &mockData)
 			assert.NoError(t, err)
 			assert.NotEqual(t, int64(0), mockData.ID)
 
 			// Execute
-			err = repo.DeleteNetwork(context.Background(), mockData.ID)
+			err = repo.DeleteNetwork(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
-			fetchedNetwork, fetchErr := repo.GetNetworkByID(context.Background(), mockData.ID)
+			fetchedNetwork, fetchErr := repo.GetNetworkByID(t.Context(), mockData.ID)
 			assert.Error(t, fetchErr)
 			assert.Nil(t, fetchedNetwork)
 		})
@@ -223,7 +227,8 @@ func TestIrcRepo_DeleteNetwork(t *testing.T) {
 }
 
 func TestIrcRepo_FindActiveNetworks(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -240,13 +245,13 @@ func TestIrcRepo_FindActiveNetworks(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindActiveNetworks_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(context.Background(), &mockData1)
+			err := repo.StoreNetwork(t.Context(), &mockData1)
 			assert.NoError(t, err)
-			err = repo.StoreNetwork(context.Background(), &mockData2)
+			err = repo.StoreNetwork(t.Context(), &mockData2)
 			assert.NoError(t, err)
 
 			// Execute
-			activeNetworks, err := repo.FindActiveNetworks(context.Background())
+			activeNetworks, err := repo.FindActiveNetworks(t.Context())
 			assert.NoError(t, err)
 
 			// Verify
@@ -255,14 +260,15 @@ func TestIrcRepo_FindActiveNetworks(t *testing.T) {
 			assert.True(t, activeNetworks[0].Enabled)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockData1.ID)
-			_ = repo.DeleteNetwork(context.Background(), mockData2.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockData1.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockData2.ID)
 		})
 	}
 }
 
 func TestIrcRepo_ListNetworks(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -278,13 +284,13 @@ func TestIrcRepo_ListNetworks(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ListNetworks_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(context.Background(), &mockData1)
+			err := repo.StoreNetwork(t.Context(), &mockData1)
 			assert.NoError(t, err)
-			err = repo.StoreNetwork(context.Background(), &mockData2)
+			err = repo.StoreNetwork(t.Context(), &mockData2)
 			assert.NoError(t, err)
 
 			// Execute
-			listedNetworks, err := repo.ListNetworks(context.Background())
+			listedNetworks, err := repo.ListNetworks(t.Context())
 			assert.NoError(t, err)
 
 			// Verify
@@ -296,14 +302,15 @@ func TestIrcRepo_ListNetworks(t *testing.T) {
 			assert.Equal(t, "ZNetwork", listedNetworks[1].Name)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockData1.ID)
-			_ = repo.DeleteNetwork(context.Background(), mockData2.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockData1.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockData2.ID)
 		})
 	}
 }
 
 func TestIrcRepo_ListChannels(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -312,10 +319,10 @@ func TestIrcRepo_ListChannels(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ListChannels_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(context.Background(), &mockNetwork)
+			err := repo.StoreNetwork(t.Context(), &mockNetwork)
 			assert.NoError(t, err)
 
-			err = repo.StoreChannel(context.Background(), mockNetwork.ID, &mockChannel)
+			err = repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Execute
@@ -327,13 +334,14 @@ func TestIrcRepo_ListChannels(t *testing.T) {
 			assert.Len(t, listedChannels, 1)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_CheckExistingNetwork(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -341,7 +349,7 @@ func TestIrcRepo_CheckExistingNetwork(t *testing.T) {
 
 		t.Run(fmt.Sprintf("CheckExistingNetwork_NoMatch [%s]", dbType), func(t *testing.T) {
 			// Execute
-			existingNetwork, err := repo.CheckExistingNetwork(context.Background(), &mockNetwork)
+			existingNetwork, err := repo.CheckExistingNetwork(t.Context(), &mockNetwork)
 			assert.NoError(t, err)
 
 			// Verify
@@ -350,11 +358,11 @@ func TestIrcRepo_CheckExistingNetwork(t *testing.T) {
 
 		t.Run(fmt.Sprintf("CheckExistingNetwork_MatchFound [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(context.Background(), &mockNetwork)
+			err := repo.StoreNetwork(t.Context(), &mockNetwork)
 			assert.NoError(t, err)
 
 			// Execute
-			existingNetwork, err := repo.CheckExistingNetwork(context.Background(), &mockNetwork)
+			existingNetwork, err := repo.CheckExistingNetwork(t.Context(), &mockNetwork)
 			assert.NoError(t, err)
 
 			// Verify
@@ -364,13 +372,14 @@ func TestIrcRepo_CheckExistingNetwork(t *testing.T) {
 			assert.Equal(t, mockNetwork.Nick, existingNetwork.Nick)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_StoreNetworkChannels(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -379,14 +388,14 @@ func TestIrcRepo_StoreNetworkChannels(t *testing.T) {
 
 		t.Run(fmt.Sprintf("StoreNetworkChannels_DeleteOldChannels [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(context.Background(), &mockNetwork)
+			err := repo.StoreNetwork(t.Context(), &mockNetwork)
 			assert.NoError(t, err)
 
-			err = repo.StoreNetworkChannels(context.Background(), mockNetwork.ID, mockChannels)
+			err = repo.StoreNetworkChannels(t.Context(), mockNetwork.ID, mockChannels)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.StoreNetworkChannels(context.Background(), mockNetwork.ID, []domain.IrcChannel{})
+			err = repo.StoreNetworkChannels(t.Context(), mockNetwork.ID, []domain.IrcChannel{})
 			assert.NoError(t, err)
 
 			// Verify
@@ -395,16 +404,16 @@ func TestIrcRepo_StoreNetworkChannels(t *testing.T) {
 			assert.Len(t, existingChannels, 0)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
 		})
 
 		t.Run(fmt.Sprintf("StoreNetworkChannels_InsertNewChannels [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(context.Background(), &mockNetwork)
+			err := repo.StoreNetwork(t.Context(), &mockNetwork)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.StoreNetworkChannels(context.Background(), mockNetwork.ID, mockChannels)
+			err = repo.StoreNetworkChannels(t.Context(), mockNetwork.ID, mockChannels)
 			assert.NoError(t, err)
 
 			// Verify
@@ -413,13 +422,14 @@ func TestIrcRepo_StoreNetworkChannels(t *testing.T) {
 			assert.Len(t, existingChannels, len(mockChannels))
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_UpdateChannel(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -428,10 +438,10 @@ func TestIrcRepo_UpdateChannel(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdateChannel_Success [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(context.Background(), &mockNetwork)
+			err := repo.StoreNetwork(t.Context(), &mockNetwork)
 			assert.NoError(t, err)
 
-			err = repo.StoreChannel(context.Background(), mockNetwork.ID, &mockChannel)
+			err = repo.StoreChannel(t.Context(), mockNetwork.ID, &mockChannel)
 			assert.NoError(t, err)
 
 			// Update mockChannel properties
@@ -454,13 +464,14 @@ func TestIrcRepo_UpdateChannel(t *testing.T) {
 			assert.Equal(t, updatedChannel.Password, fetchedChannel.Password)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
 		})
 	}
 }
 
 func TestIrcRepo_UpdateInviteCommand(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewIrcRepo(log, db)
@@ -468,7 +479,7 @@ func TestIrcRepo_UpdateInviteCommand(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdateInviteCommand_Success [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreNetwork(context.Background(), &mockNetwork)
+			err := repo.StoreNetwork(t.Context(), &mockNetwork)
 			assert.NoError(t, err)
 
 			// Update invite_command
@@ -477,13 +488,13 @@ func TestIrcRepo_UpdateInviteCommand(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Verify
-			updatedNetwork, err := repo.ListNetworks(context.Background())
+			updatedNetwork, err := repo.ListNetworks(t.Context())
 			assert.NoError(t, err)
 
 			assert.Equal(t, newInviteCommand, updatedNetwork[0].InviteCommand)
 
 			// Cleanup
-			_ = repo.DeleteNetwork(context.Background(), mockNetwork.ID)
+			_ = repo.DeleteNetwork(t.Context(), mockNetwork.ID)
 		})
 	}
 }

--- a/internal/database/migrations/migrations_linux_test.go
+++ b/internal/database/migrations/migrations_linux_test.go
@@ -8,6 +8,7 @@ package migrations_test
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"testing"
@@ -22,6 +23,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// GetFreePort asks the kernel for a free open port that is ready to use.
+func GetFreePort() (port int, err error) {
+	var a *net.TCPAddr
+	if a, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
+		var l *net.TCPListener
+		if l, err = net.ListenTCP("tcp", a); err == nil {
+			defer l.Close()
+			return l.Addr().(*net.TCPAddr).Port, nil
+		}
+	}
+	return
+}
 
 func TestMigrateOldVersionsToLatest(t *testing.T) {
 	// This test downloads an old version of autobrr (v1.30.0), initializes a database with it,
@@ -142,11 +156,14 @@ type = "sqlite"
 
 		configPath := workDir + "/config.toml"
 
+		freePort, err := GetFreePort()
+		require.NoError(t, err, "Failed to get free port")
+
 		var (
 			dbUsername = "postgres"
 			dbPassword = "postgres"
 			dbName     = "autobrr"
-			dbPort     = 9877
+			dbPort     = freePort
 		)
 
 		binariesPath, runtimePath := embeddedPGPaths(t)
@@ -164,7 +181,7 @@ type = "sqlite"
 			StartParameters(map[string]string{"max_connections": "200"}).
 			Logger(pgLogger))
 
-		err := postgres.Start()
+		err = postgres.Start()
 		require.NoError(t, err, "Failed to start postgres")
 
 		dsn := fmt.Sprintf("postgres://%s:%s@localhost:%d/%s?sslmode=disable", dbUsername, dbPassword, dbPort, dbName)

--- a/internal/database/migrations/migrations_linux_test.go
+++ b/internal/database/migrations/migrations_linux_test.go
@@ -149,6 +149,8 @@ type = "sqlite"
 			dbPort     = 9877
 		)
 
+		binariesPath, runtimePath := embeddedPGPaths(t)
+
 		pgLogger := &bytes.Buffer{}
 		postgres := embeddedpostgres.NewDatabase(embeddedpostgres.DefaultConfig().
 			Username(dbUsername).
@@ -156,7 +158,8 @@ type = "sqlite"
 			Database(dbName).
 			Port(uint32(dbPort)).
 			Version(embeddedpostgres.V17).
-			//RuntimePath("/tmp").
+			BinariesPath(binariesPath).
+			RuntimePath(runtimePath).
 			StartTimeout(45 * time.Second).
 			StartParameters(map[string]string{"max_connections": "200"}).
 			Logger(pgLogger))

--- a/internal/database/migrations/postgres_test.go
+++ b/internal/database/migrations/postgres_test.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -23,6 +25,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// embeddedPGPaths returns the directory the Postgres binaries are extracted to along with a
+// runtime directory for a single instance. embedded-postgres wipes its runtime path on every
+// Start, so instances must not share one; the binaries are extracted once and reused. The
+// binaries path is package specific so a cold start can never have two test binaries
+// extracting into the same directory.
+func embeddedPGPaths(t *testing.T) (binariesPath, runtimePath string) {
+	t.Helper()
+
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		cacheDir = os.TempDir()
+	}
+
+	return filepath.Join(cacheDir, "autobrr", "embedded-postgres", "v17-migrations"), t.TempDir()
+}
+
 func setupPGTestDB(t *testing.T) (*database.DB, func(), error) {
 	t.Helper()
 
@@ -33,6 +51,8 @@ func setupPGTestDB(t *testing.T) (*database.DB, func(), error) {
 		dbPort     = 9876
 	)
 
+	binariesPath, runtimePath := embeddedPGPaths(t)
+
 	pgLogger := &bytes.Buffer{}
 	postgres := embeddedpostgres.NewDatabase(embeddedpostgres.DefaultConfig().
 		Username(dbUsername).
@@ -40,8 +60,8 @@ func setupPGTestDB(t *testing.T) (*database.DB, func(), error) {
 		Database(dbName).
 		Port(uint32(dbPort)).
 		Version(embeddedpostgres.V17).
-		//RuntimePath("/tmp").
-		//BinaryRepositoryURL("https://repo.local/central.proxy").
+		BinariesPath(binariesPath).
+		RuntimePath(runtimePath).
 		StartTimeout(45 * time.Second).
 		StartParameters(map[string]string{"max_connections": "200"}).
 		Logger(pgLogger))
@@ -130,6 +150,8 @@ func startEmbeddedPGOnPort(t *testing.T, port int) (*database.DB, func()) {
 		dbName     = "autobrr"
 	)
 
+	binariesPath, runtimePath := embeddedPGPaths(t)
+
 	pgLogger := &bytes.Buffer{}
 	pg := embeddedpostgres.NewDatabase(embeddedpostgres.DefaultConfig().
 		Username(dbUsername).
@@ -137,6 +159,8 @@ func startEmbeddedPGOnPort(t *testing.T, port int) (*database.DB, func()) {
 		Database(dbName).
 		Port(uint32(port)).
 		Version(embeddedpostgres.V17).
+		BinariesPath(binariesPath).
+		RuntimePath(runtimePath).
 		StartTimeout(45 * time.Second).
 		StartParameters(map[string]string{"max_connections": "200"}).
 		Logger(pgLogger))

--- a/internal/database/migrations/postgres_test.go
+++ b/internal/database/migrations/postgres_test.go
@@ -23,45 +23,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// runMigrationTestPostgres executes a pluggable migration test
-func runMigrationTestPostgres(t *testing.T, testCase MigrationTestCase) {
-	db, cleanup := setupTestPostgresDB(t)
-	defer cleanup()
+func setupPGTestDB(t *testing.T) (*database.DB, func(), error) {
+	t.Helper()
 
-	log := logger.New(&domain.Config{LogLevel: "ERROR", LogPath: ""}, nil)
-
-	migrate := migrations.PostgresMigrations(db.Handler, log.With().Logger())
-
-	err := migrate.InitVersionTable()
-	require.NoError(t, err)
-
-	// Run initial schema setup (all migrations up to the target migration - 1)
-	m := migrate.GetUpTo(testCase.MigrationsUntilName)
-
-	err = migrate.RunMigrations(m)
-	require.NoError(t, err)
-
-	// Insert test data
-	if testCase.SetupData != nil {
-		err = testCase.SetupData(db.Handler)
-		require.NoError(t, err, "Failed to setup test data")
-	}
-
-	// Get the migration to run
-	currentMigration, err := migrate.Get(testCase.MigrationToRun)
-	require.NoError(t, err, "Failed to get migration")
-
-	// Run the specific migration being tested
-	err = migrate.RunMigrations([]*migrator.Migration{currentMigration})
-	require.NoError(t, err, "Failed to run target migration")
-
-	// Validate the results
-	if testCase.ValidateResult != nil {
-		testCase.ValidateResult(db.Handler, t)
-	}
-}
-
-func setupPGTestDB() (*database.DB, func(), error) {
 	var (
 		dbUsername = "postgres"
 		dbPassword = "postgres"
@@ -116,34 +80,9 @@ func setupPGTestDB() (*database.DB, func(), error) {
 	return db, cleanup, nil
 }
 
-func setupTestPostgresDB(t *testing.T) (*database.DB, func()) {
-	dsn := "postgres://postgres:postgres@localhost:9876/autobrr?sslmode=disable"
-
-	cfg := &domain.Config{
-		DatabaseType:        "postgres",
-		DatabaseDSN:         dsn,
-		DatabaseAutoMigrate: false,
-	}
-
-	log := logger.New(&domain.Config{LogLevel: "ERROR", LogPath: ""}, nil)
-	db, err := database.NewDB(cfg, log)
-	require.NoError(t, err)
-
-	err = db.Open()
-	require.NoError(t, err)
-
-	cleanup := func() {
-		_ = db.Close()
-		//_ = os.Remove(dbPath)
-	}
-
-	return db, cleanup
-}
-
 // Test full migration sequence
 func TestFullMigrationSequencePostgres(t *testing.T) {
-	//db, cleanup := setupTestPostgresDB(t)
-	db, cleanup, err := setupPGTestDB()
+	db, cleanup, err := setupPGTestDB(t)
 	defer cleanup()
 	require.NoError(t, err)
 

--- a/internal/database/migrations/postgres_test.go
+++ b/internal/database/migrations/postgres_test.go
@@ -198,7 +198,10 @@ func resetPublicSchema(t *testing.T, db *sql.DB) {
 }
 
 func TestRunMigrationTest_Postgres(t *testing.T) {
-	db, cleanup := startEmbeddedPGOnPort(t, 9879)
+	freePort, err := GetFreePort()
+	require.NoError(t, err)
+
+	db, cleanup := startEmbeddedPGOnPort(t, freePort)
 	defer cleanup()
 
 	tests := []MigrationTestCase{

--- a/internal/database/notification_test.go
+++ b/internal/database/notification_test.go
@@ -42,6 +42,8 @@ func getMockNotification() domain.Notification {
 }
 
 func TestNotificationRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -57,7 +59,7 @@ func TestNotificationRepo_Store(t *testing.T) {
 			notification := getMockNotification()
 
 			// Execute
-			err := repo.Store(t.Context(), &notification)
+			err := repo.Store(ctx, &notification)
 
 			// Verify
 			assert.NoError(t, err)
@@ -65,12 +67,14 @@ func TestNotificationRepo_Store(t *testing.T) {
 			assert.Equal(t, mockData.Type, notification.Type)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 	}
 }
 
 func TestNotificationRepo_Update(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -80,7 +84,7 @@ func TestNotificationRepo_Update(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Initial setup and Store
-			err := repo.Store(t.Context(), &mockData)
+			err := repo.Store(ctx, &mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, &mockData)
 
@@ -95,7 +99,7 @@ func TestNotificationRepo_Update(t *testing.T) {
 			updatedMockData.Priority = newPriority
 
 			// Execute Update
-			err = repo.Update(t.Context(), updatedMockData)
+			err = repo.Update(ctx, updatedMockData)
 
 			// Verify
 			assert.NoError(t, err)
@@ -105,12 +109,14 @@ func TestNotificationRepo_Update(t *testing.T) {
 			assert.Equal(t, updatedMockData.Priority, newPriority)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 	}
 }
 
 func TestNotificationRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -122,18 +128,18 @@ func TestNotificationRepo_Delete(t *testing.T) {
 			notification := getMockNotification()
 
 			// Initial setup and Store
-			err := repo.Store(t.Context(), &notification)
+			err := repo.Store(ctx, &notification)
 			assert.NoError(t, err)
 			assert.NotNil(t, notification)
 
 			// Execute Delete
-			err = repo.Delete(t.Context(), notification.ID)
+			err = repo.Delete(ctx, notification.ID)
 
 			// Verify
 			assert.NoError(t, err)
 
 			// Further verification: Attempt to fetch deleted notification, expect an error or a nil result
-			deletedNotification, err := repo.FindByID(t.Context(), notification.ID)
+			deletedNotification, err := repo.FindByID(ctx, notification.ID)
 			assert.Error(t, err)
 			assert.Nil(t, deletedNotification)
 		})
@@ -141,6 +147,8 @@ func TestNotificationRepo_Delete(t *testing.T) {
 }
 
 func TestNotificationRepo_Find(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -154,16 +162,16 @@ func TestNotificationRepo_Find(t *testing.T) {
 			// Setup
 
 			// Clear out any existing notifications
-			notificationsList, _ := repo.List(t.Context())
+			notificationsList, _ := repo.List(ctx)
 			for _, notification := range notificationsList {
-				_ = repo.Delete(t.Context(), notification.ID)
+				_ = repo.Delete(ctx, notification.ID)
 			}
 
-			err := repo.Store(t.Context(), &mockData1)
+			err := repo.Store(ctx, &mockData1)
 			assert.NoError(t, err)
-			err = repo.Store(t.Context(), &mockData2)
+			err = repo.Store(ctx, &mockData2)
 			assert.NoError(t, err)
-			err = repo.Store(t.Context(), &mockData3)
+			err = repo.Store(ctx, &mockData3)
 			assert.NoError(t, err)
 
 			// Setup query params
@@ -173,7 +181,7 @@ func TestNotificationRepo_Find(t *testing.T) {
 			}
 
 			// Execute Find
-			notifications, totalCount, err := repo.Find(t.Context(), params)
+			notifications, totalCount, err := repo.Find(ctx, params)
 
 			// Verify
 			assert.NoError(t, err)
@@ -181,15 +189,17 @@ func TestNotificationRepo_Find(t *testing.T) {
 			assert.Equal(t, 3, totalCount)
 
 			// Cleanup
-			notificationsList, _ = repo.List(t.Context())
+			notificationsList, _ = repo.List(ctx)
 			for _, notification := range notificationsList {
-				_ = repo.Delete(t.Context(), notification.ID)
+				_ = repo.Delete(ctx, notification.ID)
 			}
 		})
 	}
 }
 
 func TestNotificationRepo_FindByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -203,10 +213,10 @@ func TestNotificationRepo_FindByID(t *testing.T) {
 			//notification := getMockNotification()
 
 			assert.NotNil(t, mockData)
-			err := repo.Store(t.Context(), &mockData)
+			err := repo.Store(ctx, &mockData)
 
 			// Execute
-			notification, err := repo.FindByID(t.Context(), mockData.ID)
+			notification, err := repo.FindByID(ctx, mockData.ID)
 
 			// Verify
 			assert.NoError(t, err)
@@ -215,12 +225,14 @@ func TestNotificationRepo_FindByID(t *testing.T) {
 			assert.Equal(t, mockData.Type, notification.Type)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 	}
 }
 
 func TestNotificationRepo_List(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -230,18 +242,18 @@ func TestNotificationRepo_List(t *testing.T) {
 
 		t.Run(fmt.Sprintf("List_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			notificationsList, _ := repo.List(t.Context())
+			notificationsList, _ := repo.List(ctx)
 			for _, notification := range notificationsList {
-				_ = repo.Delete(t.Context(), notification.ID)
+				_ = repo.Delete(ctx, notification.ID)
 			}
 
 			for i := 0; i < 10; i++ {
-				err := repo.Store(t.Context(), &mockData)
+				err := repo.Store(ctx, &mockData)
 				assert.NoError(t, err)
 			}
 
 			// Execute
-			notifications, err := repo.List(t.Context())
+			notifications, err := repo.List(ctx)
 
 			// Verify
 			assert.NoError(t, err)
@@ -249,7 +261,7 @@ func TestNotificationRepo_List(t *testing.T) {
 
 			// Cleanup
 			for _, notification := range notifications {
-				_ = repo.Delete(t.Context(), notification.ID)
+				_ = repo.Delete(ctx, notification.ID)
 			}
 		})
 	}

--- a/internal/database/notification_test.go
+++ b/internal/database/notification_test.go
@@ -6,7 +6,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -43,7 +42,8 @@ func getMockNotification() domain.Notification {
 }
 
 func TestNotificationRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewNotificationRepo(log, db)
@@ -57,7 +57,7 @@ func TestNotificationRepo_Store(t *testing.T) {
 			notification := getMockNotification()
 
 			// Execute
-			err := repo.Store(context.Background(), &notification)
+			err := repo.Store(t.Context(), &notification)
 
 			// Verify
 			assert.NoError(t, err)
@@ -65,13 +65,14 @@ func TestNotificationRepo_Store(t *testing.T) {
 			assert.Equal(t, mockData.Type, notification.Type)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
+			_ = repo.Delete(t.Context(), mockData.ID)
 		})
 	}
 }
 
 func TestNotificationRepo_Update(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewNotificationRepo(log, db)
@@ -79,7 +80,7 @@ func TestNotificationRepo_Update(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Initial setup and Store
-			err := repo.Store(context.Background(), &mockData)
+			err := repo.Store(t.Context(), &mockData)
 			assert.NoError(t, err)
 			assert.NotNil(t, &mockData)
 
@@ -94,7 +95,7 @@ func TestNotificationRepo_Update(t *testing.T) {
 			updatedMockData.Priority = newPriority
 
 			// Execute Update
-			err = repo.Update(context.Background(), updatedMockData)
+			err = repo.Update(t.Context(), updatedMockData)
 
 			// Verify
 			assert.NoError(t, err)
@@ -104,13 +105,14 @@ func TestNotificationRepo_Update(t *testing.T) {
 			assert.Equal(t, updatedMockData.Priority, newPriority)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
+			_ = repo.Delete(t.Context(), mockData.ID)
 		})
 	}
 }
 
 func TestNotificationRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewNotificationRepo(log, db)
@@ -120,18 +122,18 @@ func TestNotificationRepo_Delete(t *testing.T) {
 			notification := getMockNotification()
 
 			// Initial setup and Store
-			err := repo.Store(context.Background(), &notification)
+			err := repo.Store(t.Context(), &notification)
 			assert.NoError(t, err)
 			assert.NotNil(t, notification)
 
 			// Execute Delete
-			err = repo.Delete(context.Background(), notification.ID)
+			err = repo.Delete(t.Context(), notification.ID)
 
 			// Verify
 			assert.NoError(t, err)
 
 			// Further verification: Attempt to fetch deleted notification, expect an error or a nil result
-			deletedNotification, err := repo.FindByID(context.Background(), notification.ID)
+			deletedNotification, err := repo.FindByID(t.Context(), notification.ID)
 			assert.Error(t, err)
 			assert.Nil(t, deletedNotification)
 		})
@@ -139,7 +141,8 @@ func TestNotificationRepo_Delete(t *testing.T) {
 }
 
 func TestNotificationRepo_Find(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewNotificationRepo(log, db)
@@ -151,16 +154,16 @@ func TestNotificationRepo_Find(t *testing.T) {
 			// Setup
 
 			// Clear out any existing notifications
-			notificationsList, _ := repo.List(context.Background())
+			notificationsList, _ := repo.List(t.Context())
 			for _, notification := range notificationsList {
-				_ = repo.Delete(context.Background(), notification.ID)
+				_ = repo.Delete(t.Context(), notification.ID)
 			}
 
-			err := repo.Store(context.Background(), &mockData1)
+			err := repo.Store(t.Context(), &mockData1)
 			assert.NoError(t, err)
-			err = repo.Store(context.Background(), &mockData2)
+			err = repo.Store(t.Context(), &mockData2)
 			assert.NoError(t, err)
-			err = repo.Store(context.Background(), &mockData3)
+			err = repo.Store(t.Context(), &mockData3)
 			assert.NoError(t, err)
 
 			// Setup query params
@@ -170,7 +173,7 @@ func TestNotificationRepo_Find(t *testing.T) {
 			}
 
 			// Execute Find
-			notifications, totalCount, err := repo.Find(context.Background(), params)
+			notifications, totalCount, err := repo.Find(t.Context(), params)
 
 			// Verify
 			assert.NoError(t, err)
@@ -178,16 +181,17 @@ func TestNotificationRepo_Find(t *testing.T) {
 			assert.Equal(t, 3, totalCount)
 
 			// Cleanup
-			notificationsList, _ = repo.List(context.Background())
+			notificationsList, _ = repo.List(t.Context())
 			for _, notification := range notificationsList {
-				_ = repo.Delete(context.Background(), notification.ID)
+				_ = repo.Delete(t.Context(), notification.ID)
 			}
 		})
 	}
 }
 
 func TestNotificationRepo_FindByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewNotificationRepo(log, db)
@@ -199,10 +203,10 @@ func TestNotificationRepo_FindByID(t *testing.T) {
 			//notification := getMockNotification()
 
 			assert.NotNil(t, mockData)
-			err := repo.Store(context.Background(), &mockData)
+			err := repo.Store(t.Context(), &mockData)
 
 			// Execute
-			notification, err := repo.FindByID(context.Background(), mockData.ID)
+			notification, err := repo.FindByID(t.Context(), mockData.ID)
 
 			// Verify
 			assert.NoError(t, err)
@@ -211,13 +215,14 @@ func TestNotificationRepo_FindByID(t *testing.T) {
 			assert.Equal(t, mockData.Type, notification.Type)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
+			_ = repo.Delete(t.Context(), mockData.ID)
 		})
 	}
 }
 
 func TestNotificationRepo_List(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewNotificationRepo(log, db)
@@ -225,18 +230,18 @@ func TestNotificationRepo_List(t *testing.T) {
 
 		t.Run(fmt.Sprintf("List_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			notificationsList, _ := repo.List(context.Background())
+			notificationsList, _ := repo.List(t.Context())
 			for _, notification := range notificationsList {
-				_ = repo.Delete(context.Background(), notification.ID)
+				_ = repo.Delete(t.Context(), notification.ID)
 			}
 
 			for i := 0; i < 10; i++ {
-				err := repo.Store(context.Background(), &mockData)
+				err := repo.Store(t.Context(), &mockData)
 				assert.NoError(t, err)
 			}
 
 			// Execute
-			notifications, err := repo.List(context.Background())
+			notifications, err := repo.List(t.Context())
 
 			// Verify
 			assert.NoError(t, err)
@@ -244,7 +249,7 @@ func TestNotificationRepo_List(t *testing.T) {
 
 			// Cleanup
 			for _, notification := range notifications {
-				_ = repo.Delete(context.Background(), notification.ID)
+				_ = repo.Delete(t.Context(), notification.ID)
 			}
 		})
 	}

--- a/internal/database/proxy_test.go
+++ b/internal/database/proxy_test.go
@@ -30,31 +30,32 @@ func getMockProxy() *domain.Proxy {
 }
 
 func TestProxyRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewProxyRepo(log, db)
 		mockData := getMockProxy()
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(context.Background(), mockData)
+			err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(context.Background())
+			proxies, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 			assert.Equal(t, mockData.Name, proxies[0].Name)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), mockData.ID)
+			_ = repo.Delete(t.Context(), mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Missing_or_empty_fields [%s]", dbType), func(t *testing.T) {
 			mockData := domain.Proxy{}
-			err := repo.Store(context.Background(), &mockData)
+			err := repo.Store(t.Context(), &mockData)
 			assert.Error(t, err)
 
-			proxies, err := repo.List(context.Background())
+			proxies, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.Empty(t, proxies)
 			//assert.Nil(t, proxies)
@@ -64,7 +65,7 @@ func TestProxyRepo_Store(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
 			defer cancel()
 
 			err := repo.Store(ctx, mockData)
@@ -74,14 +75,15 @@ func TestProxyRepo_Store(t *testing.T) {
 }
 
 func TestProxyRepo_Update(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewProxyRepo(log, db)
 		mockData := getMockProxy()
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(context.Background(), mockData)
+			err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Update mockData
@@ -90,22 +92,22 @@ func TestProxyRepo_Update(t *testing.T) {
 			updatedProxy.Enabled = false
 
 			// Execute
-			err = repo.Update(context.Background(), updatedProxy)
+			err = repo.Update(t.Context(), updatedProxy)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(context.Background())
+			proxies, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 			assert.Equal(t, "Updated Proxy", proxies[0].Name)
 			assert.Equal(t, false, proxies[0].Enabled)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), proxies[0].ID)
+			_ = repo.Delete(t.Context(), proxies[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("Update_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
 			mockData.ID = -1
-			err := repo.Update(context.Background(), mockData)
+			err := repo.Update(t.Context(), mockData)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrUpdateFailed)
 		})
@@ -113,33 +115,34 @@ func TestProxyRepo_Update(t *testing.T) {
 }
 
 func TestProxyRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewProxyRepo(log, db)
 		mockData := getMockProxy()
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(context.Background(), mockData)
+			err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(context.Background())
+			proxies, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 			assert.Equal(t, mockData.Name, proxies[0].Name)
 
 			// Execute
-			err = repo.Delete(context.Background(), proxies[0].ID)
+			err = repo.Delete(t.Context(), proxies[0].ID)
 			assert.NoError(t, err)
 
 			// Verify that the proxy is deleted and return error ErrRecordNotFound
-			proxy, err := repo.FindByID(context.Background(), proxies[0].ID)
+			proxy, err := repo.FindByID(t.Context(), proxies[0].ID)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 			assert.Nil(t, proxy)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_No_Record [%s]", dbType), func(t *testing.T) {
-			err := repo.Delete(context.Background(), 9999)
+			err := repo.Delete(t.Context(), 9999)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrDeleteFailed)
 		})
@@ -147,37 +150,38 @@ func TestProxyRepo_Delete(t *testing.T) {
 }
 
 func TestProxyRepo_ToggleEnabled(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewProxyRepo(log, db)
 		mockData := getMockProxy()
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(context.Background(), mockData)
+			err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(context.Background())
+			proxies, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 			assert.Equal(t, true, proxies[0].Enabled)
 
 			// Execute
-			err = repo.ToggleEnabled(context.Background(), mockData.ID, false)
+			err = repo.ToggleEnabled(t.Context(), mockData.ID, false)
 			assert.NoError(t, err)
 
 			// Verify that the proxy is updated
-			proxy, err := repo.FindByID(context.Background(), proxies[0].ID)
+			proxy, err := repo.FindByID(t.Context(), proxies[0].ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, proxy)
 			assert.Equal(t, false, proxy.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), proxies[0].ID)
+			_ = repo.Delete(t.Context(), proxies[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
-			err := repo.ToggleEnabled(context.Background(), -1, false)
+			err := repo.ToggleEnabled(t.Context(), -1, false)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrUpdateFailed)
 		})
@@ -185,33 +189,34 @@ func TestProxyRepo_ToggleEnabled(t *testing.T) {
 }
 
 func TestProxyRepo_FindByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewProxyRepo(log, db)
 		mockData := getMockProxy()
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(context.Background(), mockData)
+			err := repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(context.Background())
+			proxies, err := repo.List(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 
 			// Execute
-			proxy, err := repo.FindByID(context.Background(), proxies[0].ID)
+			proxy, err := repo.FindByID(t.Context(), proxies[0].ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, proxy)
 			assert.Equal(t, proxies[0].ID, proxy.ID)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), proxies[0].ID)
+			_ = repo.Delete(t.Context(), proxies[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
 			// Test using an invalid ID
-			proxy, err := repo.FindByID(context.Background(), -1)
+			proxy, err := repo.FindByID(t.Context(), -1)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound) // should return an error
 			assert.Nil(t, proxy)                             // should be nil
 		})

--- a/internal/database/proxy_test.go
+++ b/internal/database/proxy_test.go
@@ -30,6 +30,8 @@ func getMockProxy() *domain.Proxy {
 }
 
 func TestProxyRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -38,24 +40,24 @@ func TestProxyRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(t.Context())
+			proxies, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 			assert.Equal(t, mockData.Name, proxies[0].Name)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), mockData.ID)
+			_ = repo.Delete(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Missing_or_empty_fields [%s]", dbType), func(t *testing.T) {
 			mockData := domain.Proxy{}
-			err := repo.Store(t.Context(), &mockData)
+			err := repo.Store(ctx, &mockData)
 			assert.Error(t, err)
 
-			proxies, err := repo.List(t.Context())
+			proxies, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.Empty(t, proxies)
 			//assert.Nil(t, proxies)
@@ -65,16 +67,18 @@ func TestProxyRepo_Store(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("Store_Fails_With_Context_Timeout [%s]", dbType), func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
+			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Nanosecond)
 			defer cancel()
 
-			err := repo.Store(ctx, mockData)
+			err := repo.Store(timeoutCtx, mockData)
 			assert.Error(t, err)
 		})
 	}
 }
 
 func TestProxyRepo_Update(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -83,7 +87,7 @@ func TestProxyRepo_Update(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Update mockData
@@ -92,22 +96,22 @@ func TestProxyRepo_Update(t *testing.T) {
 			updatedProxy.Enabled = false
 
 			// Execute
-			err = repo.Update(t.Context(), updatedProxy)
+			err = repo.Update(ctx, updatedProxy)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(t.Context())
+			proxies, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 			assert.Equal(t, "Updated Proxy", proxies[0].Name)
 			assert.Equal(t, false, proxies[0].Enabled)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), proxies[0].ID)
+			_ = repo.Delete(ctx, proxies[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("Update_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
 			mockData.ID = -1
-			err := repo.Update(t.Context(), mockData)
+			err := repo.Update(ctx, mockData)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrUpdateFailed)
 		})
@@ -115,6 +119,8 @@ func TestProxyRepo_Update(t *testing.T) {
 }
 
 func TestProxyRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -123,26 +129,26 @@ func TestProxyRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(t.Context())
+			proxies, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 			assert.Equal(t, mockData.Name, proxies[0].Name)
 
 			// Execute
-			err = repo.Delete(t.Context(), proxies[0].ID)
+			err = repo.Delete(ctx, proxies[0].ID)
 			assert.NoError(t, err)
 
 			// Verify that the proxy is deleted and return error ErrRecordNotFound
-			proxy, err := repo.FindByID(t.Context(), proxies[0].ID)
+			proxy, err := repo.FindByID(ctx, proxies[0].ID)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 			assert.Nil(t, proxy)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_No_Record [%s]", dbType), func(t *testing.T) {
-			err := repo.Delete(t.Context(), 9999)
+			err := repo.Delete(ctx, 9999)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrDeleteFailed)
 		})
@@ -150,6 +156,8 @@ func TestProxyRepo_Delete(t *testing.T) {
 }
 
 func TestProxyRepo_ToggleEnabled(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -158,30 +166,30 @@ func TestProxyRepo_ToggleEnabled(t *testing.T) {
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(t.Context())
+			proxies, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 			assert.Equal(t, true, proxies[0].Enabled)
 
 			// Execute
-			err = repo.ToggleEnabled(t.Context(), mockData.ID, false)
+			err = repo.ToggleEnabled(ctx, mockData.ID, false)
 			assert.NoError(t, err)
 
 			// Verify that the proxy is updated
-			proxy, err := repo.FindByID(t.Context(), proxies[0].ID)
+			proxy, err := repo.FindByID(ctx, proxies[0].ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, proxy)
 			assert.Equal(t, false, proxy.Enabled)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), proxies[0].ID)
+			_ = repo.Delete(ctx, proxies[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
-			err := repo.ToggleEnabled(t.Context(), -1, false)
+			err := repo.ToggleEnabled(ctx, -1, false)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrUpdateFailed)
 		})
@@ -189,6 +197,8 @@ func TestProxyRepo_ToggleEnabled(t *testing.T) {
 }
 
 func TestProxyRepo_FindByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -197,26 +207,26 @@ func TestProxyRepo_FindByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Store(t.Context(), mockData)
+			err := repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			proxies, err := repo.List(t.Context())
+			proxies, err := repo.List(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, proxies)
 
 			// Execute
-			proxy, err := repo.FindByID(t.Context(), proxies[0].ID)
+			proxy, err := repo.FindByID(ctx, proxies[0].ID)
 			assert.NoError(t, err)
 			assert.NotNil(t, proxy)
 			assert.Equal(t, proxies[0].ID, proxy.ID)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), proxies[0].ID)
+			_ = repo.Delete(ctx, proxies[0].ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_Invalid_ID [%s]", dbType), func(t *testing.T) {
 			// Test using an invalid ID
-			proxy, err := repo.FindByID(t.Context(), -1)
+			proxy, err := repo.FindByID(ctx, -1)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound) // should return an error
 			assert.Nil(t, proxy)                             // should be nil
 		})

--- a/internal/database/release_test.go
+++ b/internal/database/release_test.go
@@ -76,6 +76,8 @@ func getMockReleaseActionStatus() *domain.ReleaseActionStatus {
 }
 
 func TestReleaseRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -92,14 +94,14 @@ func TestReleaseRepo_Store(t *testing.T) {
 		t.Run(fmt.Sprintf("StoreReleaseActionStatus_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -108,31 +110,33 @@ func TestReleaseRepo_Store(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Execute
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(t.Context(), actionMockData)
+			err = actionRepo.Store(ctx, actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(ctx, releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.NotEqual(t, int64(0), mockData.ID)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_StoreReleaseActionStatus(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -149,14 +153,14 @@ func TestReleaseRepo_StoreReleaseActionStatus(t *testing.T) {
 		t.Run(fmt.Sprintf("StoreReleaseActionStatus_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -165,31 +169,33 @@ func TestReleaseRepo_StoreReleaseActionStatus(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Execute
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(t.Context(), actionMockData)
+			err = actionRepo.Store(ctx, actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(ctx, releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.NotEqual(t, int64(0), releaseActionMockData.ID)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_Find(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -206,14 +212,14 @@ func TestReleaseRepo_Find(t *testing.T) {
 		t.Run(fmt.Sprintf("FindReleases_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -222,7 +228,7 @@ func TestReleaseRepo_Find(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Execute
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Search with query params
@@ -235,7 +241,7 @@ func TestReleaseRepo_Find(t *testing.T) {
 				Search: "",
 			}
 
-			resp, err := repo.Find(t.Context(), queryParams)
+			resp, err := repo.Find(ctx, queryParams)
 
 			// Verify
 			assert.NotNil(t, resp)
@@ -244,27 +250,29 @@ func TestReleaseRepo_Find(t *testing.T) {
 
 			// Search by type
 			queryParams.Search = "type:movie"
-			resp, err = repo.Find(t.Context(), queryParams)
+			resp, err = repo.Find(ctx, queryParams)
 			assert.NoError(t, err)
 			assert.NotNil(t, resp)
 			assert.Equal(t, uint64(1), resp.TotalCount)
 
 			// Search by type with no matches
 			queryParams.Search = "type:episode"
-			resp, err = repo.Find(t.Context(), queryParams)
+			resp, err = repo.Find(ctx, queryParams)
 			assert.NoError(t, err)
 			assert.NotNil(t, resp)
 			assert.Equal(t, uint64(0), resp.TotalCount)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_FindRecent(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -281,14 +289,14 @@ func TestReleaseRepo_FindRecent(t *testing.T) {
 		t.Run(fmt.Sprintf("FindRecent_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -297,24 +305,26 @@ func TestReleaseRepo_FindRecent(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Execute
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
 
-			resp, err := repo.Find(t.Context(), domain.ReleaseQueryParams{Limit: 10})
+			resp, err := repo.Find(ctx, domain.ReleaseQueryParams{Limit: 10})
 
 			// Verify
 			assert.NotNil(t, resp.Data)
 			assert.Lenf(t, resp.Data, 1, "Expected 1 release, got %d", len(resp.Data))
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_GetIndexerOptions(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -331,14 +341,14 @@ func TestReleaseRepo_GetIndexerOptions(t *testing.T) {
 		t.Run(fmt.Sprintf("GetIndexerOptions_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -346,35 +356,37 @@ func TestReleaseRepo_GetIndexerOptions(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(t.Context(), actionMockData)
+			err = actionRepo.Store(ctx, actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(ctx, releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			options, err := repo.GetIndexerOptions(t.Context())
+			options, err := repo.GetIndexerOptions(ctx)
 
 			// Verify
 			assert.NotNil(t, options)
 			assert.Len(t, options, 1)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_GetActionStatusByReleaseID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -391,14 +403,14 @@ func TestReleaseRepo_GetActionStatusByReleaseID(t *testing.T) {
 		t.Run(fmt.Sprintf("GetActionStatusByReleaseID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -406,20 +418,20 @@ func TestReleaseRepo_GetActionStatusByReleaseID(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(t.Context(), actionMockData)
+			err = actionRepo.Store(ctx, actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(ctx, releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			actionStatus, err := repo.GetActionStatus(t.Context(), &domain.GetReleaseActionStatusRequest{Id: int(releaseActionMockData.ID)})
+			actionStatus, err := repo.GetActionStatus(ctx, &domain.GetReleaseActionStatusRequest{Id: int(releaseActionMockData.ID)})
 
 			// Verify
 			assert.NoError(t, err)
@@ -427,15 +439,17 @@ func TestReleaseRepo_GetActionStatusByReleaseID(t *testing.T) {
 			assert.Equal(t, releaseActionMockData.ID, actionStatus.ID)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_Get(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -452,14 +466,14 @@ func TestReleaseRepo_Get(t *testing.T) {
 		t.Run(fmt.Sprintf("Get_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -467,20 +481,20 @@ func TestReleaseRepo_Get(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(t.Context(), actionMockData)
+			err = actionRepo.Store(ctx, actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(ctx, releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			release, err := repo.Get(t.Context(), &domain.GetReleaseRequest{Id: int(mockData.ID)})
+			release, err := repo.Get(ctx, &domain.GetReleaseRequest{Id: int(mockData.ID)})
 
 			// Verify
 			assert.NoError(t, err)
@@ -488,15 +502,17 @@ func TestReleaseRepo_Get(t *testing.T) {
 			assert.Equal(t, mockData.ID, release.ID)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_Stats(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -513,14 +529,14 @@ func TestReleaseRepo_Stats(t *testing.T) {
 		t.Run(fmt.Sprintf("Stats_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -528,20 +544,20 @@ func TestReleaseRepo_Stats(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(t.Context(), actionMockData)
+			err = actionRepo.Store(ctx, actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(ctx, releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			stats, err := repo.Stats(t.Context())
+			stats, err := repo.Stats(ctx)
 
 			// Verify
 			assert.NoError(t, err)
@@ -554,15 +570,17 @@ func TestReleaseRepo_Stats(t *testing.T) {
 			assert.Equal(t, int64(0), stats.PushErrorCount)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_StatsDashboard(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -579,13 +597,13 @@ func TestReleaseRepo_StatsDashboard(t *testing.T) {
 		t.Run(fmt.Sprintf("StatsDashboard_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -593,20 +611,20 @@ func TestReleaseRepo_StatsDashboard(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(t.Context(), actionMockData)
+			err = actionRepo.Store(ctx, actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(ctx, releaseActionMockData)
 			assert.NoError(t, err)
 
 			for _, days := range []int{30, 0} {
-				activity, err := repo.StatsActivity(t.Context(), days)
+				activity, err := repo.StatsActivity(ctx, days)
 				assert.NoError(t, err)
 				assert.Equal(t, days, activity.Days)
 				assert.NotEmpty(t, activity.Daily)
@@ -615,11 +633,11 @@ func TestReleaseRepo_StatsDashboard(t *testing.T) {
 				assert.Equal(t, int64(1), today.PushApprovedCount)
 				assert.Equal(t, int64(0), today.PushRejectedCount)
 
-				volume, err := repo.StatsVolume(t.Context(), days)
+				volume, err := repo.StatsVolume(ctx, days)
 				assert.NoError(t, err)
 				assert.NotEmpty(t, volume.Daily)
 
-				heatmap, err := repo.StatsHeatmap(t.Context(), days)
+				heatmap, err := repo.StatsHeatmap(ctx, days)
 				assert.NoError(t, err)
 				assert.Len(t, heatmap.Heatmap, 168)
 				var heatmapTotal int64
@@ -628,27 +646,29 @@ func TestReleaseRepo_StatsDashboard(t *testing.T) {
 				}
 				assert.Equal(t, int64(1), heatmapTotal)
 
-				indexers, err := repo.StatsTopIndexers(t.Context(), days)
+				indexers, err := repo.StatsTopIndexers(ctx, days)
 				assert.NoError(t, err)
 				assert.Len(t, indexers.Top, 1)
 				assert.Equal(t, int64(1), indexers.Top[0].MatchedCount)
 				assert.Equal(t, int64(1), indexers.Top[0].PushApprovedCount)
 
-				filters, err := repo.StatsTopFilters(t.Context(), days)
+				filters, err := repo.StatsTopFilters(ctx, days)
 				assert.NoError(t, err)
 				assert.NotEmpty(t, filters.Top)
 			}
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -660,20 +680,20 @@ func TestReleaseRepo_Delete(t *testing.T) {
 
 		// Setup shared dependencies
 		mock := getMockDownloadClient()
-		err := downloadClientRepo.Store(t.Context(), &mock)
+		err := downloadClientRepo.Store(ctx, &mock)
 		assert.NoError(t, err)
 
-		err = filterRepo.Store(t.Context(), getMockFilter())
+		err = filterRepo.Store(ctx, getMockFilter())
 		assert.NoError(t, err)
 
-		createdFilters, err := filterRepo.ListFilters(t.Context())
+		createdFilters, err := filterRepo.ListFilters(ctx)
 		assert.NoError(t, err)
 		assert.NotNil(t, createdFilters)
 
 		actionMock := getMockAction()
 		actionMock.FilterID = createdFilters[0].ID
 		actionMock.ClientID = mock.ID
-		err = actionRepo.Store(t.Context(), actionMock)
+		err = actionRepo.Store(ctx, actionMock)
 		assert.NoError(t, err)
 
 		tests := []struct {
@@ -710,7 +730,6 @@ func TestReleaseRepo_Delete(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("Delete_%s [%s]", tt.name, dbType), func(t *testing.T) {
-				ctx := t.Context()
 
 				// Setup - create test-specific releases
 				switch tt.name {
@@ -841,13 +860,15 @@ func TestReleaseRepo_Delete(t *testing.T) {
 		}
 
 		// Cleanup shared resources
-		_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMock.ID})
-		_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-		_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+		_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMock.ID})
+		_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+		_ = downloadClientRepo.Delete(ctx, mock.ID)
 	}
 }
 
 func TestReleaseRepo_CheckSmartEpisodeCanDownloadShow(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -864,14 +885,14 @@ func TestReleaseRepo_CheckSmartEpisodeCanDownloadShow(t *testing.T) {
 		t.Run(fmt.Sprintf("Check_Smart_Episode_Can_Download [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(t.Context(), &mock)
+			err := downloadClientRepo.Store(ctx, &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(t.Context(), getMockFilter())
+			err = filterRepo.Store(ctx, getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(t.Context())
+			createdFilters, err := filterRepo.ListFilters(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -879,16 +900,16 @@ func TestReleaseRepo_CheckSmartEpisodeCanDownloadShow(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(t.Context(), mockData)
+			err = repo.Store(ctx, mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(t.Context(), actionMockData)
+			err = actionRepo.Store(ctx, actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(ctx, releaseActionMockData)
 			assert.NoError(t, err)
 
 			params := &domain.SmartEpisodeParams{
@@ -901,17 +922,17 @@ func TestReleaseRepo_CheckSmartEpisodeCanDownloadShow(t *testing.T) {
 			}
 
 			// Execute
-			canDownload, err := repo.CheckSmartEpisodeCanDownload(t.Context(), params)
+			canDownload, err := repo.CheckSmartEpisodeCanDownload(ctx, params)
 
 			// Verify
 			assert.NoError(t, err)
 			assert.True(t, canDownload)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
 		})
 	}
 }
@@ -1045,6 +1066,8 @@ func getMockFilterDuplicates() *domain.Filter {
 }
 
 func TestReleaseRepo_CheckIsDuplicateRelease(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -1063,16 +1086,16 @@ func TestReleaseRepo_CheckIsDuplicateRelease(t *testing.T) {
 		filterMock := getMockFilterDuplicates()
 
 		// Setup
-		err := filterRepo.Store(t.Context(), filterMock)
+		err := filterRepo.Store(ctx, filterMock)
 		assert.NoError(t, err)
 
-		createdFilters, err := filterRepo.ListFilters(t.Context())
+		createdFilters, err := filterRepo.ListFilters(ctx)
 		assert.NoError(t, err)
 		assert.NotNil(t, createdFilters)
 
 		actionMock.FilterID = filterMock.ID
 
-		err = actionRepo.Store(t.Context(), actionMock)
+		err = actionRepo.Store(ctx, actionMock)
 		assert.NoError(t, err)
 
 		type fields struct {
@@ -1587,7 +1610,6 @@ func TestReleaseRepo_CheckIsDuplicateRelease(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("Check_Is_Duplicate_Release %s [%s]", tt.name, dbType), func(t *testing.T) {
-				ctx := t.Context()
 
 				// Setup
 				for _, rel := range tt.fields.releaseTitles {
@@ -1637,9 +1659,9 @@ func TestReleaseRepo_CheckIsDuplicateRelease(t *testing.T) {
 		}
 
 		// Cleanup
-		//_ = releaseRepo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
-		_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMock.ID})
-		_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+		//_ = releaseRepo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+		_ = actionRepo.Delete(ctx, &domain.DeleteActionRequest{ActionId: actionMock.ID})
+		_ = filterRepo.Delete(ctx, createdFilters[0].ID)
 	}
 }
 
@@ -1658,6 +1680,8 @@ func getMockReleaseCleanupJob() *domain.ReleaseCleanupJob {
 }
 
 func TestReleaseCleanupJobRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -1666,12 +1690,12 @@ func TestReleaseCleanupJobRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.StoreCleanupJob(t.Context(), mockData)
+			err := repo.StoreCleanupJob(ctx, mockData)
 			assert.NoError(t, err)
 			assert.NotZero(t, mockData.ID)
 
 			// Verify
-			job, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
+			job, err := repo.FindCleanupJobByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, mockData.Name, job.Name)
 			assert.Equal(t, mockData.Enabled, job.Enabled)
@@ -1681,12 +1705,14 @@ func TestReleaseCleanupJobRepo_Store(t *testing.T) {
 			assert.Equal(t, mockData.Statuses, job.Statuses)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
+			_ = repo.DeleteCleanupJob(ctx, mockData.ID)
 		})
 	}
 }
 
 func TestReleaseCleanupJobRepo_FindByID(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -1695,22 +1721,22 @@ func TestReleaseCleanupJobRepo_FindByID(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreCleanupJob(t.Context(), mockData)
+			err := repo.StoreCleanupJob(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			job, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
+			job, err := repo.FindCleanupJobByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, mockData.Name, job.Name)
 			assert.Equal(t, mockData.ID, job.ID)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
+			_ = repo.DeleteCleanupJob(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_Not_Found [%s]", dbType), func(t *testing.T) {
 			// Execute
-			_, err := repo.FindCleanupJobByID(t.Context(), 99999)
+			_, err := repo.FindCleanupJobByID(ctx, 99999)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
@@ -1718,6 +1744,8 @@ func TestReleaseCleanupJobRepo_FindByID(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_List(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -1732,15 +1760,15 @@ func TestReleaseCleanupJobRepo_List(t *testing.T) {
 			job3 := getMockReleaseCleanupJob()
 			job3.Name = "Job 3"
 
-			err := repo.StoreCleanupJob(t.Context(), job1)
+			err := repo.StoreCleanupJob(ctx, job1)
 			assert.NoError(t, err)
-			err = repo.StoreCleanupJob(t.Context(), job2)
+			err = repo.StoreCleanupJob(ctx, job2)
 			assert.NoError(t, err)
-			err = repo.StoreCleanupJob(t.Context(), job3)
+			err = repo.StoreCleanupJob(ctx, job3)
 			assert.NoError(t, err)
 
 			// Execute
-			jobs, err := repo.ListCleanupJobs(t.Context())
+			jobs, err := repo.ListCleanupJobs(ctx)
 			assert.NoError(t, err)
 			assert.GreaterOrEqual(t, len(jobs), 3)
 
@@ -1754,14 +1782,14 @@ func TestReleaseCleanupJobRepo_List(t *testing.T) {
 			assert.Equal(t, 3, foundJobs)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(t.Context(), job1.ID)
-			_ = repo.DeleteCleanupJob(t.Context(), job2.ID)
-			_ = repo.DeleteCleanupJob(t.Context(), job3.ID)
+			_ = repo.DeleteCleanupJob(ctx, job1.ID)
+			_ = repo.DeleteCleanupJob(ctx, job2.ID)
+			_ = repo.DeleteCleanupJob(ctx, job3.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Empty_Table [%s]", dbType), func(t *testing.T) {
 			// Execute
-			jobs, err := repo.ListCleanupJobs(t.Context())
+			jobs, err := repo.ListCleanupJobs(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, jobs)
 		})
@@ -1769,6 +1797,8 @@ func TestReleaseCleanupJobRepo_List(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_Update(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -1777,7 +1807,7 @@ func TestReleaseCleanupJobRepo_Update(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreCleanupJob(t.Context(), mockData)
+			err := repo.StoreCleanupJob(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Update data
@@ -1789,11 +1819,11 @@ func TestReleaseCleanupJobRepo_Update(t *testing.T) {
 			mockData.Statuses = "PUSH_APPROVED"
 
 			// Execute
-			err = repo.UpdateCleanupJob(t.Context(), mockData)
+			err = repo.UpdateCleanupJob(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedJob, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
+			updatedJob, err := repo.FindCleanupJobByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, "Updated Name", updatedJob.Name)
 			assert.Equal(t, "0 4 * * *", updatedJob.Schedule)
@@ -1803,7 +1833,7 @@ func TestReleaseCleanupJobRepo_Update(t *testing.T) {
 			assert.Equal(t, "PUSH_APPROVED", updatedJob.Statuses)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
+			_ = repo.DeleteCleanupJob(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("Update_Fails_Non_Existing_Job [%s]", dbType), func(t *testing.T) {
@@ -1812,7 +1842,7 @@ func TestReleaseCleanupJobRepo_Update(t *testing.T) {
 			nonExistingJob.ID = 99999
 
 			// Execute
-			err := repo.UpdateCleanupJob(t.Context(), nonExistingJob)
+			err := repo.UpdateCleanupJob(ctx, nonExistingJob)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
@@ -1820,6 +1850,8 @@ func TestReleaseCleanupJobRepo_Update(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_UpdateLastRun(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -1828,7 +1860,7 @@ func TestReleaseCleanupJobRepo_UpdateLastRun(t *testing.T) {
 
 		t.Run(fmt.Sprintf("UpdateLastRun_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreCleanupJob(t.Context(), mockData)
+			err := repo.StoreCleanupJob(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Update last run data
@@ -1838,18 +1870,18 @@ func TestReleaseCleanupJobRepo_UpdateLastRun(t *testing.T) {
 			mockData.LastRunData = `{"error": "test error"}`
 
 			// Execute
-			err = repo.UpdateCleanupJobLastRun(t.Context(), mockData)
+			err = repo.UpdateCleanupJobLastRun(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedJob, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
+			updatedJob, err := repo.FindCleanupJobByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, domain.ReleaseCleanupStatusError, updatedJob.LastRunStatus)
 			assert.Equal(t, `{"error": "test error"}`, updatedJob.LastRunData)
 			assert.WithinDuration(t, newLastRun, updatedJob.LastRun, 2*time.Second)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
+			_ = repo.DeleteCleanupJob(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("UpdateLastRun_Fails_Non_Existing_Job [%s]", dbType), func(t *testing.T) {
@@ -1858,7 +1890,7 @@ func TestReleaseCleanupJobRepo_UpdateLastRun(t *testing.T) {
 			nonExistingJob.ID = 99999
 
 			// Execute
-			err := repo.UpdateCleanupJobLastRun(t.Context(), nonExistingJob)
+			err := repo.UpdateCleanupJobLastRun(ctx, nonExistingJob)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
@@ -1866,6 +1898,8 @@ func TestReleaseCleanupJobRepo_UpdateLastRun(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_ToggleEnabled(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -1875,34 +1909,34 @@ func TestReleaseCleanupJobRepo_ToggleEnabled(t *testing.T) {
 		t.Run(fmt.Sprintf("ToggleEnabled_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData.Enabled = true
-			err := repo.StoreCleanupJob(t.Context(), mockData)
+			err := repo.StoreCleanupJob(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Execute - disable
-			err = repo.CleanupJobToggleEnabled(t.Context(), mockData.ID, false)
+			err = repo.CleanupJobToggleEnabled(ctx, mockData.ID, false)
 			assert.NoError(t, err)
 
 			// Verify
-			job, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
+			job, err := repo.FindCleanupJobByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.False(t, job.Enabled)
 
 			// Execute - enable
-			err = repo.CleanupJobToggleEnabled(t.Context(), mockData.ID, true)
+			err = repo.CleanupJobToggleEnabled(ctx, mockData.ID, true)
 			assert.NoError(t, err)
 
 			// Verify
-			job, err = repo.FindCleanupJobByID(t.Context(), mockData.ID)
+			job, err = repo.FindCleanupJobByID(ctx, mockData.ID)
 			assert.NoError(t, err)
 			assert.True(t, job.Enabled)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
+			_ = repo.DeleteCleanupJob(ctx, mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Fails_Non_Existing_Job [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.CleanupJobToggleEnabled(t.Context(), 99999, false)
+			err := repo.CleanupJobToggleEnabled(ctx, 99999, false)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
@@ -1910,6 +1944,8 @@ func TestReleaseCleanupJobRepo_ToggleEnabled(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -1918,22 +1954,22 @@ func TestReleaseCleanupJobRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreCleanupJob(t.Context(), mockData)
+			err := repo.StoreCleanupJob(ctx, mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.DeleteCleanupJob(t.Context(), mockData.ID)
+			err = repo.DeleteCleanupJob(ctx, mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
-			_, err = repo.FindCleanupJobByID(t.Context(), mockData.ID)
+			_, err = repo.FindCleanupJobByID(ctx, mockData.ID)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_Non_Existing_Job [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.DeleteCleanupJob(t.Context(), 99999)
+			err := repo.DeleteCleanupJob(ctx, 99999)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})

--- a/internal/database/release_test.go
+++ b/internal/database/release_test.go
@@ -6,7 +6,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -77,7 +76,8 @@ func getMockReleaseActionStatus() *domain.ReleaseActionStatus {
 }
 
 func TestReleaseRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -92,14 +92,14 @@ func TestReleaseRepo_Store(t *testing.T) {
 		t.Run(fmt.Sprintf("StoreReleaseActionStatus_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -108,32 +108,33 @@ func TestReleaseRepo_Store(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Execute
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(context.Background(), actionMockData)
+			err = actionRepo.Store(t.Context(), actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(context.Background(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.NotEqual(t, int64(0), mockData.ID)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_StoreReleaseActionStatus(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -148,14 +149,14 @@ func TestReleaseRepo_StoreReleaseActionStatus(t *testing.T) {
 		t.Run(fmt.Sprintf("StoreReleaseActionStatus_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -164,32 +165,33 @@ func TestReleaseRepo_StoreReleaseActionStatus(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Execute
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(context.Background(), actionMockData)
+			err = actionRepo.Store(t.Context(), actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(context.Background(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Verify
 			assert.NotEqual(t, int64(0), releaseActionMockData.ID)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_Find(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -204,14 +206,14 @@ func TestReleaseRepo_Find(t *testing.T) {
 		t.Run(fmt.Sprintf("FindReleases_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -220,7 +222,7 @@ func TestReleaseRepo_Find(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Execute
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Search with query params
@@ -233,7 +235,7 @@ func TestReleaseRepo_Find(t *testing.T) {
 				Search: "",
 			}
 
-			resp, err := repo.Find(context.Background(), queryParams)
+			resp, err := repo.Find(t.Context(), queryParams)
 
 			// Verify
 			assert.NotNil(t, resp)
@@ -242,28 +244,29 @@ func TestReleaseRepo_Find(t *testing.T) {
 
 			// Search by type
 			queryParams.Search = "type:movie"
-			resp, err = repo.Find(context.Background(), queryParams)
+			resp, err = repo.Find(t.Context(), queryParams)
 			assert.NoError(t, err)
 			assert.NotNil(t, resp)
 			assert.Equal(t, uint64(1), resp.TotalCount)
 
 			// Search by type with no matches
 			queryParams.Search = "type:episode"
-			resp, err = repo.Find(context.Background(), queryParams)
+			resp, err = repo.Find(t.Context(), queryParams)
 			assert.NoError(t, err)
 			assert.NotNil(t, resp)
 			assert.Equal(t, uint64(0), resp.TotalCount)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_FindRecent(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -278,14 +281,14 @@ func TestReleaseRepo_FindRecent(t *testing.T) {
 		t.Run(fmt.Sprintf("FindRecent_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -294,25 +297,26 @@ func TestReleaseRepo_FindRecent(t *testing.T) {
 			mockData.FilterID = createdFilters[0].ID
 
 			// Execute
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
 
-			resp, err := repo.Find(context.Background(), domain.ReleaseQueryParams{Limit: 10})
+			resp, err := repo.Find(t.Context(), domain.ReleaseQueryParams{Limit: 10})
 
 			// Verify
 			assert.NotNil(t, resp.Data)
 			assert.Lenf(t, resp.Data, 1, "Expected 1 release, got %d", len(resp.Data))
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_GetIndexerOptions(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -327,14 +331,14 @@ func TestReleaseRepo_GetIndexerOptions(t *testing.T) {
 		t.Run(fmt.Sprintf("GetIndexerOptions_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -342,36 +346,37 @@ func TestReleaseRepo_GetIndexerOptions(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(context.Background(), actionMockData)
+			err = actionRepo.Store(t.Context(), actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(context.Background(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			options, err := repo.GetIndexerOptions(context.Background())
+			options, err := repo.GetIndexerOptions(t.Context())
 
 			// Verify
 			assert.NotNil(t, options)
 			assert.Len(t, options, 1)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_GetActionStatusByReleaseID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -386,14 +391,14 @@ func TestReleaseRepo_GetActionStatusByReleaseID(t *testing.T) {
 		t.Run(fmt.Sprintf("GetActionStatusByReleaseID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -401,20 +406,20 @@ func TestReleaseRepo_GetActionStatusByReleaseID(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(context.Background(), actionMockData)
+			err = actionRepo.Store(t.Context(), actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(context.Background(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			actionStatus, err := repo.GetActionStatus(context.Background(), &domain.GetReleaseActionStatusRequest{Id: int(releaseActionMockData.ID)})
+			actionStatus, err := repo.GetActionStatus(t.Context(), &domain.GetReleaseActionStatusRequest{Id: int(releaseActionMockData.ID)})
 
 			// Verify
 			assert.NoError(t, err)
@@ -422,16 +427,17 @@ func TestReleaseRepo_GetActionStatusByReleaseID(t *testing.T) {
 			assert.Equal(t, releaseActionMockData.ID, actionStatus.ID)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_Get(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -446,14 +452,14 @@ func TestReleaseRepo_Get(t *testing.T) {
 		t.Run(fmt.Sprintf("Get_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -461,20 +467,20 @@ func TestReleaseRepo_Get(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(context.Background(), actionMockData)
+			err = actionRepo.Store(t.Context(), actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(context.Background(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			release, err := repo.Get(context.Background(), &domain.GetReleaseRequest{Id: int(mockData.ID)})
+			release, err := repo.Get(t.Context(), &domain.GetReleaseRequest{Id: int(mockData.ID)})
 
 			// Verify
 			assert.NoError(t, err)
@@ -482,16 +488,17 @@ func TestReleaseRepo_Get(t *testing.T) {
 			assert.Equal(t, mockData.ID, release.ID)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_Stats(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -506,14 +513,14 @@ func TestReleaseRepo_Stats(t *testing.T) {
 		t.Run(fmt.Sprintf("Stats_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -521,20 +528,20 @@ func TestReleaseRepo_Stats(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(context.Background(), actionMockData)
+			err = actionRepo.Store(t.Context(), actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(context.Background(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
 			assert.NoError(t, err)
 
 			// Execute
-			stats, err := repo.Stats(context.Background())
+			stats, err := repo.Stats(t.Context())
 
 			// Verify
 			assert.NoError(t, err)
@@ -547,16 +554,17 @@ func TestReleaseRepo_Stats(t *testing.T) {
 			assert.Equal(t, int64(0), stats.PushErrorCount)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_StatsDashboard(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -571,13 +579,13 @@ func TestReleaseRepo_StatsDashboard(t *testing.T) {
 		t.Run(fmt.Sprintf("StatsDashboard_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -585,20 +593,20 @@ func TestReleaseRepo_StatsDashboard(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(context.Background(), actionMockData)
+			err = actionRepo.Store(t.Context(), actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(context.Background(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
 			assert.NoError(t, err)
 
 			for _, days := range []int{30, 0} {
-				activity, err := repo.StatsActivity(context.Background(), days)
+				activity, err := repo.StatsActivity(t.Context(), days)
 				assert.NoError(t, err)
 				assert.Equal(t, days, activity.Days)
 				assert.NotEmpty(t, activity.Daily)
@@ -607,11 +615,11 @@ func TestReleaseRepo_StatsDashboard(t *testing.T) {
 				assert.Equal(t, int64(1), today.PushApprovedCount)
 				assert.Equal(t, int64(0), today.PushRejectedCount)
 
-				volume, err := repo.StatsVolume(context.Background(), days)
+				volume, err := repo.StatsVolume(t.Context(), days)
 				assert.NoError(t, err)
 				assert.NotEmpty(t, volume.Daily)
 
-				heatmap, err := repo.StatsHeatmap(context.Background(), days)
+				heatmap, err := repo.StatsHeatmap(t.Context(), days)
 				assert.NoError(t, err)
 				assert.Len(t, heatmap.Heatmap, 168)
 				var heatmapTotal int64
@@ -620,28 +628,29 @@ func TestReleaseRepo_StatsDashboard(t *testing.T) {
 				}
 				assert.Equal(t, int64(1), heatmapTotal)
 
-				indexers, err := repo.StatsTopIndexers(context.Background(), days)
+				indexers, err := repo.StatsTopIndexers(t.Context(), days)
 				assert.NoError(t, err)
 				assert.Len(t, indexers.Top, 1)
 				assert.Equal(t, int64(1), indexers.Top[0].MatchedCount)
 				assert.Equal(t, int64(1), indexers.Top[0].PushApprovedCount)
 
-				filters, err := repo.StatsTopFilters(context.Background(), days)
+				filters, err := repo.StatsTopFilters(t.Context(), days)
 				assert.NoError(t, err)
 				assert.NotEmpty(t, filters.Top)
 			}
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
 
 func TestReleaseRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -651,20 +660,20 @@ func TestReleaseRepo_Delete(t *testing.T) {
 
 		// Setup shared dependencies
 		mock := getMockDownloadClient()
-		err := downloadClientRepo.Store(context.Background(), &mock)
+		err := downloadClientRepo.Store(t.Context(), &mock)
 		assert.NoError(t, err)
 
-		err = filterRepo.Store(context.Background(), getMockFilter())
+		err = filterRepo.Store(t.Context(), getMockFilter())
 		assert.NoError(t, err)
 
-		createdFilters, err := filterRepo.ListFilters(context.Background())
+		createdFilters, err := filterRepo.ListFilters(t.Context())
 		assert.NoError(t, err)
 		assert.NotNil(t, createdFilters)
 
 		actionMock := getMockAction()
 		actionMock.FilterID = createdFilters[0].ID
 		actionMock.ClientID = mock.ID
-		err = actionRepo.Store(context.Background(), actionMock)
+		err = actionRepo.Store(t.Context(), actionMock)
 		assert.NoError(t, err)
 
 		tests := []struct {
@@ -701,7 +710,7 @@ func TestReleaseRepo_Delete(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("Delete_%s [%s]", tt.name, dbType), func(t *testing.T) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				// Setup - create test-specific releases
 				switch tt.name {
@@ -832,14 +841,15 @@ func TestReleaseRepo_Delete(t *testing.T) {
 		}
 
 		// Cleanup shared resources
-		_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMock.ID})
-		_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-		_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+		_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMock.ID})
+		_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+		_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 	}
 }
 
 func TestReleaseRepo_CheckSmartEpisodeCanDownloadShow(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		downloadClientRepo := NewDownloadClientRepo(log, db)
@@ -854,14 +864,14 @@ func TestReleaseRepo_CheckSmartEpisodeCanDownloadShow(t *testing.T) {
 		t.Run(fmt.Sprintf("Check_Smart_Episode_Can_Download [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mock := getMockDownloadClient()
-			err := downloadClientRepo.Store(context.Background(), &mock)
+			err := downloadClientRepo.Store(t.Context(), &mock)
 			assert.NoError(t, err)
 			assert.NotNil(t, mock)
 
-			err = filterRepo.Store(context.Background(), getMockFilter())
+			err = filterRepo.Store(t.Context(), getMockFilter())
 			assert.NoError(t, err)
 
-			createdFilters, err := filterRepo.ListFilters(context.Background())
+			createdFilters, err := filterRepo.ListFilters(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, createdFilters)
 
@@ -869,16 +879,16 @@ func TestReleaseRepo_CheckSmartEpisodeCanDownloadShow(t *testing.T) {
 			actionMockData.ClientID = mock.ID
 			mockData.FilterID = createdFilters[0].ID
 
-			err = repo.Store(context.Background(), mockData)
+			err = repo.Store(t.Context(), mockData)
 			assert.NoError(t, err)
-			err = actionRepo.Store(context.Background(), actionMockData)
+			err = actionRepo.Store(t.Context(), actionMockData)
 			assert.NoError(t, err)
 
 			releaseActionMockData.ReleaseID = mockData.ID
 			releaseActionMockData.ActionID = int64(actionMockData.ID)
 			releaseActionMockData.FilterID = int64(createdFilters[0].ID)
 
-			err = repo.StoreReleaseActionStatus(context.Background(), releaseActionMockData)
+			err = repo.StoreReleaseActionStatus(t.Context(), releaseActionMockData)
 			assert.NoError(t, err)
 
 			params := &domain.SmartEpisodeParams{
@@ -891,17 +901,17 @@ func TestReleaseRepo_CheckSmartEpisodeCanDownloadShow(t *testing.T) {
 			}
 
 			// Execute
-			canDownload, err := repo.CheckSmartEpisodeCanDownload(context.Background(), params)
+			canDownload, err := repo.CheckSmartEpisodeCanDownload(t.Context(), params)
 
 			// Verify
 			assert.NoError(t, err)
 			assert.True(t, canDownload)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-			_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
-			_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
-			_ = downloadClientRepo.Delete(context.Background(), mock.ID)
+			_ = repo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMockData.ID})
+			_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(t.Context(), mock.ID)
 		})
 	}
 }
@@ -1035,7 +1045,8 @@ func getMockFilterDuplicates() *domain.Filter {
 }
 
 func TestReleaseRepo_CheckIsDuplicateRelease(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		filterRepo := NewFilterRepo(log, db)
@@ -1052,16 +1063,16 @@ func TestReleaseRepo_CheckIsDuplicateRelease(t *testing.T) {
 		filterMock := getMockFilterDuplicates()
 
 		// Setup
-		err := filterRepo.Store(context.Background(), filterMock)
+		err := filterRepo.Store(t.Context(), filterMock)
 		assert.NoError(t, err)
 
-		createdFilters, err := filterRepo.ListFilters(context.Background())
+		createdFilters, err := filterRepo.ListFilters(t.Context())
 		assert.NoError(t, err)
 		assert.NotNil(t, createdFilters)
 
 		actionMock.FilterID = filterMock.ID
 
-		err = actionRepo.Store(context.Background(), actionMock)
+		err = actionRepo.Store(t.Context(), actionMock)
 		assert.NoError(t, err)
 
 		type fields struct {
@@ -1576,7 +1587,7 @@ func TestReleaseRepo_CheckIsDuplicateRelease(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("Check_Is_Duplicate_Release %s [%s]", tt.name, dbType), func(t *testing.T) {
-				ctx := context.Background()
+				ctx := t.Context()
 
 				// Setup
 				for _, rel := range tt.fields.releaseTitles {
@@ -1626,9 +1637,9 @@ func TestReleaseRepo_CheckIsDuplicateRelease(t *testing.T) {
 		}
 
 		// Cleanup
-		//_ = releaseRepo.Delete(context.Background(), &domain.DeleteReleaseRequest{OlderThan: 0})
-		_ = actionRepo.Delete(context.Background(), &domain.DeleteActionRequest{ActionId: actionMock.ID})
-		_ = filterRepo.Delete(context.Background(), createdFilters[0].ID)
+		//_ = releaseRepo.Delete(t.Context(), &domain.DeleteReleaseRequest{OlderThan: 0})
+		_ = actionRepo.Delete(t.Context(), &domain.DeleteActionRequest{ActionId: actionMock.ID})
+		_ = filterRepo.Delete(t.Context(), createdFilters[0].ID)
 	}
 }
 
@@ -1647,19 +1658,20 @@ func getMockReleaseCleanupJob() *domain.ReleaseCleanupJob {
 }
 
 func TestReleaseCleanupJobRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewReleaseRepo(log, db)
 		mockData := getMockReleaseCleanupJob()
 
 		t.Run(fmt.Sprintf("Store_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.StoreCleanupJob(context.Background(), mockData)
+			err := repo.StoreCleanupJob(t.Context(), mockData)
 			assert.NoError(t, err)
 			assert.NotZero(t, mockData.ID)
 
 			// Verify
-			job, err := repo.FindCleanupJobByID(context.Background(), mockData.ID)
+			job, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, mockData.Name, job.Name)
 			assert.Equal(t, mockData.Enabled, job.Enabled)
@@ -1669,35 +1681,36 @@ func TestReleaseCleanupJobRepo_Store(t *testing.T) {
 			assert.Equal(t, mockData.Statuses, job.Statuses)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(context.Background(), mockData.ID)
+			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
 		})
 	}
 }
 
 func TestReleaseCleanupJobRepo_FindByID(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewReleaseRepo(log, db)
 		mockData := getMockReleaseCleanupJob()
 
 		t.Run(fmt.Sprintf("FindByID_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreCleanupJob(context.Background(), mockData)
+			err := repo.StoreCleanupJob(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			job, err := repo.FindCleanupJobByID(context.Background(), mockData.ID)
+			job, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, mockData.Name, job.Name)
 			assert.Equal(t, mockData.ID, job.ID)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(context.Background(), mockData.ID)
+			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("FindByID_Fails_Not_Found [%s]", dbType), func(t *testing.T) {
 			// Execute
-			_, err := repo.FindCleanupJobByID(context.Background(), 99999)
+			_, err := repo.FindCleanupJobByID(t.Context(), 99999)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
@@ -1705,7 +1718,8 @@ func TestReleaseCleanupJobRepo_FindByID(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_List(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewReleaseRepo(log, db)
 
@@ -1718,15 +1732,15 @@ func TestReleaseCleanupJobRepo_List(t *testing.T) {
 			job3 := getMockReleaseCleanupJob()
 			job3.Name = "Job 3"
 
-			err := repo.StoreCleanupJob(context.Background(), job1)
+			err := repo.StoreCleanupJob(t.Context(), job1)
 			assert.NoError(t, err)
-			err = repo.StoreCleanupJob(context.Background(), job2)
+			err = repo.StoreCleanupJob(t.Context(), job2)
 			assert.NoError(t, err)
-			err = repo.StoreCleanupJob(context.Background(), job3)
+			err = repo.StoreCleanupJob(t.Context(), job3)
 			assert.NoError(t, err)
 
 			// Execute
-			jobs, err := repo.ListCleanupJobs(context.Background())
+			jobs, err := repo.ListCleanupJobs(t.Context())
 			assert.NoError(t, err)
 			assert.GreaterOrEqual(t, len(jobs), 3)
 
@@ -1740,14 +1754,14 @@ func TestReleaseCleanupJobRepo_List(t *testing.T) {
 			assert.Equal(t, 3, foundJobs)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(context.Background(), job1.ID)
-			_ = repo.DeleteCleanupJob(context.Background(), job2.ID)
-			_ = repo.DeleteCleanupJob(context.Background(), job3.ID)
+			_ = repo.DeleteCleanupJob(t.Context(), job1.ID)
+			_ = repo.DeleteCleanupJob(t.Context(), job2.ID)
+			_ = repo.DeleteCleanupJob(t.Context(), job3.ID)
 		})
 
 		t.Run(fmt.Sprintf("List_Empty_Table [%s]", dbType), func(t *testing.T) {
 			// Execute
-			jobs, err := repo.ListCleanupJobs(context.Background())
+			jobs, err := repo.ListCleanupJobs(t.Context())
 			assert.NoError(t, err)
 			assert.NotNil(t, jobs)
 		})
@@ -1755,14 +1769,15 @@ func TestReleaseCleanupJobRepo_List(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_Update(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewReleaseRepo(log, db)
 		mockData := getMockReleaseCleanupJob()
 
 		t.Run(fmt.Sprintf("Update_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreCleanupJob(context.Background(), mockData)
+			err := repo.StoreCleanupJob(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Update data
@@ -1774,11 +1789,11 @@ func TestReleaseCleanupJobRepo_Update(t *testing.T) {
 			mockData.Statuses = "PUSH_APPROVED"
 
 			// Execute
-			err = repo.UpdateCleanupJob(context.Background(), mockData)
+			err = repo.UpdateCleanupJob(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedJob, err := repo.FindCleanupJobByID(context.Background(), mockData.ID)
+			updatedJob, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, "Updated Name", updatedJob.Name)
 			assert.Equal(t, "0 4 * * *", updatedJob.Schedule)
@@ -1788,7 +1803,7 @@ func TestReleaseCleanupJobRepo_Update(t *testing.T) {
 			assert.Equal(t, "PUSH_APPROVED", updatedJob.Statuses)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(context.Background(), mockData.ID)
+			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("Update_Fails_Non_Existing_Job [%s]", dbType), func(t *testing.T) {
@@ -1797,7 +1812,7 @@ func TestReleaseCleanupJobRepo_Update(t *testing.T) {
 			nonExistingJob.ID = 99999
 
 			// Execute
-			err := repo.UpdateCleanupJob(context.Background(), nonExistingJob)
+			err := repo.UpdateCleanupJob(t.Context(), nonExistingJob)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
@@ -1805,14 +1820,15 @@ func TestReleaseCleanupJobRepo_Update(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_UpdateLastRun(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewReleaseRepo(log, db)
 		mockData := getMockReleaseCleanupJob()
 
 		t.Run(fmt.Sprintf("UpdateLastRun_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreCleanupJob(context.Background(), mockData)
+			err := repo.StoreCleanupJob(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Update last run data
@@ -1822,18 +1838,18 @@ func TestReleaseCleanupJobRepo_UpdateLastRun(t *testing.T) {
 			mockData.LastRunData = `{"error": "test error"}`
 
 			// Execute
-			err = repo.UpdateCleanupJobLastRun(context.Background(), mockData)
+			err = repo.UpdateCleanupJobLastRun(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedJob, err := repo.FindCleanupJobByID(context.Background(), mockData.ID)
+			updatedJob, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, domain.ReleaseCleanupStatusError, updatedJob.LastRunStatus)
 			assert.Equal(t, `{"error": "test error"}`, updatedJob.LastRunData)
 			assert.WithinDuration(t, newLastRun, updatedJob.LastRun, 2*time.Second)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(context.Background(), mockData.ID)
+			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("UpdateLastRun_Fails_Non_Existing_Job [%s]", dbType), func(t *testing.T) {
@@ -1842,7 +1858,7 @@ func TestReleaseCleanupJobRepo_UpdateLastRun(t *testing.T) {
 			nonExistingJob.ID = 99999
 
 			// Execute
-			err := repo.UpdateCleanupJobLastRun(context.Background(), nonExistingJob)
+			err := repo.UpdateCleanupJobLastRun(t.Context(), nonExistingJob)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
@@ -1850,7 +1866,8 @@ func TestReleaseCleanupJobRepo_UpdateLastRun(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_ToggleEnabled(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewReleaseRepo(log, db)
 		mockData := getMockReleaseCleanupJob()
@@ -1858,34 +1875,34 @@ func TestReleaseCleanupJobRepo_ToggleEnabled(t *testing.T) {
 		t.Run(fmt.Sprintf("ToggleEnabled_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
 			mockData.Enabled = true
-			err := repo.StoreCleanupJob(context.Background(), mockData)
+			err := repo.StoreCleanupJob(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Execute - disable
-			err = repo.CleanupJobToggleEnabled(context.Background(), mockData.ID, false)
+			err = repo.CleanupJobToggleEnabled(t.Context(), mockData.ID, false)
 			assert.NoError(t, err)
 
 			// Verify
-			job, err := repo.FindCleanupJobByID(context.Background(), mockData.ID)
+			job, err := repo.FindCleanupJobByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 			assert.False(t, job.Enabled)
 
 			// Execute - enable
-			err = repo.CleanupJobToggleEnabled(context.Background(), mockData.ID, true)
+			err = repo.CleanupJobToggleEnabled(t.Context(), mockData.ID, true)
 			assert.NoError(t, err)
 
 			// Verify
-			job, err = repo.FindCleanupJobByID(context.Background(), mockData.ID)
+			job, err = repo.FindCleanupJobByID(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 			assert.True(t, job.Enabled)
 
 			// Cleanup
-			_ = repo.DeleteCleanupJob(context.Background(), mockData.ID)
+			_ = repo.DeleteCleanupJob(t.Context(), mockData.ID)
 		})
 
 		t.Run(fmt.Sprintf("ToggleEnabled_Fails_Non_Existing_Job [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.CleanupJobToggleEnabled(context.Background(), 99999, false)
+			err := repo.CleanupJobToggleEnabled(t.Context(), 99999, false)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
@@ -1893,29 +1910,30 @@ func TestReleaseCleanupJobRepo_ToggleEnabled(t *testing.T) {
 }
 
 func TestReleaseCleanupJobRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 		repo := NewReleaseRepo(log, db)
 		mockData := getMockReleaseCleanupJob()
 
 		t.Run(fmt.Sprintf("Delete_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.StoreCleanupJob(context.Background(), mockData)
+			err := repo.StoreCleanupJob(t.Context(), mockData)
 			assert.NoError(t, err)
 
 			// Execute
-			err = repo.DeleteCleanupJob(context.Background(), mockData.ID)
+			err = repo.DeleteCleanupJob(t.Context(), mockData.ID)
 			assert.NoError(t, err)
 
 			// Verify
-			_, err = repo.FindCleanupJobByID(context.Background(), mockData.ID)
+			_, err = repo.FindCleanupJobByID(t.Context(), mockData.ID)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})
 
 		t.Run(fmt.Sprintf("Delete_Fails_Non_Existing_Job [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.DeleteCleanupJob(context.Background(), 99999)
+			err := repo.DeleteCleanupJob(t.Context(), 99999)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, domain.ErrRecordNotFound)
 		})

--- a/internal/database/user_test.go
+++ b/internal/database/user_test.go
@@ -6,7 +6,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -24,7 +23,8 @@ func getMockUser() domain.User {
 }
 
 func TestUserRepo_Store(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewUserRepo(log, db)
@@ -33,7 +33,7 @@ func TestUserRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("StoreUser_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Store(context.Background(), domain.CreateUserRequest{
+			err := repo.Store(t.Context(), domain.CreateUserRequest{
 				Username: userMockData.Username,
 				Password: userMockData.Password,
 			})
@@ -42,25 +42,26 @@ func TestUserRepo_Store(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), userMockData.Username)
+			_ = repo.Delete(t.Context(), userMockData.Username)
 		})
 	}
 }
 
 func TestUserRepo_Update(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewUserRepo(log, db)
 
 		user := getMockUser()
-		err := repo.Store(context.Background(), domain.CreateUserRequest{
+		err := repo.Store(t.Context(), domain.CreateUserRequest{
 			Username: user.Username,
 			Password: user.Password,
 		})
 		assert.NoError(t, err)
 
-		storedUser, err := repo.FindByUsername(context.Background(), user.Username)
+		storedUser, err := repo.FindByUsername(t.Context(), user.Username)
 		assert.NoError(t, err)
 		user.ID = storedUser.ID
 
@@ -72,51 +73,53 @@ func TestUserRepo_Update(t *testing.T) {
 				UsernameCurrent: user.Username,
 				PasswordNewHash: newPassword,
 			}
-			err := repo.Update(context.Background(), req)
+			err := repo.Update(t.Context(), req)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedUser, err := repo.FindByUsername(context.Background(), user.Username)
+			updatedUser, err := repo.FindByUsername(t.Context(), user.Username)
 			assert.NoError(t, err)
 			assert.Equal(t, newPassword, updatedUser.Password)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), updatedUser.Username)
+			_ = repo.Delete(t.Context(), updatedUser.Username)
 		})
 	}
 }
 
 func TestUserRepo_GetUserCount(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewUserRepo(log, db)
 
 		t.Run(fmt.Sprintf("GetUserCount_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			initialCount, err := repo.GetUserCount(context.Background())
+			initialCount, err := repo.GetUserCount(t.Context())
 			assert.NoError(t, err)
 
 			user := getMockUser()
-			err = repo.Store(context.Background(), domain.CreateUserRequest{
+			err = repo.Store(t.Context(), domain.CreateUserRequest{
 				Username: user.Username,
 				Password: user.Password,
 			})
 			assert.NoError(t, err)
 
 			// Verify
-			updatedCount, err := repo.GetUserCount(context.Background())
+			updatedCount, err := repo.GetUserCount(t.Context())
 			assert.NoError(t, err)
 			assert.Equal(t, initialCount+1, updatedCount)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), user.Username)
+			_ = repo.Delete(t.Context(), user.Username)
 		})
 	}
 }
 
 func TestUserRepo_FindByUsername(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewUserRepo(log, db)
@@ -125,32 +128,33 @@ func TestUserRepo_FindByUsername(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByUsername_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Store(context.Background(), domain.CreateUserRequest{
+			err := repo.Store(t.Context(), domain.CreateUserRequest{
 				Username: userMockData.Username,
 				Password: userMockData.Password,
 			})
 			assert.NoError(t, err)
 
 			// Verify
-			user, err := repo.FindByUsername(context.Background(), userMockData.Username)
+			user, err := repo.FindByUsername(t.Context(), userMockData.Username)
 			assert.NoError(t, err)
 			assert.NotNil(t, user)
 			assert.Equal(t, userMockData.Username, user.Username)
 
 			// Cleanup
-			_ = repo.Delete(context.Background(), userMockData.Username)
+			_ = repo.Delete(t.Context(), userMockData.Username)
 		})
 	}
 }
 
 func TestUserRepo_Delete(t *testing.T) {
-	for dbType, db := range testDBs {
+	for dbType, testDb := range testDBs {
+		db := testDb.db
 		log := setupLoggerForTest()
 
 		repo := NewUserRepo(log, db)
 
 		user := getMockUser()
-		err := repo.Store(context.Background(), domain.CreateUserRequest{
+		err := repo.Store(t.Context(), domain.CreateUserRequest{
 			Username: user.Username,
 			Password: user.Password,
 		})
@@ -158,11 +162,11 @@ func TestUserRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("DeleteUser_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Delete(context.Background(), user.Username)
+			err := repo.Delete(t.Context(), user.Username)
 			assert.NoError(t, err)
 
 			// Verify
-			_, err = repo.FindByUsername(context.Background(), user.Username)
+			_, err = repo.FindByUsername(t.Context(), user.Username)
 			assert.Error(t, err)
 			assert.Equal(t, domain.ErrRecordNotFound, err)
 		})

--- a/internal/database/user_test.go
+++ b/internal/database/user_test.go
@@ -23,6 +23,8 @@ func getMockUser() domain.User {
 }
 
 func TestUserRepo_Store(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -33,7 +35,7 @@ func TestUserRepo_Store(t *testing.T) {
 
 		t.Run(fmt.Sprintf("StoreUser_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Store(t.Context(), domain.CreateUserRequest{
+			err := repo.Store(ctx, domain.CreateUserRequest{
 				Username: userMockData.Username,
 				Password: userMockData.Password,
 			})
@@ -42,12 +44,14 @@ func TestUserRepo_Store(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), userMockData.Username)
+			_ = repo.Delete(ctx, userMockData.Username)
 		})
 	}
 }
 
 func TestUserRepo_Update(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -55,13 +59,13 @@ func TestUserRepo_Update(t *testing.T) {
 		repo := NewUserRepo(log, db)
 
 		user := getMockUser()
-		err := repo.Store(t.Context(), domain.CreateUserRequest{
+		err := repo.Store(ctx, domain.CreateUserRequest{
 			Username: user.Username,
 			Password: user.Password,
 		})
 		assert.NoError(t, err)
 
-		storedUser, err := repo.FindByUsername(t.Context(), user.Username)
+		storedUser, err := repo.FindByUsername(ctx, user.Username)
 		assert.NoError(t, err)
 		user.ID = storedUser.ID
 
@@ -73,21 +77,23 @@ func TestUserRepo_Update(t *testing.T) {
 				UsernameCurrent: user.Username,
 				PasswordNewHash: newPassword,
 			}
-			err := repo.Update(t.Context(), req)
+			err := repo.Update(ctx, req)
 			assert.NoError(t, err)
 
 			// Verify
-			updatedUser, err := repo.FindByUsername(t.Context(), user.Username)
+			updatedUser, err := repo.FindByUsername(ctx, user.Username)
 			assert.NoError(t, err)
 			assert.Equal(t, newPassword, updatedUser.Password)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), updatedUser.Username)
+			_ = repo.Delete(ctx, updatedUser.Username)
 		})
 	}
 }
 
 func TestUserRepo_GetUserCount(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -96,28 +102,30 @@ func TestUserRepo_GetUserCount(t *testing.T) {
 
 		t.Run(fmt.Sprintf("GetUserCount_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			initialCount, err := repo.GetUserCount(t.Context())
+			initialCount, err := repo.GetUserCount(ctx)
 			assert.NoError(t, err)
 
 			user := getMockUser()
-			err = repo.Store(t.Context(), domain.CreateUserRequest{
+			err = repo.Store(ctx, domain.CreateUserRequest{
 				Username: user.Username,
 				Password: user.Password,
 			})
 			assert.NoError(t, err)
 
 			// Verify
-			updatedCount, err := repo.GetUserCount(t.Context())
+			updatedCount, err := repo.GetUserCount(ctx)
 			assert.NoError(t, err)
 			assert.Equal(t, initialCount+1, updatedCount)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), user.Username)
+			_ = repo.Delete(ctx, user.Username)
 		})
 	}
 }
 
 func TestUserRepo_FindByUsername(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -128,25 +136,27 @@ func TestUserRepo_FindByUsername(t *testing.T) {
 
 		t.Run(fmt.Sprintf("FindByUsername_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Execute
-			err := repo.Store(t.Context(), domain.CreateUserRequest{
+			err := repo.Store(ctx, domain.CreateUserRequest{
 				Username: userMockData.Username,
 				Password: userMockData.Password,
 			})
 			assert.NoError(t, err)
 
 			// Verify
-			user, err := repo.FindByUsername(t.Context(), userMockData.Username)
+			user, err := repo.FindByUsername(ctx, userMockData.Username)
 			assert.NoError(t, err)
 			assert.NotNil(t, user)
 			assert.Equal(t, userMockData.Username, user.Username)
 
 			// Cleanup
-			_ = repo.Delete(t.Context(), userMockData.Username)
+			_ = repo.Delete(ctx, userMockData.Username)
 		})
 	}
 }
 
 func TestUserRepo_Delete(t *testing.T) {
+	ctx := t.Context()
+
 	for dbType, testDb := range testDBs {
 		db := testDb.db
 		log := setupLoggerForTest()
@@ -154,7 +164,7 @@ func TestUserRepo_Delete(t *testing.T) {
 		repo := NewUserRepo(log, db)
 
 		user := getMockUser()
-		err := repo.Store(t.Context(), domain.CreateUserRequest{
+		err := repo.Store(ctx, domain.CreateUserRequest{
 			Username: user.Username,
 			Password: user.Password,
 		})
@@ -162,11 +172,11 @@ func TestUserRepo_Delete(t *testing.T) {
 
 		t.Run(fmt.Sprintf("DeleteUser_Succeeds [%s]", dbType), func(t *testing.T) {
 			// Setup
-			err := repo.Delete(t.Context(), user.Username)
+			err := repo.Delete(ctx, user.Username)
 			assert.NoError(t, err)
 
 			// Verify
-			_, err = repo.FindByUsername(t.Context(), user.Username)
+			_, err = repo.FindByUsername(ctx, user.Username)
 			assert.Error(t, err)
 			assert.Equal(t, domain.ErrRecordNotFound, err)
 		})

--- a/internal/domain/release_download_test.go
+++ b/internal/domain/release_download_test.go
@@ -6,7 +6,6 @@
 package domain
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -292,7 +291,7 @@ func TestRelease_DownloadTorrentFile(t *testing.T) {
 				Filter:                      tt.fields.Filter,
 				ActionStatus:                tt.fields.ActionStatus,
 			}
-			err := r.DownloadTorrentFileCtx(context.Background())
+			err := r.DownloadTorrentFileCtx(t.Context())
 			if err == nil && tt.wantErr {
 				fmt.Println("error")
 			}

--- a/internal/indexer/deprecations_test.go
+++ b/internal/indexer/deprecations_test.go
@@ -71,7 +71,7 @@ func TestReconcileDeprecations(t *testing.T) {
 		{Identifier: "customreadded", Name: "Custom Re-Added"},
 	}
 
-	require.NoError(t, s.reconcileDeprecations(context.Background(), deprecations))
+	require.NoError(t, s.reconcileDeprecations(t.Context(), deprecations))
 
 	assert.Equal(t, deprecations, fake.deprecations)
 	assert.Contains(t, fake.activeIdentifiers, "customreadded")

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -410,7 +410,7 @@ func TestIndexersParseAndFilter(t *testing.T) {
 
 					// release/service.go
 
-					//ctx := context.Background()
+					//ctx := t.Context()
 					//filterSvc := filter.NewService(l, nil, nil, nil, nil, nil)
 
 					for _, filterT := range subT.args.filters {

--- a/internal/indexer/service_test.go
+++ b/internal/indexer/service_test.go
@@ -126,7 +126,7 @@ func TestServiceUpdate_SecretSettings(t *testing.T) {
 
 			update := &domain.Indexer{ID: 1, Name: "Test RSS", Identifier: current.Identifier, Implementation: "rss", Enabled: true, Settings: tt.settings}
 
-			err := svc.Update(context.Background(), update)
+			err := svc.Update(t.Context(), update)
 
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
@@ -155,7 +155,7 @@ func TestServiceUpdate_EmptySavedSecretMayBeOmitted(t *testing.T) {
 	svc := NewService(zerolog.Nop(), nil, EventBus.New(), repo, nil, nil)
 	svc.mappedDefinitions["rss-test-rss"] = &domain.IndexerDefinition{Identifier: "rss-test-rss", Implementation: "rss"}
 
-	err := svc.Update(context.Background(), &domain.Indexer{ID: 1, Name: "Test RSS", Identifier: "rss-test-rss", Implementation: "rss", Settings: map[string]string{}})
+	err := svc.Update(t.Context(), &domain.Indexer{ID: 1, Name: "Test RSS", Identifier: "rss-test-rss", Implementation: "rss", Settings: map[string]string{}})
 
 	assert.NoError(t, err)
 	assert.NotNil(t, repo.updated)

--- a/internal/list/process_list_trakt_test.go
+++ b/internal/list/process_list_trakt_test.go
@@ -126,7 +126,7 @@ func Test_trakt_smartList(t *testing.T) {
 		},
 	}
 
-	err := svc.trakt(context.Background(), list)
+	err := svc.trakt(t.Context(), list)
 	require.NoError(t, err)
 
 	require.NotNil(t, mockFilter.updatedFilter.Shows)

--- a/internal/release/service_test.go
+++ b/internal/release/service_test.go
@@ -97,7 +97,7 @@ func TestService_Process_PublishesEvent(t *testing.T) {
 		Indexer:     domain.IndexerMinimal{Name: "MockIndexer", Identifier: "mock"},
 	}
 
-	s.Process(context.Background(), release)
+	s.Process(t.Context(), release)
 
 	// s.bus.Publish is synchronous in EventBus when using standard Publish
 	assert.True(t, published, "RELEASE_NEW event should have been published")

--- a/pkg/aria2/aria2_test.go
+++ b/pkg/aria2/aria2_test.go
@@ -4,7 +4,6 @@
 package aria2
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -89,7 +88,7 @@ func TestClientAddURI(t *testing.T) {
 	c, err := NewClient(Config{Host: ts.URL, Secret: "mock-secret"})
 	require.NoError(t, err)
 
-	gid, err := c.AddURI(context.Background(), []string{"magnet:?xt=urn:btih:mock"}, Options{"dir": "/downloads"})
+	gid, err := c.AddURI(t.Context(), []string{"magnet:?xt=urn:btih:mock"}, Options{"dir": "/downloads"})
 	require.NoError(t, err)
 	assert.Equal(t, "2089b05ecca3d829", gid)
 
@@ -108,7 +107,7 @@ func TestClientAddURIWithoutSecret(t *testing.T) {
 	c, err := NewClient(Config{Host: ts.URL})
 	require.NoError(t, err)
 
-	_, err = c.AddURI(context.Background(), []string{"magnet:?xt=urn:btih:mock"}, nil)
+	_, err = c.AddURI(t.Context(), []string{"magnet:?xt=urn:btih:mock"}, nil)
 	require.NoError(t, err)
 
 	require.Len(t, *calls, 1)
@@ -124,7 +123,7 @@ func TestClientAddTorrent(t *testing.T) {
 	c, err := NewClient(Config{Host: ts.URL, Secret: "mock-secret"})
 	require.NoError(t, err)
 
-	gid, err := c.AddTorrent(context.Background(), []byte("d4:infod4:name4:mockee"), Options{"pause": "true"})
+	gid, err := c.AddTorrent(t.Context(), []byte("d4:infod4:name4:mockee"), Options{"pause": "true"})
 	require.NoError(t, err)
 	assert.Equal(t, "2089b05ecca3d829", gid)
 
@@ -148,7 +147,7 @@ func TestClientTellActive(t *testing.T) {
 	c, err := NewClient(Config{Host: ts.URL})
 	require.NoError(t, err)
 
-	active, err := c.TellActive(context.Background())
+	active, err := c.TellActive(t.Context())
 	require.NoError(t, err)
 	require.Len(t, active, 3)
 
@@ -171,7 +170,7 @@ func TestClientRPCError(t *testing.T) {
 	c, err := NewClient(Config{Host: ts.URL, Secret: "wrong"})
 	require.NoError(t, err)
 
-	_, err = c.GetVersion(context.Background())
+	_, err = c.GetVersion(t.Context())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Unauthorized")
 }

--- a/pkg/arr/lidarr/lidarr_test.go
+++ b/pkg/arr/lidarr/lidarr_test.go
@@ -6,7 +6,6 @@
 package lidarr
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -107,7 +106,7 @@ func Test_client_Push(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.fields.config)
 
-			rejections, err := c.Push(context.Background(), tt.args.release)
+			rejections, err := c.Push(t.Context(), tt.args.release)
 			assert.Equal(t, tt.rejections, rejections)
 			if tt.wantErr && assert.Error(t, err) {
 				assert.Equal(t, tt.err, err)
@@ -176,7 +175,7 @@ func Test_client_Test(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.cfg)
 
-			got, err := c.Test(context.Background())
+			got, err := c.Test(t.Context())
 			if tt.wantErr && assert.Error(t, err) {
 				assert.EqualErrorf(t, err, tt.expectedErr, "Error should be: %v, got: %v", tt.wantErr, err)
 			}
@@ -205,7 +204,7 @@ func Test_client_Push_temporarilyRejected(t *testing.T) {
 
 	c := New(Config{Hostname: ts.URL})
 
-	rejections, err := c.Push(context.Background(), Release{
+	rejections, err := c.Push(t.Context(), Release{
 		Title:            "Famous Artist - Great Album (2026) [FLAC]",
 		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
 		Size:             1048576,

--- a/pkg/arr/radarr/radarr_test.go
+++ b/pkg/arr/radarr/radarr_test.go
@@ -6,7 +6,6 @@
 package radarr
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -146,7 +145,7 @@ func Test_client_Push(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.fields.config)
 
-			rejections, err := c.Push(context.Background(), tt.args.release)
+			rejections, err := c.Push(t.Context(), tt.args.release)
 			assert.Equal(t, tt.rejections, rejections)
 			if tt.wantErr && assert.Error(t, err) {
 				assert.Equal(t, tt.err, err)
@@ -228,7 +227,7 @@ func Test_client_Test(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.cfg)
 
-			got, err := c.Test(context.Background())
+			got, err := c.Test(t.Context())
 			if tt.wantErr && assert.Error(t, err) {
 				assert.EqualErrorf(t, err, tt.expectedErr, "Error should be: %v, got: %v", tt.wantErr, err)
 			}
@@ -261,7 +260,7 @@ func Test_client_Push_invalid_download_client(t *testing.T) {
 		Hostname: ts.URL,
 	})
 
-	rejections, err := client.Push(context.Background(), ReleasePushRequest{
+	rejections, err := client.Push(t.Context(), ReleasePushRequest{
 		Title:            "Example",
 		DownloadUrl:      "https://example.invalid/release.torrent",
 		Size:             0,
@@ -298,7 +297,7 @@ func Test_client_Push_temporarilyRejected(t *testing.T) {
 
 	c := New(Config{Hostname: ts.URL})
 
-	rejections, err := c.Push(context.Background(), ReleasePushRequest{
+	rejections, err := c.Push(t.Context(), ReleasePushRequest{
 		Title:            "Movie.Title.2026.1080p.BluRay.x264-GROUP",
 		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
 		Size:             1048576,

--- a/pkg/arr/readarr/readarr_test.go
+++ b/pkg/arr/readarr/readarr_test.go
@@ -6,7 +6,6 @@
 package readarr
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -84,7 +83,7 @@ func Test_client_Push(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.fields.config)
 
-			rejections, err := c.Push(context.Background(), tt.args.release)
+			rejections, err := c.Push(t.Context(), tt.args.release)
 			assert.Equal(t, tt.rejections, rejections)
 			if tt.wantErr && assert.Error(t, err) {
 				assert.Equal(t, tt.err, err)
@@ -153,7 +152,7 @@ func Test_client_Test(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.cfg)
 
-			got, err := c.Test(context.Background())
+			got, err := c.Test(t.Context())
 			if tt.wantErr && assert.Error(t, err) {
 				assert.EqualErrorf(t, err, tt.expectedErr, "Error should be: %v, got: %v", tt.wantErr, err)
 			}
@@ -182,7 +181,7 @@ func Test_client_Push_temporarilyRejected(t *testing.T) {
 
 	c := New(Config{Hostname: ts.URL})
 
-	rejections, err := c.Push(context.Background(), Release{
+	rejections, err := c.Push(t.Context(), Release{
 		Title:            "The Best Book by Famous Author [English / epub, mobi]",
 		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
 		Size:             1048576,

--- a/pkg/arr/sonarr/sonarr_test.go
+++ b/pkg/arr/sonarr/sonarr_test.go
@@ -6,7 +6,6 @@
 package sonarr
 
 import (
-	"context"
 	"io"
 	"log"
 	"net/http"
@@ -114,7 +113,7 @@ func Test_client_Push(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.fields.config)
 
-			rejections, err := c.Push(context.Background(), tt.args.release)
+			rejections, err := c.Push(t.Context(), tt.args.release)
 			assert.Equal(t, tt.rejections, rejections)
 			if tt.wantErr && assert.Error(t, err) {
 				assert.Equal(t, tt.err, err)
@@ -184,7 +183,7 @@ func Test_client_Test(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.cfg)
 
-			got, err := c.Test(context.Background())
+			got, err := c.Test(t.Context())
 			if tt.wantErr && assert.Error(t, err) {
 				assert.EqualErrorf(t, err, tt.expectedErr, "Error should be: %v, got: %v", tt.wantErr, err)
 			}
@@ -218,7 +217,7 @@ func Test_client_Push_invalid_download_client(t *testing.T) {
 		Hostname: ts.URL,
 	})
 
-	rejections, err := client.Push(context.Background(), ReleasePushRequest{
+	rejections, err := client.Push(t.Context(), ReleasePushRequest{
 		Title:            "Example",
 		DownloadUrl:      "https://example.invalid/release.torrent",
 		Size:             0,
@@ -256,7 +255,7 @@ func Test_client_Push_temporarilyRejected(t *testing.T) {
 
 	c := New(Config{Hostname: ts.URL})
 
-	rejections, err := c.Push(context.Background(), ReleasePushRequest{
+	rejections, err := c.Push(t.Context(), ReleasePushRequest{
 		Title:            "Series.Title.S01E01.1080p.WEB-DL.x264-GROUP",
 		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
 		Size:             1048576,

--- a/pkg/arr/sportarr/sportarr_test.go
+++ b/pkg/arr/sportarr/sportarr_test.go
@@ -6,7 +6,6 @@
 package sportarr
 
 import (
-	"context"
 	"io"
 	"log"
 	"net/http"
@@ -110,7 +109,7 @@ func Test_client_Push(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.fields.config)
 
-			rejections, err := c.Push(context.Background(), tt.args.release)
+			rejections, err := c.Push(t.Context(), tt.args.release)
 			assert.Equal(t, tt.rejections, rejections)
 			if tt.wantErr && assert.Error(t, err) {
 				assert.Equal(t, tt.err, err)
@@ -180,7 +179,7 @@ func Test_client_Test(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.cfg)
 
-			got, err := c.Test(context.Background())
+			got, err := c.Test(t.Context())
 			if tt.wantErr && assert.Error(t, err) {
 				assert.EqualErrorf(t, err, tt.expectedErr, "Error should be: %v, got: %v", tt.expectedErr, err)
 			}
@@ -232,7 +231,7 @@ func Test_client_Push_temporarilyRejected(t *testing.T) {
 
 	c := New(Config{Hostname: ts.URL})
 
-	rejections, err := c.Push(context.Background(), ReleasePushRequest{
+	rejections, err := c.Push(t.Context(), ReleasePushRequest{
 		Title:            "Formula.1.2026x10.Belgium.Race.SkyF1HD.1080p",
 		DownloadUrl:      "https://www.mock-indexer.test/tor/download.php?tid=000000",
 		Size:             1048576,

--- a/pkg/arr/whisparr/whisparr_test.go
+++ b/pkg/arr/whisparr/whisparr_test.go
@@ -4,7 +4,6 @@
 package whisparr
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -94,7 +93,7 @@ func TestClient_Test(t *testing.T) {
 	t.Run("v2 client against v2 server", func(t *testing.T) {
 		ts := newTestServer(t, VersionV2)
 
-		status, err := newTestClient(ts.URL, VersionV2).Test(context.Background())
+		status, err := newTestClient(ts.URL, VersionV2).Test(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, "2.2.0.108", status.Version)
 	})
@@ -102,7 +101,7 @@ func TestClient_Test(t *testing.T) {
 	t.Run("v3 client against v3 server", func(t *testing.T) {
 		ts := newTestServer(t, VersionV3)
 
-		status, err := newTestClient(ts.URL, VersionV3).Test(context.Background())
+		status, err := newTestClient(ts.URL, VersionV3).Test(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, "3.3.7.979", status.Version)
 	})
@@ -110,7 +109,7 @@ func TestClient_Test(t *testing.T) {
 	t.Run("v2 client against v3 server reports the mismatch", func(t *testing.T) {
 		ts := newTestServer(t, VersionV3)
 
-		_, err := newTestClient(ts.URL, VersionV2).Test(context.Background())
+		_, err := newTestClient(ts.URL, VersionV2).Test(t.Context())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "configured for Whisparr v2")
 		assert.Contains(t, err.Error(), "3.3.7.979")
@@ -119,7 +118,7 @@ func TestClient_Test(t *testing.T) {
 	t.Run("v3 client against v2 server reports the mismatch", func(t *testing.T) {
 		ts := newTestServer(t, VersionV2)
 
-		_, err := newTestClient(ts.URL, VersionV3).Test(context.Background())
+		_, err := newTestClient(ts.URL, VersionV3).Test(t.Context())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "configured for Whisparr v3")
 	})
@@ -129,7 +128,7 @@ func TestClient_Test(t *testing.T) {
 
 		client := New(Config{Hostname: ts.URL, APIKey: "wrong", Version: VersionV2, Log: zerolog.Nop()})
 
-		_, err := client.Test(context.Background())
+		_, err := client.Test(t.Context())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unauthorized")
 	})
@@ -140,7 +139,7 @@ func TestClient_GetAllSeries(t *testing.T) {
 
 	ts := newTestServer(t, VersionV2)
 
-	series, err := newTestClient(ts.URL, VersionV2).GetAllSeries(context.Background())
+	series, err := newTestClient(ts.URL, VersionV2).GetAllSeries(t.Context())
 	require.NoError(t, err)
 	require.Len(t, series, 2)
 
@@ -158,7 +157,7 @@ func TestClient_GetMovies(t *testing.T) {
 
 	ts := newTestServer(t, VersionV3)
 
-	movies, err := newTestClient(ts.URL, VersionV3).GetMovies(context.Background())
+	movies, err := newTestClient(ts.URL, VersionV3).GetMovies(t.Context())
 	require.NoError(t, err)
 	require.Len(t, movies, 2)
 
@@ -181,14 +180,14 @@ func TestClient_ItemEndpointsAreVersionSpecific(t *testing.T) {
 	t.Run("no movie endpoint on v2", func(t *testing.T) {
 		ts := newTestServer(t, VersionV2)
 
-		_, err := newTestClient(ts.URL, VersionV2).GetMovies(context.Background())
+		_, err := newTestClient(ts.URL, VersionV2).GetMovies(t.Context())
 		require.Error(t, err)
 	})
 
 	t.Run("no series endpoint on v3", func(t *testing.T) {
 		ts := newTestServer(t, VersionV3)
 
-		_, err := newTestClient(ts.URL, VersionV3).GetAllSeries(context.Background())
+		_, err := newTestClient(ts.URL, VersionV3).GetAllSeries(t.Context())
 		require.Error(t, err)
 	})
 }
@@ -198,7 +197,7 @@ func TestClient_Push(t *testing.T) {
 
 	ts := newTestServer(t, VersionV3)
 
-	rejections, err := newTestClient(ts.URL, VersionV3).Push(context.Background(), ReleasePushRequest{
+	rejections, err := newTestClient(ts.URL, VersionV3).Push(t.Context(), ReleasePushRequest{
 		Title:            "Brazzers.Goes.Black.2018.1080p.BluRay.x264-GROUP",
 		DownloadUrl:      ts.URL + "/download",
 		Size:             1073741824,
@@ -229,7 +228,7 @@ func TestClient_Push_temporarilyRejected(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	t.Cleanup(ts.Close)
 
-	rejections, err := newTestClient(ts.URL, VersionV3).Push(context.Background(), ReleasePushRequest{
+	rejections, err := newTestClient(ts.URL, VersionV3).Push(t.Context(), ReleasePushRequest{
 		Title:            "Brazzers.Goes.Black.2018.1080p.BluRay.x264-GROUP",
 		DownloadUrl:      ts.URL + "/download",
 		Size:             1073741824,

--- a/pkg/btn/btn_test.go
+++ b/pkg/btn/btn_test.go
@@ -6,7 +6,6 @@
 package btn
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -71,7 +70,7 @@ func TestAPI(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewClient(tt.fields.APIKey, WithUrl(ts.URL))
 
-			got, err := c.TestAPI(context.Background())
+			got, err := c.TestAPI(t.Context())
 			if tt.wantErr && assert.Error(t, err) {
 				assert.Equal(t, tt.wantErr, err)
 			}
@@ -170,7 +169,7 @@ func TestClient_GetTorrentByID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewClient(tt.fields.APIKey, WithUrl(ts.URL))
 
-			got, err := c.GetTorrentByID(context.Background(), tt.args.torrentID)
+			got, err := c.GetTorrentByID(t.Context(), tt.args.torrentID)
 			if tt.wantErr && assert.Error(t, err) {
 				assert.Equal(t, tt.wantErr, err)
 			}
@@ -197,12 +196,12 @@ func TestClient_ThrottleOn503(t *testing.T) {
 
 	c := NewClient("mock-key", WithUrl(ts.URL))
 
-	_, err := c.GetTorrentByID(context.Background(), "9555073")
+	_, err := c.GetTorrentByID(t.Context(), "9555073")
 	assert.Error(t, err)
 	assert.Equal(t, int64(1), requests.Load())
 
 	// the second call must be refused locally instead of spending more budget
-	_, err = c.GetTorrentByID(context.Background(), "9555073")
+	_, err = c.GetTorrentByID(t.Context(), "9555073")
 	assert.ErrorContains(t, err, "not calling again until")
 	assert.Equal(t, int64(1), requests.Load())
 }

--- a/pkg/ggn/ggn_test.go
+++ b/pkg/ggn/ggn_test.go
@@ -6,7 +6,6 @@
 package ggn
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -109,7 +108,7 @@ func Test_client_GetTorrentByID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewClient(tt.fields.APIKey, WithUrl(ts.URL))
 
-			got, err := c.GetTorrentByID(context.Background(), tt.args.torrentID)
+			got, err := c.GetTorrentByID(t.Context(), tt.args.torrentID)
 			if tt.wantErr && assert.Error(t, err) {
 				t.Logf("got err: %v", err)
 				assert.Equal(t, tt.wantErr, err)

--- a/pkg/ops/ops_test.go
+++ b/pkg/ops/ops_test.go
@@ -6,7 +6,6 @@
 package ops
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -105,7 +104,7 @@ func TestOrpheusClient_GetTorrentByID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewClient(tt.fields.APIKey, WithUrl(ts.URL))
 
-			got, err := c.GetTorrentByID(context.Background(), tt.args.torrentID)
+			got, err := c.GetTorrentByID(t.Context(), tt.args.torrentID)
 			if tt.wantErr != "" && assert.Error(t, err) {
 				assert.EqualErrorf(t, err, tt.wantErr, "Error should be: %v, got: %v", tt.wantErr, err)
 			}

--- a/pkg/ptp/ptp_test.go
+++ b/pkg/ptp/ptp_test.go
@@ -6,7 +6,6 @@
 package ptp
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -96,7 +95,7 @@ func TestPTPClient_GetTorrentByID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewClient(tt.fields.APIUser, tt.fields.APIKey, WithUrl(ts.URL))
 
-			got, err := c.GetTorrentByID(context.Background(), tt.args.torrentID)
+			got, err := c.GetTorrentByID(t.Context(), tt.args.torrentID)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -179,7 +178,7 @@ func Test(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewClient(tt.fields.APIUser, tt.fields.APIKey, WithUrl(ts.URL))
 
-			got, err := c.TestAPI(context.Background())
+			got, err := c.TestAPI(t.Context())
 
 			if tt.wantErr && assert.Error(t, err) {
 				assert.Equal(t, tt.wantErr, err)

--- a/pkg/red/red_test.go
+++ b/pkg/red/red_test.go
@@ -6,7 +6,6 @@
 package red
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -105,7 +104,7 @@ func TestREDClient_GetTorrentByID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewClient(tt.fields.APIKey, WithUrl(ts.URL))
 
-			got, err := c.GetTorrentByID(context.Background(), tt.args.torrentID)
+			got, err := c.GetTorrentByID(t.Context(), tt.args.torrentID)
 			if tt.wantErr != "" && assert.Error(t, err) {
 				assert.EqualErrorf(t, err, tt.wantErr, "Error should be: %v, got: %v", tt.wantErr, err)
 			}


### PR DESCRIPTION
# Description

Runs the Postgres side of the database tests against an embedded Postgres instead of an externally provisioned server, and modernises context usage across the test suite.

* `internal/database` tests now boot an embedded Postgres (v17) on a free port in `TestMain` instead of expecting a server on `localhost:5437`
* `testDBs` holds a `*testDB` (db + cleanup) so teardown stops the server and closes both handles
* Dropped the `postgres:12.10` service container from the `test` job in `.github/workflows/release.yml` - CI no longer provisions a database, and tests run against v17 rather than 12.10
* Each embedded instance gets its own `RuntimePath`; binaries are extracted once into a package-specific `BinariesPath` under `os.UserCacheDir()` and reused. embedded-postgres does `os.RemoveAll(runtimePath)` on every `Start()`, so a shared default made `go test ./internal/database/...` race between the two packages that boot Postgres
* `migrations` tests take `*testing.T` for their setup helpers and use the same path isolation
* Replaced `context.Background()`/`context.TODO()` with `t.Context()` across `internal/` and `pkg/` tests; in `internal/database` it is hoisted to one `ctx := t.Context()` per top-level test function
* Context-timeout subtests now name their expired context `timeoutCtx`, so only the call under test gets it and setup/cleanup keep a live context

## Type of change

- [x] Refactor / maintenance (no functional change)

## How has this been tested?

* `go test -tags=integration ./internal/database/...` - passes, including with packages running in parallel (previously needed `-p 1` to avoid the extraction race)
* Verified cold start (binaries cache removed) and warm rerun; cleanup leaves no `autobrr-pg-runtime-*` directories behind
* Extraction reuse also cuts runtime: `migrations` 28.5s -> 6.5s, `database` 13.0s -> 1.8s warm
* `go vet -tags=integration ./internal/database/...` and `gofmt` clean
* Known failure, pre-existing and unrelated to this refactor: `TestReleaseCleanupJobRepo_UpdateLastRun` fails on hosts with a non-UTC local timezone. `release_cleanup_job.last_run` is `TIMESTAMP` without time zone, so lib/pq stores the local wall clock and reads it back tagged UTC. CI runs UTC so it is green there; now that everyone runs the Postgres tests locally, it will show up on non-UTC machines

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL