### PR TITLE
fix(indexers): torrentleech auth

### DIFF
--- a/internal/indexer/definition_test.go
+++ b/internal/indexer/definition_test.go
@@ -108,12 +108,19 @@ func TestBundledDefinitionIRCAuth(t *testing.T) {
 	require.NoError(t, s.LoadIndexerDefinitions())
 
 	for _, identifier := range []string{
-		"aither", "animebytes", "brks", "docspedia", "funfile", "sharewood", "superbits", "torrentleech", "zenith",
+		"aither", "animebytes", "brks", "docspedia", "funfile", "sharewood", "superbits", "zenith",
 	} {
 		definition := s.definitions[identifier]
 		require.NotNil(t, definition.IRC, identifier)
 		require.NotNil(t, definition.IRC.Auth, identifier)
 		assert.Equal(t, domain.IRCAuthMechanismNickServ, definition.IRC.Auth.Mechanism, identifier)
+	}
+
+	for _, identifier := range []string{"torrentleech"} {
+		definition := s.definitions[identifier]
+		require.NotNil(t, definition.IRC, identifier)
+		require.NotNil(t, definition.IRC.Auth, identifier)
+		assert.Equal(t, domain.IRCAuthMechanismNone, definition.IRC.Auth.Mechanism, identifier)
 	}
 
 	for _, identifier := range []string{"alpharatio"} {

--- a/internal/indexer/definitions/torrentleech.yaml
+++ b/internal/indexer/definitions/torrentleech.yaml
@@ -31,7 +31,7 @@ irc:
   port: 7021
   tls: true
   auth:
-    mechanism: NICKSERV
+    mechanism: NONE
   settings:
     - name: nick
       type: text


### PR DESCRIPTION
# Description

TorrentLeech has changed some configuration on their end and now the default auth settings are causing problems for them that they have been banning people for. They claim people have changed their config from the defaults, but in fact the defaults are no longer correct.

Their official statement:
<blockquote>
⚠️ autobrr users: IRC settings causing connect/disconnect spam — please read before configuring

We've had to ban over 500 users in the past period due to a misconfiguration in autobrr's IRC settings that was hammering our IRC network with rapid connect/disconnect cycles — effectively a DDoS against our own infrastructure.

The issue: In autobrr, under Settings → IRC, when editing your announce connection (e.g. TorrentLeech), there's an Identification section with a "Mechanism" dropdown. Some users are setting this to SASL (plain) or NickServ, which causes their bot to connect and disconnect every 1-2 seconds — flooding the network.

The fix: Leave the Mechanism set to None. This is the default setting for a reason.
- You do not need to register your bot on IRC
- You do not need SASL or NickServ authentication
- Your bot will autojoin the correct channel automatically with no extra configuration

If you're affected:
1. Go to autobrr → Settings → IRC
2. Click the 3 dots on the TorrentLeech tab
3. Click Edit
4. Open the Identification section
5. If Mechanism is set to anything other than None, change it back to None

Accounts caught repeatedly triggering this will be banned to protect the network for everyone else. If you were banned and have now fixed your settings, please reach out to support/staff to be reconsidered.
</blockquote>

## Type of change

- [x] Indexer definition update

## How has this been tested?

- `go test ./internal/indexer/` passes

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally

## AI disclosure

AI made this change for me.
I am a Software Dev of 15 years and reviewed it's changes.
