### PR TITLE
feat(indexers): add Simurg

### DIFF
--- a/internal/indexer/definitions/simurg.yaml
+++ b/internal/indexer/definitions/simurg.yaml
@@ -58,9 +58,9 @@ irc:
       parse:
         type: single
         lines:
-          - pattern: '^SIMURG \| NEW \| Category=(?P<category>.*?) \| Leech=(?P<leechEnum>Normal|Freeleech|Naturaleech) \| Tags=(?P<releaseTags>.* \/ (?P<language>[^|]+?)) \| Size=(?P<torrentSize>.*?) \| Name=(?P<releaseName>.*?) \| GroupID=(?P<groupId>\d+) \| TorrentID=(?P<torrentId>\d+) \| URL=(?P<baseUrl>https?:\/\/[^\/]+\/)torrents\.php\?id=\d+&torrentid=\d+$'
+          - pattern: '^NEW \| Category=(?P<category>.*?) \| Leech=(?P<leechEnum>Normal|Freeleech|Naturaleech) \| Tags=(?P<releaseTags>.* \/ (?P<language>[^|]+?)) \| Size=(?P<torrentSize>.*?) \| Name=(?P<releaseName>.*?) \| URL=(?P<baseUrl>https?:\/\/[^\/]+\/)torrents\.php\?id=(?P<groupId>\d+)&torrentid=(?P<torrentId>\d+)$'
             tests:
-              - line: 'SIMURG | NEW | Category=E-Book | Leech=Freeleech | Tags=PDF / OCR / Turkish | Size=2.48 MiB | Name=Example Turkish Book by Example Author | GroupID=1001 | TorrentID=2001 | URL=https://simurg.world/torrents.php?id=1001&torrentid=2001'
+              - line: 'NEW | Category=E-Book | Leech=Freeleech | Tags=PDF / OCR / Turkish | Size=2.48 MiB | Name=Example Turkish Book by Example Author | URL=https://simurg.world/torrents.php?id=1001&torrentid=2001'
                 expect:
                   category: E-Book
                   leechEnum: Freeleech
@@ -68,11 +68,11 @@ irc:
                   language: Turkish
                   torrentSize: 2.48 MiB
                   releaseName: Example Turkish Book by Example Author
+                  baseUrl: https://simurg.world/
                   groupId: "1001"
                   torrentId: "2001"
-                  baseUrl: https://simurg.world/
 
-              - line: 'SIMURG | NEW | Category=Magazine | Leech=Freeleech | Tags=PDF / Scan / English | Size=461.16 MiB | Name=Example Magazine - 1954 Complete Year | GroupID=1002 | TorrentID=2002 | URL=https://simurg.world/torrents.php?id=1002&torrentid=2002'
+              - line: 'NEW | Category=Magazine | Leech=Freeleech | Tags=PDF / Scan / English | Size=461.16 MiB | Name=Example Magazine - 1954 Complete Year | URL=https://simurg.world/torrents.php?id=1002&torrentid=2002'
                 expect:
                   category: Magazine
                   leechEnum: Freeleech
@@ -80,11 +80,11 @@ irc:
                   language: English
                   torrentSize: 461.16 MiB
                   releaseName: Example Magazine - 1954 Complete Year
+                  baseUrl: https://simurg.world/
                   groupId: "1002"
                   torrentId: "2002"
-                  baseUrl: https://simurg.world/
 
-              - line: 'SIMURG | NEW | Category=Audiobook | Leech=Normal | Tags=MP3 / English | Size=1.20 GiB | Name=Example Audiobook | GroupID=1003 | TorrentID=2003 | URL=https://simurg.world/torrents.php?id=1003&torrentid=2003'
+              - line: 'NEW | Category=Audiobook | Leech=Normal | Tags=MP3 / English | Size=1.20 GiB | Name=Example Audiobook | URL=https://simurg.world/torrents.php?id=1003&torrentid=2003'
                 expect:
                   category: Audiobook
                   leechEnum: Normal
@@ -92,11 +92,11 @@ irc:
                   language: English
                   torrentSize: 1.20 GiB
                   releaseName: Example Audiobook
+                  baseUrl: https://simurg.world/
                   groupId: "1003"
                   torrentId: "2003"
-                  baseUrl: https://simurg.world/
 
-              - line: 'SIMURG | NEW | Category=Comics & Manga | Leech=Naturaleech | Tags=CBZ / English | Size=850.00 MiB | Name=Example Comic | GroupID=1004 | TorrentID=2004 | URL=https://simurg.world/torrents.php?id=1004&torrentid=2004'
+              - line: 'NEW | Category=Comics & Manga | Leech=Naturaleech | Tags=CBZ / English | Size=850.00 MiB | Name=Example Comic | URL=https://simurg.world/torrents.php?id=1004&torrentid=2004'
                 expect:
                   category: Comics & Manga
                   leechEnum: Naturaleech
@@ -104,9 +104,9 @@ irc:
                   language: English
                   torrentSize: 850.00 MiB
                   releaseName: Example Comic
+                  baseUrl: https://simurg.world/
                   groupId: "1004"
                   torrentId: "2004"
-                  baseUrl: https://simurg.world/
 
         mappings:
           leechEnum:

--- a/internal/indexer/definitions/simurg.yaml
+++ b/internal/indexer/definitions/simurg.yaml
@@ -1,0 +1,125 @@
+---
+version: 2
+#id: simurg
+name: Simurg
+identifier: simurg
+description: Simurg (SIM) is a private tracker for E-BOOKS, AUDIOBOOKS, COMICS, MANGA, and MAGAZINES.
+language: en-us
+urls:
+  - https://simurg.world/
+privacy: private
+protocol: torrent
+supports:
+  - irc
+  - rss
+# source: gazelle
+settings:
+  - name: torrent_pass
+    type: secret
+    required: true
+    label: Torrent pass
+    help: Right click a torrent's download link and copy the torrent_pass value.
+
+irc:
+  network: Simurg
+  server: irc.simurg.world
+  port: 6697
+  tls: true
+  settings:
+    - name: nick
+      type: text
+      required: true
+      label: Nick
+      help: Bot nick. Eg. user|bot
+
+    - name: auth.account
+      type: text
+      required: true
+      label: NickServ Account
+      help: NickServ account. Make sure to group your user and bot.
+
+    - name: auth.password
+      type: secret
+      required: true
+      label: NickServ Password
+      help: NickServ password
+
+    - name: invite_command
+      type: secret
+      default: "Qaf .invite IRCKEY"
+      required: true
+      label: Invite command
+      help: Invite auth with Qaf. Replace IRCKEY with your IRC key.
+
+  channels:
+    - name: "#announce"
+      announcers:
+        - Soroush
+      parse:
+        type: single
+        lines:
+          - pattern: '^SIMURG \| NEW \| Category=(?P<category>.*?) \| Leech=(?P<leechEnum>Normal|Freeleech|Naturaleech) \| Tags=(?P<releaseTags>.* \/ (?P<language>[^|]+?)) \| Size=(?P<torrentSize>.*?) \| Name=(?P<releaseName>.*?) \| GroupID=(?P<groupId>\d+) \| TorrentID=(?P<torrentId>\d+) \| URL=(?P<baseUrl>https?:\/\/[^\/]+\/)torrents\.php\?id=\d+&torrentid=\d+$'
+            tests:
+              - line: 'SIMURG | NEW | Category=E-Book | Leech=Freeleech | Tags=PDF / OCR / Turkish | Size=2.48 MiB | Name=Example Turkish Book by Example Author | GroupID=1001 | TorrentID=2001 | URL=https://simurg.world/torrents.php?id=1001&torrentid=2001'
+                expect:
+                  category: E-Book
+                  leechEnum: Freeleech
+                  releaseTags: PDF / OCR / Turkish
+                  language: Turkish
+                  torrentSize: 2.48 MiB
+                  releaseName: Example Turkish Book by Example Author
+                  groupId: "1001"
+                  torrentId: "2001"
+                  baseUrl: https://simurg.world/
+
+              - line: 'SIMURG | NEW | Category=Magazine | Leech=Freeleech | Tags=PDF / Scan / English | Size=461.16 MiB | Name=Example Magazine - 1954 Complete Year | GroupID=1002 | TorrentID=2002 | URL=https://simurg.world/torrents.php?id=1002&torrentid=2002'
+                expect:
+                  category: Magazine
+                  leechEnum: Freeleech
+                  releaseTags: PDF / Scan / English
+                  language: English
+                  torrentSize: 461.16 MiB
+                  releaseName: Example Magazine - 1954 Complete Year
+                  groupId: "1002"
+                  torrentId: "2002"
+                  baseUrl: https://simurg.world/
+
+              - line: 'SIMURG | NEW | Category=Audiobook | Leech=Normal | Tags=MP3 / English | Size=1.20 GiB | Name=Example Audiobook | GroupID=1003 | TorrentID=2003 | URL=https://simurg.world/torrents.php?id=1003&torrentid=2003'
+                expect:
+                  category: Audiobook
+                  leechEnum: Normal
+                  releaseTags: MP3 / English
+                  language: English
+                  torrentSize: 1.20 GiB
+                  releaseName: Example Audiobook
+                  groupId: "1003"
+                  torrentId: "2003"
+                  baseUrl: https://simurg.world/
+
+              - line: 'SIMURG | NEW | Category=Comics & Manga | Leech=Naturaleech | Tags=CBZ / English | Size=850.00 MiB | Name=Example Comic | GroupID=1004 | TorrentID=2004 | URL=https://simurg.world/torrents.php?id=1004&torrentid=2004'
+                expect:
+                  category: Comics & Manga
+                  leechEnum: Naturaleech
+                  releaseTags: CBZ / English
+                  language: English
+                  torrentSize: 850.00 MiB
+                  releaseName: Example Comic
+                  groupId: "1004"
+                  torrentId: "2004"
+                  baseUrl: https://simurg.world/
+
+        mappings:
+          leechEnum:
+            Normal:
+              downloadVolumeFactor: 1
+              uploadVolumeFactor: 1
+            Freeleech:
+              downloadVolumeFactor: 0
+              uploadVolumeFactor: 1
+            Naturaleech:
+              downloadVolumeFactor: 0
+              uploadVolumeFactor: 0
+
+        match:
+          infourl: "/torrents.php?id={{ .groupId }}&torrentid={{ .torrentId }}"
+          downloadurl: "/torrents.php?action=download&id={{ .torrentId }}&torrent_pass={{ .torrent_pass }}"


### PR DESCRIPTION
# Description

Adds an indexer definition for Simurg.

The definition includes:

- IRC connection, NickServ, and invite command settings
- Torrent pass configuration and download URLs
- Parsing for category, tags, language, size, release name, group ID, and torrent ID
- Volume-factor mappings for Normal, Freeleech, and Naturaleech releases
- Parser tests covering each leech mode and multiple categories

Fixes #2638

## Type of change

- [x] New indexer definition

## How has this been tested?

- `go test ./internal/indexer/...`
- `git diff --check`

## Checklist

- [x] My PR title follows the Conventional Commits format
- [x] I have linked the related issue
- [x] No database or documentation changes are required