### PR TITLE
feat(actions): support rejection via exec script output

### DIFF
--- a/internal/action/exec.go
+++ b/internal/action/exec.go
@@ -4,8 +4,11 @@
 package action
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -15,34 +18,28 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func (s *Service) execCmd(ctx context.Context, action *domain.Action, release *domain.Release) error {
+func (s *Service) execCmd(ctx context.Context, action *domain.Action, release *domain.Release) ([]string, error) {
 	l := zerolog.Ctx(ctx)
 
 	l.Debug().Msg("running Exec action")
 
-	// check if program exists
 	cmd, err := exec.LookPath(action.ExecCmd)
 	if err != nil {
-		return errors.Wrap(err, "exec failed, could not find program: %s", action.ExecCmd)
+		return nil, errors.Wrap(err, "exec failed, could not find program: %s", action.ExecCmd)
 	}
 
 	args, err := shellquote.Split(action.ExecArgs)
 	if err != nil {
-		return errors.Wrap(err, "could not parse exec args: %s", action.ExecArgs)
+		return nil, errors.Wrap(err, "could not parse exec args: %s", action.ExecArgs)
 	}
-
-	// we need to split on space into a string slice, so we can spread the args into exec
 
 	start := time.Now()
 
-	// setup command and args
 	command := exec.CommandContext(ctx, cmd, args...)
 
-	// execute command
 	output, err := command.CombinedOutput()
 	if err != nil {
-		// everything other than exit 0 is considered an error
-		return errors.Wrap(err, "error executing command: %s args: %s", cmd, args)
+		return nil, errors.Wrap(err, "error executing command: %s args: %s", cmd, args)
 	}
 
 	l.Trace().Str("output", string(output)).Msg("executed command")
@@ -51,5 +48,17 @@ func (s *Service) execCmd(ctx context.Context, action *domain.Action, release *d
 
 	l.Info().Str("cmd", cmd).Strs("args", args).Str("indexer", release.Indexer.Identifier).Dur("duration", duration).Msg("executed command")
 
-	return nil
+	// Scripts signal rejection by printing one or more lines prefixed with "REJECT:".
+	// Any other output is ignored, preserving backwards compatibility with existing scripts.
+	var rejections []string
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		if line := scanner.Text(); strings.HasPrefix(line, "REJECT:") {
+			if reason := strings.TrimSpace(strings.TrimPrefix(line, "REJECT:")); reason != "" {
+				rejections = append(rejections, reason)
+			}
+		}
+	}
+
+	return rejections, nil
 }

--- a/internal/action/exec.go
+++ b/internal/action/exec.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
@@ -48,17 +49,32 @@ func (s *Service) execCmd(ctx context.Context, action *domain.Action, release *d
 
 	l.Info().Str("cmd", cmd).Strs("args", args).Str("indexer", release.Indexer.Identifier).Dur("duration", duration).Msg("executed command")
 
-	// Scripts signal rejection by printing one or more lines prefixed with "REJECT:".
-	// Any other output is ignored, preserving backwards compatibility with existing scripts.
-	var rejections []string
+	return parseExecRejections(output), nil
+}
+
+// parseExecRejections reads the trailing block of "REJECT:"-prefixed lines from a script's
+// output. Only lines at the very end of the output are considered, so scripts can log freely
+// before signalling rejection; the scan stops at the first line (from the bottom) that isn't
+// a REJECT: line, and any output before that is ignored for backwards compatibility.
+func parseExecRejections(output []byte) []string {
+	var lines []string
 	scanner := bufio.NewScanner(bytes.NewReader(output))
 	for scanner.Scan() {
-		if line := scanner.Text(); strings.HasPrefix(line, "REJECT:") {
-			if reason := strings.TrimSpace(strings.TrimPrefix(line, "REJECT:")); reason != "" {
-				rejections = append(rejections, reason)
-			}
+		lines = append(lines, scanner.Text())
+	}
+
+	var rejections []string
+	for i := len(lines) - 1; i >= 0; i-- {
+		reason, ok := strings.CutPrefix(lines[i], "REJECT:")
+		if !ok {
+			break
+		}
+		if reason = strings.TrimSpace(reason); reason != "" {
+			rejections = append(rejections, reason)
 		}
 	}
 
-	return rejections, nil
+	slices.Reverse(rejections)
+
+	return rejections
 }

--- a/internal/action/exec_test.go
+++ b/internal/action/exec_test.go
@@ -127,6 +127,38 @@ func Test_service_execCmd(t *testing.T) {
 			wantErr:        false,
 		},
 		{
+			name: "rejected_after_leading_log_output",
+			args: args{
+				release: domain.Release{
+					TorrentName: "This is a test",
+					Indexer:     domain.IndexerMinimal{Identifier: "mock"},
+				},
+				action: &domain.Action{
+					Name:     "sh",
+					ExecCmd:  "sh",
+					ExecArgs: `-c "printf 'checking release\nREJECT: too old\n'"`,
+				},
+			},
+			wantRejections: []string{"too old"},
+			wantErr:        false,
+		},
+		{
+			name: "approved_reject_not_trailing",
+			args: args{
+				release: domain.Release{
+					TorrentName: "This is a test",
+					Indexer:     domain.IndexerMinimal{Identifier: "mock"},
+				},
+				action: &domain.Action{
+					Name:     "sh",
+					ExecCmd:  "sh",
+					ExecArgs: `-c "printf 'REJECT: too old\ndone\n'"`,
+				},
+			},
+			wantRejections: nil,
+			wantErr:        false,
+		},
+		{
 			name: "approved_non_reject_output",
 			args: args{
 				release: domain.Release{

--- a/internal/action/exec_test.go
+++ b/internal/action/exec_test.go
@@ -73,21 +73,17 @@ func Test_service_execCmd(t *testing.T) {
 		action  *domain.Action
 	}
 	tests := []struct {
-		name string
-		args args
+		name           string
+		args           args
+		wantRejections []string
+		wantErr        bool
 	}{
 		{
-			name: "test_1",
+			name: "approved_no_output",
 			args: args{
 				release: domain.Release{
-					TorrentName:    "This is a test",
-					TorrentTmpFile: "tmp-10000",
-					Indexer: domain.IndexerMinimal{
-						ID:                 0,
-						Name:               "Mock Indexer",
-						Identifier:         "mock",
-						IdentifierExternal: "Mock Indexer",
-					},
+					TorrentName: "This is a test",
+					Indexer:     domain.IndexerMinimal{Identifier: "mock"},
 				},
 				action: &domain.Action{
 					Name:     "echo",
@@ -95,6 +91,72 @@ func Test_service_execCmd(t *testing.T) {
 					ExecArgs: "hello",
 				},
 			},
+			wantRejections: nil,
+			wantErr:        false,
+		},
+		{
+			name: "rejected_single_reason",
+			args: args{
+				release: domain.Release{
+					TorrentName: "This is a test",
+					Indexer:     domain.IndexerMinimal{Identifier: "mock"},
+				},
+				action: &domain.Action{
+					Name:     "sh",
+					ExecCmd:  "sh",
+					ExecArgs: `-c "echo 'REJECT: release is too old'"`,
+				},
+			},
+			wantRejections: []string{"release is too old"},
+			wantErr:        false,
+		},
+		{
+			name: "rejected_multiple_reasons",
+			args: args{
+				release: domain.Release{
+					TorrentName: "This is a test",
+					Indexer:     domain.IndexerMinimal{Identifier: "mock"},
+				},
+				action: &domain.Action{
+					Name:     "sh",
+					ExecCmd:  "sh",
+					ExecArgs: `-c "printf 'REJECT: too old\nREJECT: wrong group\n'"`,
+				},
+			},
+			wantRejections: []string{"too old", "wrong group"},
+			wantErr:        false,
+		},
+		{
+			name: "approved_non_reject_output",
+			args: args{
+				release: domain.Release{
+					TorrentName: "This is a test",
+					Indexer:     domain.IndexerMinimal{Identifier: "mock"},
+				},
+				action: &domain.Action{
+					Name:     "sh",
+					ExecCmd:  "sh",
+					ExecArgs: `-c "echo 'all good'"`,
+				},
+			},
+			wantRejections: nil,
+			wantErr:        false,
+		},
+		{
+			name: "error_nonzero_exit",
+			args: args{
+				release: domain.Release{
+					TorrentName: "This is a test",
+					Indexer:     domain.IndexerMinimal{Identifier: "mock"},
+				},
+				action: &domain.Action{
+					Name:     "sh",
+					ExecCmd:  "sh",
+					ExecArgs: `-c "exit 1"`,
+				},
+			},
+			wantRejections: nil,
+			wantErr:        true,
 		},
 	}
 	for _, tt := range tests {
@@ -104,7 +166,13 @@ func Test_service_execCmd(t *testing.T) {
 				repo:      nil,
 				clientSvc: nil,
 			}
-			s.execCmd(t.Context(), tt.args.action, &tt.args.release)
+			rejections, err := s.execCmd(t.Context(), tt.args.action, &tt.args.release)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantRejections, rejections)
 		})
 	}
 }

--- a/internal/action/run.go
+++ b/internal/action/run.go
@@ -49,7 +49,7 @@ func (s *Service) RunAction(ctx context.Context, action *domain.Action, release 
 		s.test(ctx)
 
 	case domain.ActionTypeExec:
-		err = s.execCmd(ctx, action, release)
+		rejections, err = s.execCmd(ctx, action, release)
 
 	case domain.ActionTypeWatchFolder:
 		err = s.watchFolder(ctx, action, release)


### PR DESCRIPTION
# Description

The `Exec` action currently supports only two outcomes: approved (exit 0) or error (non-zero exit). This adds a third outcome — **rejected** — without breaking existing scripts.

Scripts can signal rejection by printing a trailing block of one or more lines prefixed with `REJECT:` to stdout/stderr and exiting 0. Detection walks backward from the end of the output and stops at the first non-`REJECT:` line, so a script can log freely and only its final lines control the rejection decision; a `REJECT:` line that isn't part of that trailing block is ignored. Each captured line (minus the prefix and surrounding whitespace) becomes a rejection reason, matching the `[]string` pattern used by other action types (arr clients, qBittorrent, etc.).

Non-zero exit codes remain errors, and scripts with no trailing `REJECT:` lines continue to be treated as approved. Existing scripts require no modification.

Example script:
```bash
#!/bin/bash
if some_condition; then
    echo "REJECT: release does not meet criteria"
    exit 0
fi
# approved — exit 0 with no REJECT: lines
```

**Why this format:** the goal was a rejection signal that's trivial for any script to emit and impossible to get wrong, without forcing script authors to adopt a structured output format. A convention that required scripts to emit JSON (or any other structured payload) on stdout would break every existing Exec action script overnight and raise the bar for writing a new one — you'd need a JSON encoder just to say "no thanks" from a five-line shell script. Plain `REJECT: <reason>` lines mean:

- **Backwards compatible** - scripts that don't know about this convention keep working exactly as before; their output is simply ignored and the release is approved, same as today.
- **Trivial to adopt** - `echo "REJECT: too old"` (or the equivalent in any language) is the whole integration. No schema, no encoding/escaping rules, no library.
- **Easy to reason about** - a human reading a script's output can immediately tell whether/why it rejected, without decoding anything.

> **Note:** The Exec action docs at autobrr.com should be updated to document the `REJECT:` prefix convention.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Added/updated unit tests in `internal/action/exec_test.go` covering:

* no output (approved)
* a single trailing `REJECT:` line
* multiple trailing `REJECT:` lines
* a `REJECT:` line preceded by unrelated log output (still detected)
* a `REJECT:` line followed by non-`REJECT:` output (ignored, not trailing)
* non-`REJECT:`-prefixed output (approved)
* non-zero exit code (error)

`go test ./internal/action/...` passes.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [ ] I have linked any related issue and updated docs if needed

## AI disclosure

Yes. This PR was developed with the help of Claude (Sonnet 5, Anthropic) via Claude Code. The implementation, tests, and this description were AI-assisted, but every design decision (the `REJECT:` convention itself, the trailing-block-only detection semantics, and the rationale for avoiding a structured/JSON output format) was discussed, iterated on, and reviewed by me. The resulting code and tests were read and verified line-by-line before pushing, not accepted as-is.