### PR TITLE
feat(filters): set new external filter to enabled by default

### DIFF
--- a/web/src/screens/filters/sections/External.tsx
+++ b/web/src/screens/filters/sections/External.tsx
@@ -34,7 +34,7 @@ export function External() {
     id: values.external.length + 1,
     index: values.external.length,
     name: `External ${values.external.length + 1}`,
-    enabled: false,
+    enabled: true,
     type: "EXEC",
     on_error: "REJECT",
   };


### PR DESCRIPTION
# Description

When adding an external filter (script/webhook) in the filter form, the new entry now starts as `enabled: true` instead of disabled. Adding one is an explicit action, so defaulting it to off was an easy way to save a filter and wonder why the external check never ran.

- `web/src/screens/filters/sections/External.tsx`: new external filter object is created with `enabled: true`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

* Manually: added a new external filter in the filter External tab and verified the toggle starts enabled; existing saved filters are unaffected

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)