### PR TITLE
feat(downloaders): Sonarr and Radarr send IMDB and TMDB ids

### DIFF
--- a/internal/action/radarr.go
+++ b/internal/action/radarr.go
@@ -5,6 +5,8 @@ package action
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -48,6 +50,18 @@ func (s *Service) radarr(ctx context.Context, action *domain.Action, release *do
 		DownloadProtocol: release.Protocol.String(),
 		Protocol:         release.Protocol.String(),
 		PublishDate:      time.Now().Format(time.RFC3339),
+		TmdbID:           release.MetaTMDB,
+	}
+
+	if release.MetaIMDB != "" {
+		if idStr, idOk := strings.CutPrefix(release.MetaIMDB, "tt"); idOk {
+			id, err := strconv.Atoi(idStr)
+			if err == nil {
+				r.ImdbID = id
+			} else {
+				s.log.Error().Err(err).Msg("could not parse IMDB ID from release")
+			}
+		}
 	}
 
 	if action.ExternalDownloadClientID > 0 {

--- a/internal/action/sonarr.go
+++ b/internal/action/sonarr.go
@@ -48,6 +48,7 @@ func (s *Service) sonarr(ctx context.Context, action *domain.Action, release *do
 		DownloadProtocol: release.Protocol.String(),
 		Protocol:         release.Protocol.String(),
 		PublishDate:      time.Now().Format(time.RFC3339),
+		ImdbID:           release.MetaIMDB,
 	}
 
 	if action.ExternalDownloadClientID > 0 {

--- a/pkg/arr/radarr/types.go
+++ b/pkg/arr/radarr/types.go
@@ -114,6 +114,8 @@ type ReleasePushRequest struct {
 	DownloadClientId int    `json:"downloadClientId,omitempty"`
 	DownloadClient   string `json:"downloadClient,omitempty"`
 	IndexerFlags     int    `json:"indexerFlags,omitempty"`
+	TmdbID           int    `json:"tmdbId,omitempty"`
+	ImdbID           int    `json:"imdbId,omitempty"`
 }
 
 type ReleasePushResponse struct {

--- a/pkg/arr/sonarr/types.go
+++ b/pkg/arr/sonarr/types.go
@@ -24,6 +24,7 @@ type ReleasePushRequest struct {
 	DownloadClientId int    `json:"downloadClientId,omitempty"`
 	DownloadClient   string `json:"downloadClient,omitempty"`
 	IndexerFlags     int    `json:"indexerFlags,omitempty"`
+	ImdbID           string `json:"imdbId,omitempty"`
 }
 
 type ReleasePushResponse struct {


### PR DESCRIPTION
# Description

Sonarr and Radarr pushes now carry the meta ids parsed from the announce, so the arr can match the release to the right series/movie directly instead of relying on title matching alone.

* Sonarr `ReleasePushRequest` gains `imdbId`, set from `release.MetaIMDB` (the tt-prefixed string)
* Radarr `ReleasePushRequest` gains `tmdbId` and `imdbId`, set from `release.MetaTMDB` and from `MetaIMDB` with the `tt` prefix stripped and parsed to an int (Radarr models `imdbId` as a number)
* All new fields are `omitempty`, so pushes from indexers without `imdb`/`tmdb` announce vars are unchanged

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

* `go build ./...` and the Go test suite pass locally

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed
