### PR TITLE
build(deps): update Go to 1.27.0 and bump Docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build web
-FROM node:24.18.0-alpine3.24 AS web-builder
+FROM node:24.19.0-alpine3.24 AS web-builder
 # Update and enable Corepack
 RUN npm install -g corepack@latest && \
     corepack enable
@@ -13,7 +13,7 @@ COPY web ./
 RUN pnpm run build
 
 # build app
-FROM golang:1.26-alpine3.24 AS app-builder
+FROM golang:1.27-alpine3.24 AS app-builder
 
 ARG VERSION=dev
 ARG REVISION=dev

--- a/distrib/docker/ci.Dockerfile
+++ b/distrib/docker/ci.Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.24 AS app-builder
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine3.24 AS app-builder
 RUN apk add --no-cache git tzdata
 
 ENV SERVICE=autobrr

--- a/distrib/docker/ciwindows.Dockerfile
+++ b/distrib/docker/ciwindows.Dockerfile
@@ -1,5 +1,5 @@
 # build app
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.24 AS app-builder
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine3.24 AS app-builder
 RUN apk add --no-cache git tzdata
 
 ENV SERVICE=autobrr

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/autobrr
 
-go 1.26.0
+go 1.27.0
 
 replace github.com/r3labs/sse/v2 => github.com/autobrr/sse/v2 v2.0.0-20230520125637-530e06346d7d
 


### PR DESCRIPTION
Automated update of the Go toolchain and Docker base images.

| Target | From | To |
| --- | --- | --- |
| go.mod `go` directive | 1.26.0 | 1.27.0 |
| builder image | golang:1.26-alpine3.24 | golang:1.27-alpine3.24 |
| web-builder image | node:24.18.0-alpine3.24 | node:24.19.0-alpine3.24 |
| runner image | alpine:3.24 | alpine:3.24 |

Generated by the `Update Go & Docker base images` workflow from scripts/update-toolchain.sh.