### PR TITLE
feat(filters): add Test button to External filters

### DIFF
--- a/internal/domain/error.go
+++ b/internal/domain/error.go
@@ -20,5 +20,6 @@ var (
 	ErrIndexerNotArchived             = errors.New("indexer is not archived")
 	ErrIndexerInUse                   = errors.New("indexer is still used by filters")
 	ErrNotificationNotFound           = errors.New("notification not found")
+	ErrExternalFilterTypeUnsupported  = errors.New("unsupported external filter type")
 	ErrIRCNetworkHandlerNotFound      = errors.New("could not find network handler")
 )

--- a/internal/domain/filter.go
+++ b/internal/domain/filter.go
@@ -250,6 +250,19 @@ const (
 	ExternalFilterTypeWebhook FilterExternalType = "WEBHOOK"
 )
 
+// FilterExternalTestResult is the outcome of running one external filter
+// against a sample release from the filter form. Status holds the exit code
+// for scripts and the HTTP status code for webhooks.
+type FilterExternalTestResult struct {
+	Type         FilterExternalType `json:"type"`
+	Success      bool               `json:"success"`
+	Status       int                `json:"status"`
+	ExpectStatus int                `json:"expect_status"`
+	Output       string             `json:"output"`
+	Error        string             `json:"error,omitempty"`
+	DurationMs   int64              `json:"duration_ms"`
+}
+
 type FilterNotification struct {
 	FilterID       int      `json:"filter_id"`
 	FilterName     string   `json:"filter_name"`

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -978,8 +978,7 @@ func (s *Service) RunExternalFilters(ctx context.Context, f *domain.Filter, exte
 
 		switch external.Type {
 		case domain.ExternalFilterTypeExec:
-			// run external script
-			exitCode, err := s.execCmd(ctx, external, release)
+			exitCode, _, err := s.execCmd(ctx, external, release)
 			if err != nil {
 				l.Error().Err(err).Msg("error executing external script")
 
@@ -997,8 +996,7 @@ func (s *Service) RunExternalFilters(ctx context.Context, f *domain.Filter, exte
 			}
 
 		case domain.ExternalFilterTypeWebhook:
-			// run external webhook
-			statusCode, err := s.webhook(ctx, external, release)
+			res, err := s.webhook(ctx, external, release)
 			if err != nil {
 				l.Error().Err(err).Msg("error executing external webhook")
 
@@ -1010,9 +1008,9 @@ func (s *Service) RunExternalFilters(ctx context.Context, f *domain.Filter, exte
 				return false, errors.Wrap(err, "error executing external webhook")
 			}
 
-			if statusCode != external.WebhookExpectStatus {
-				l.Debug().Int("expected_status", external.WebhookExpectStatus).Int("actual_status", statusCode).Msg("external webhook got unexpected status code")
-				f.RejectReasons.Add("external webhook status code", statusCode, external.WebhookExpectStatus)
+			if res.statusCode != external.WebhookExpectStatus {
+				l.Debug().Int("expected_status", external.WebhookExpectStatus).Int("actual_status", res.statusCode).Msg("external webhook got unexpected status code")
+				f.RejectReasons.Add("external webhook status code", res.statusCode, external.WebhookExpectStatus)
 				return false, nil
 			}
 		}
@@ -1021,91 +1019,143 @@ func (s *Service) RunExternalFilters(ctx context.Context, f *domain.Filter, exte
 	return true, nil
 }
 
-func (s *Service) execCmd(_ context.Context, external domain.FilterExternal, release *domain.Release) (int, error) {
-	s.log.Trace().Str("release", release.TorrentName).Msg("filter exec release")
+// TestExternal runs one external filter against a sample release so a script
+// or webhook can be verified from the filter form before it is saved. Failures
+// are reported in the result rather than returned, since they are the point of
+// the test.
+func (s *Service) TestExternal(ctx context.Context, external *domain.FilterExternal) (*domain.FilterExternalTestResult, error) {
+	l := s.log.With().Str("method", "TestExternal").Str("external_filter", external.Name).Logger()
 
-	// check if program exists
-	cmd, err := exec.LookPath(external.ExecCmd)
-	if err != nil {
-		return 0, errors.Wrap(err, "exec failed, could not find program: %s", cmd)
-	}
+	release := newSampleRelease()
 
-	// handle args and replace vars
-	m := domain.NewMacro(*release)
-
-	// parse and replace values in argument string before continuing
-	parsedArgs, err := m.Parse(external.ExecArgs)
-	if err != nil {
-		return 0, errors.Wrap(err, "could not parse macro")
-	}
-
-	// we need to split on space into a string slice, so we can spread the args into exec
-	commandArgs, err := shellquote.Split(parsedArgs)
-	if err != nil {
-		return 0, errors.Wrap(err, "could not parse into shell-words")
-	}
+	result := &domain.FilterExternalTestResult{Type: external.Type}
 
 	start := time.Now()
 
-	// setup command and args
-	command := exec.Command(cmd, commandArgs...)
-
-	s.log.Debug().Str("script", cmd).Str("args", strings.Join(commandArgs, " ")).Msg("executing script")
-
-	// Create a pipe to capture the standard output of the command
-	cmdOutput, err := command.StdoutPipe()
-	if err != nil {
-		s.log.Error().Err(err).Msg("could not create stdout pipe")
-		return 0, err
-	}
-
-	duration := time.Since(start)
-
-	// Start the command
-	if err := command.Start(); err != nil {
-		s.log.Error().Err(err).Msg("error starting command")
-		return 0, err
-	}
-
-	// Create a buffer to store the output
-	outputBuffer := make([]byte, 4096)
-
-	execLogger := s.log.With().Str("trace_id", release.TraceID).Str("release", release.TorrentName).Str("filter", release.FilterName).Logger()
-
-	for {
-		// Read the output into the buffer
-		n, err := cmdOutput.Read(outputBuffer)
+	switch external.Type {
+	case domain.ExternalFilterTypeExec:
+		exitCode, output, err := s.execCmd(ctx, *external, release)
 		if err != nil {
-			break
+			l.Debug().Err(err).Msg("external script test failed")
+			result.Error = err.Error()
 		}
 
-		// Write the output to the logger
-		execLogger.Trace().Msg(string(outputBuffer[:n]))
-	}
+		result.Status = exitCode
+		result.ExpectStatus = external.ExecExpectStatus
+		result.Output = output
 
-	// Wait for the command to finish and check for any errors
-	if err := command.Wait(); err != nil {
-		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
-			s.log.Debug().Int("exit_code", exitErr.ExitCode()).Msg("filter script exited with non-zero code")
-			return exitErr.ExitCode(), nil
+	case domain.ExternalFilterTypeWebhook:
+		res, err := s.webhook(ctx, *external, release)
+		if err != nil {
+			l.Debug().Err(err).Msg("external webhook test failed")
+			result.Error = err.Error()
 		}
 
-		s.log.Error().Err(err).Msg("error waiting for command")
-		return 0, err
+		result.Status = res.statusCode
+		result.ExpectStatus = external.WebhookExpectStatus
+		result.Output = res.body
+
+	default:
+		return nil, errors.New("unsupported external filter type: %s", external.Type)
 	}
 
-	s.log.Debug().Str("script", cmd).Str("args", parsedArgs).Str("release", release.TorrentName).Str("indexer", release.Indexer.Identifier).Dur("duration", duration).Msg("executed external script")
+	result.DurationMs = time.Since(start).Milliseconds()
+	result.Success = result.Error == "" && result.Status == result.ExpectStatus
 
-	return 0, nil
+	return result, nil
 }
 
-func (s *Service) webhook(ctx context.Context, external domain.FilterExternal, release *domain.Release) (int, error) {
+// newSampleRelease stands in for an announce when an external filter is
+// tested, so every macro expands to something realistic.
+func newSampleRelease() *domain.Release {
+	rls := domain.NewRelease(domain.IndexerMinimal{ID: 0, Name: "MockIndexer", Identifier: "mock", IdentifierExternal: "MockIndexer"})
+	rls.ParseString("Best.Show.Ever.S18E21.1080p.AMZN.WEB-DL.DDP2.0.H.264-GROUP")
+	rls.FilterName = "TV"
+	rls.Category = "TV"
+	rls.Size = 1500000000
+	rls.TorrentID = "12345"
+	rls.InfoURL = "https://mock.local/torrents/12345"
+	rls.DownloadURL = "https://mock.local/torrents/12345/download"
+	rls.Uploader = "Uploader"
+
+	return rls
+}
+
+// externalOutputMaxBytes caps how much script output or webhook response body
+// is kept for logging and the test result.
+const externalOutputMaxBytes = 4096
+
+// outputBuffer keeps the first externalOutputMaxBytes written and drops the
+// rest, so a chatty script cannot grow memory unbounded.
+type outputBuffer struct {
+	bytes.Buffer
+}
+
+func (b *outputBuffer) Write(p []byte) (int, error) {
+	if remaining := externalOutputMaxBytes - b.Len(); remaining > 0 {
+		b.Buffer.Write(p[:min(len(p), remaining)])
+	}
+
+	return len(p), nil
+}
+
+func (s *Service) execCmd(_ context.Context, external domain.FilterExternal, release *domain.Release) (int, string, error) {
+	l := s.log.With().Str("method", "execCmd").Str("trace_id", release.TraceID).Str("external_filter", external.Name).Str("release", release.TorrentName).Logger()
+
+	cmd, err := exec.LookPath(external.ExecCmd)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "exec failed, could not find program: %s", external.ExecCmd)
+	}
+
+	m := domain.NewMacro(*release)
+
+	parsedArgs, err := m.Parse(external.ExecArgs)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "could not parse macro")
+	}
+
+	commandArgs, err := shellquote.Split(parsedArgs)
+	if err != nil {
+		return 0, "", errors.Wrap(err, "could not parse into shell-words")
+	}
+
+	var output outputBuffer
+
+	command := exec.Command(cmd, commandArgs...)
+	command.Stdout = &output
+	command.Stderr = &output
+
+	l.Debug().Str("script", cmd).Str("args", strings.Join(commandArgs, " ")).Msg("executing script")
+
+	start := time.Now()
+
+	if err := command.Run(); err != nil {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+			l.Debug().Int("exit_code", exitErr.ExitCode()).Str("output", output.String()).Msg("filter script exited with non-zero code")
+			return exitErr.ExitCode(), output.String(), nil
+		}
+
+		return 0, output.String(), errors.Wrap(err, "error running command")
+	}
+
+	l.Debug().Str("script", cmd).Str("args", parsedArgs).Str("indexer", release.Indexer.Identifier).Dur("duration", time.Since(start)).Msg("executed external script")
+	l.Trace().Str("output", output.String()).Msg("external script output")
+
+	return 0, output.String(), nil
+}
+
+type webhookResponse struct {
+	statusCode int
+	body       string
+}
+
+func (s *Service) webhook(ctx context.Context, external domain.FilterExternal, release *domain.Release) (webhookResponse, error) {
 	l := s.log.With().Str("method", "webhook").Str("trace_id", release.TraceID).Str("external_filter", external.Name).Str("host", external.WebhookHost).Str("http_method", external.WebhookMethod).Logger()
 
 	l.Trace().Str("payload", external.WebhookData).Msg("preparing to run external webhook filter")
 
 	if external.WebhookHost == "" {
-		return 0, errors.New("external filter: missing host for webhook")
+		return webhookResponse{}, errors.New("external filter: missing host for webhook")
 	}
 
 	m := domain.NewMacro(*release)
@@ -1113,7 +1163,7 @@ func (s *Service) webhook(ctx context.Context, external domain.FilterExternal, r
 	// parse and replace values in argument string before continuing
 	dataArgs, err := m.Parse(external.WebhookData)
 	if err != nil {
-		return 0, errors.Wrap(err, "could not parse webhook data macro: %s", external.WebhookData)
+		return webhookResponse{}, errors.Wrap(err, "could not parse webhook data macro: %s", external.WebhookData)
 	}
 
 	l.Debug().Str("payload", external.WebhookData).Msg("sending external webhook filter request")
@@ -1125,7 +1175,7 @@ func (s *Service) webhook(ctx context.Context, external domain.FilterExternal, r
 
 	req, err := http.NewRequestWithContext(ctx, method, external.WebhookHost, nil)
 	if err != nil {
-		return 0, errors.Wrap(err, "could not build request for webhook")
+		return webhookResponse{}, errors.Wrap(err, "could not build request for webhook")
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -1166,8 +1216,8 @@ func (s *Service) webhook(ctx context.Context, external domain.FilterExternal, r
 
 	start := time.Now()
 
-	statusCode, err := retry.DoWithData(
-		func() (int, error) {
+	response, err := retry.DoWithData(
+		func() (webhookResponse, error) {
 			clonereq := req.Clone(ctx)
 			if external.WebhookData != "" && dataArgs != "" {
 				clonereq.Body = io.NopCloser(bytes.NewBufferString(dataArgs))
@@ -1177,39 +1227,33 @@ func (s *Service) webhook(ctx context.Context, external domain.FilterExternal, r
 
 			res, err := s.httpClient.Do(clonereq)
 			if err != nil {
-				return 0, errors.Wrap(err, "could not make request for webhook")
+				return webhookResponse{}, errors.Wrap(err, "could not make request for webhook")
 			}
 
 			defer sharedhttp.DrainAndClose(res)
 
-			l.Debug().Int("status_code", res.StatusCode).Msg("filter external webhook response")
-
-			if s.log.Debug().Enabled() {
-				body, err := io.ReadAll(io.LimitReader(res.Body, 4096)) // 4KB limit for debug logging
-				if err != nil {
-					return res.StatusCode, errors.Wrap(err, "could not read request body")
-				}
-
-				if len(body) > 0 {
-					l.Debug().Int("status_code", res.StatusCode).Str("body", string(body)).Msg("filter external webhook response body")
-				}
+			body, err := io.ReadAll(io.LimitReader(res.Body, externalOutputMaxBytes))
+			if err != nil {
+				return webhookResponse{}, errors.Wrap(err, "could not read response body")
 			}
+
+			l.Debug().Int("status_code", res.StatusCode).Str("body", string(body)).Msg("filter external webhook response")
 
 			if slices.Contains(retryStatusCodes, strconv.Itoa(res.StatusCode)) {
-				return 0, errors.New("webhook got unwanted status code: %d", res.StatusCode)
+				return webhookResponse{}, errors.New("webhook got unwanted status code: %d", res.StatusCode)
 			}
 
-			return res.StatusCode, nil
+			return webhookResponse{statusCode: res.StatusCode, body: string(body)}, nil
 		},
 		opts...)
 
 	if err != nil {
 		l.Error().Err(err).Msg("error sending webhook")
 
-		return statusCode, errors.Wrap(err, "could not make request for webhook")
+		return webhookResponse{}, err
 	}
 
 	l.Debug().Str("args", dataArgs).TimeDiff("duration", time.Now(), start).Msg("successfully ran external webhook filter")
 
-	return statusCode, nil
+	return response, nil
 }

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -1086,17 +1086,23 @@ func newSampleRelease() *domain.Release {
 const externalOutputMaxBytes = 4096
 
 // outputBuffer keeps the first externalOutputMaxBytes written and drops the
-// rest, so a chatty script cannot grow memory unbounded.
+// rest, so a chatty script cannot grow memory unbounded. The bytes.Buffer is a
+// named field rather than embedded: os/exec pumps output with io.Copy, which
+// would take a promoted ReadFrom and bypass the cap.
 type outputBuffer struct {
-	bytes.Buffer
+	buf bytes.Buffer
 }
 
 func (b *outputBuffer) Write(p []byte) (int, error) {
-	if remaining := externalOutputMaxBytes - b.Len(); remaining > 0 {
-		b.Buffer.Write(p[:min(len(p), remaining)])
+	if remaining := externalOutputMaxBytes - b.buf.Len(); remaining > 0 {
+		b.buf.Write(p[:min(len(p), remaining)])
 	}
 
 	return len(p), nil
+}
+
+func (b *outputBuffer) String() string {
+	return b.buf.String()
 }
 
 func (s *Service) execCmd(_ context.Context, external domain.FilterExternal, release *domain.Release) (int, string, error) {

--- a/internal/filter/service.go
+++ b/internal/filter/service.go
@@ -1056,7 +1056,7 @@ func (s *Service) TestExternal(ctx context.Context, external *domain.FilterExter
 		result.Output = res.body
 
 	default:
-		return nil, errors.New("unsupported external filter type: %s", external.Type)
+		return nil, errors.Wrap(domain.ErrExternalFilterTypeUnsupported, "external filter type '%s' is not supported", external.Type)
 	}
 
 	result.DurationMs = time.Since(start).Milliseconds()

--- a/internal/filter/service_test.go
+++ b/internal/filter/service_test.go
@@ -326,7 +326,7 @@ func TestService_TestExternal_Webhook(t *testing.T) {
 
 	t.Run("rejects unknown type", func(t *testing.T) {
 		_, err := svc.TestExternal(t.Context(), &domain.FilterExternal{Type: "UNKNOWN"})
-		assert.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrExternalFilterTypeUnsupported)
 	})
 }
 

--- a/internal/filter/service_test.go
+++ b/internal/filter/service_test.go
@@ -348,6 +348,18 @@ func TestService_TestExternal_Exec(t *testing.T) {
 		assert.Empty(t, result.Error)
 	})
 
+	t.Run("caps combined output", func(t *testing.T) {
+		result, err := svc.TestExternal(t.Context(), &domain.FilterExternal{
+			Name:     "script",
+			Type:     domain.ExternalFilterTypeExec,
+			ExecCmd:  "sh",
+			ExecArgs: `-c 'printf "%05000d" 0; printf "%05000d" 0 >&2; exit 7'`,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 7, result.Status)
+		assert.Len(t, result.Output, externalOutputMaxBytes)
+	})
+
 	t.Run("reports missing program", func(t *testing.T) {
 		result, err := svc.TestExternal(t.Context(), &domain.FilterExternal{
 			Name:    "script",
@@ -366,10 +378,10 @@ func Test_outputBuffer_Write(t *testing.T) {
 	n, err := b.Write(bytes.Repeat([]byte("a"), externalOutputMaxBytes+100))
 	assert.NoError(t, err)
 	assert.Equal(t, externalOutputMaxBytes+100, n)
-	assert.Equal(t, externalOutputMaxBytes, b.Len())
+	assert.Len(t, b.String(), externalOutputMaxBytes)
 
 	n, err = b.Write([]byte("more"))
 	assert.NoError(t, err)
 	assert.Equal(t, 4, n)
-	assert.Equal(t, externalOutputMaxBytes, b.Len())
+	assert.Len(t, b.String(), externalOutputMaxBytes)
 }

--- a/internal/filter/service_test.go
+++ b/internal/filter/service_test.go
@@ -4,7 +4,12 @@
 package filter
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/autobrr/autobrr/internal/domain"
@@ -260,4 +265,111 @@ func TestService_UpdateNotifications_ValidatesBeforePersisting(t *testing.T) {
 
 	assert.ErrorIs(t, err, domain.ErrNotificationNotFound)
 	assert.Zero(t, notificationSvc.storedFilterID)
+}
+
+func TestService_TestExternal_Webhook(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if r.Method != http.MethodPost || !strings.Contains(string(body), "Best.Show.Ever") {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	svc := &Service{log: zerolog.Nop(), httpClient: srv.Client()}
+
+	t.Run("matches expected status", func(t *testing.T) {
+		result, err := svc.TestExternal(t.Context(), &domain.FilterExternal{
+			Name:                "webhook",
+			Type:                domain.ExternalFilterTypeWebhook,
+			WebhookHost:         srv.URL,
+			WebhookData:         `{"name":"{{ .TorrentName }}"}`,
+			WebhookExpectStatus: http.StatusOK,
+		})
+		assert.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.Equal(t, http.StatusOK, result.Status)
+		assert.Equal(t, http.StatusOK, result.ExpectStatus)
+		assert.Equal(t, `{"ok":true}`, result.Output)
+		assert.Empty(t, result.Error)
+	})
+
+	t.Run("reports unexpected status", func(t *testing.T) {
+		result, err := svc.TestExternal(t.Context(), &domain.FilterExternal{
+			Name:                "webhook",
+			Type:                domain.ExternalFilterTypeWebhook,
+			WebhookHost:         srv.URL,
+			WebhookData:         `{"name":"{{ .TorrentName }}"}`,
+			WebhookExpectStatus: http.StatusCreated,
+		})
+		assert.NoError(t, err)
+		assert.False(t, result.Success)
+		assert.Equal(t, http.StatusOK, result.Status)
+		assert.Empty(t, result.Error)
+	})
+
+	t.Run("reports missing host", func(t *testing.T) {
+		result, err := svc.TestExternal(t.Context(), &domain.FilterExternal{
+			Name:                "webhook",
+			Type:                domain.ExternalFilterTypeWebhook,
+			WebhookExpectStatus: http.StatusOK,
+		})
+		assert.NoError(t, err)
+		assert.False(t, result.Success)
+		assert.Equal(t, 0, result.Status)
+		assert.NotEmpty(t, result.Error)
+	})
+
+	t.Run("rejects unknown type", func(t *testing.T) {
+		_, err := svc.TestExternal(t.Context(), &domain.FilterExternal{Type: "UNKNOWN"})
+		assert.Error(t, err)
+	})
+}
+
+func TestService_TestExternal_Exec(t *testing.T) {
+	svc := &Service{log: zerolog.Nop()}
+
+	t.Run("captures output and exit code", func(t *testing.T) {
+		result, err := svc.TestExternal(t.Context(), &domain.FilterExternal{
+			Name:             "script",
+			Type:             domain.ExternalFilterTypeExec,
+			ExecCmd:          "sh",
+			ExecArgs:         `-c 'echo "{{ .TorrentName }}"; echo oops >&2; exit 3'`,
+			ExecExpectStatus: 3,
+		})
+		assert.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.Equal(t, 3, result.Status)
+		assert.Equal(t, "Best.Show.Ever.S18E21.1080p.AMZN.WEB-DL.DDP2.0.H.264-GROUP\noops\n", result.Output)
+		assert.Empty(t, result.Error)
+	})
+
+	t.Run("reports missing program", func(t *testing.T) {
+		result, err := svc.TestExternal(t.Context(), &domain.FilterExternal{
+			Name:    "script",
+			Type:    domain.ExternalFilterTypeExec,
+			ExecCmd: "/nonexistent/autobrr-test-program",
+		})
+		assert.NoError(t, err)
+		assert.False(t, result.Success)
+		assert.NotEmpty(t, result.Error)
+	})
+}
+
+func Test_outputBuffer_Write(t *testing.T) {
+	var b outputBuffer
+
+	n, err := b.Write(bytes.Repeat([]byte("a"), externalOutputMaxBytes+100))
+	assert.NoError(t, err)
+	assert.Equal(t, externalOutputMaxBytes+100, n)
+	assert.Equal(t, externalOutputMaxBytes, b.Len())
+
+	n, err = b.Write([]byte("more"))
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, externalOutputMaxBytes, b.Len())
 }

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -28,6 +28,7 @@ type filterService interface {
 	Duplicate(ctx context.Context, filterID int) (*domain.Filter, error)
 	ToggleEnabled(ctx context.Context, filterID int, enabled bool) error
 	PruneDeprecatedIndexers(ctx context.Context, identifiers []string) (int64, error)
+	TestExternal(ctx context.Context, external *domain.FilterExternal) (*domain.FilterExternalTestResult, error)
 }
 
 type filterHandler struct {
@@ -47,6 +48,7 @@ func (h filterHandler) Routes(r chi.Router) {
 	r.Post("/", h.store)
 
 	r.Post("/indexers/prune-deprecated", h.pruneDeprecatedIndexers)
+	r.Post("/external/test", h.testExternal)
 
 	r.Route("/{filterID}", func(r chi.Router) {
 		r.Get("/", h.getByID)
@@ -159,6 +161,22 @@ func (h filterHandler) pruneDeprecatedIndexers(w http.ResponseWriter, r *http.Re
 	}
 
 	h.encoder.StatusResponse(w, http.StatusOK, map[string]int64{"removed": removed})
+}
+
+func (h filterHandler) testExternal(w http.ResponseWriter, r *http.Request) {
+	var data *domain.FilterExternal
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		h.encoder.Error(w, err)
+		return
+	}
+
+	result, err := h.service.TestExternal(r.Context(), data)
+	if err != nil {
+		h.encoder.Error(w, err)
+		return
+	}
+
+	h.encoder.StatusResponse(w, http.StatusOK, result)
 }
 
 func (h filterHandler) store(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -177,6 +177,11 @@ func (h filterHandler) testExternal(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.TestExternal(r.Context(), data)
 	if err != nil {
+		if errors.Is(err, domain.ErrExternalFilterTypeUnsupported) {
+			h.encoder.BadRequestErr(w, err)
+			return
+		}
+
 		h.encoder.Error(w, err)
 		return
 	}

--- a/internal/http/filter.go
+++ b/internal/http/filter.go
@@ -166,7 +166,12 @@ func (h filterHandler) pruneDeprecatedIndexers(w http.ResponseWriter, r *http.Re
 func (h filterHandler) testExternal(w http.ResponseWriter, r *http.Request) {
 	var data *domain.FilterExternal
 	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
-		h.encoder.Error(w, err)
+		h.encoder.BadRequestErr(w, err)
+		return
+	}
+
+	if data == nil {
+		h.encoder.BadRequestErr(w, errors.New("external filter is required"))
 		return
 	}
 

--- a/internal/http/filter_test.go
+++ b/internal/http/filter_test.go
@@ -42,3 +42,53 @@ func TestFilterHandlerUpdateNotifications(t *testing.T) {
 	assert.Equal(t, 7, service.filterID)
 	assert.Equal(t, []domain.FilterNotification{{NotificationID: 3, Events: []string{"PUSH_APPROVED"}}}, service.notifications)
 }
+
+type filterExternalTestServiceStub struct {
+	filterService
+	called   bool
+	external *domain.FilterExternal
+}
+
+func (s *filterExternalTestServiceStub) TestExternal(_ context.Context, external *domain.FilterExternal) (*domain.FilterExternalTestResult, error) {
+	s.called = true
+	s.external = external
+	return &domain.FilterExternalTestResult{Success: true}, nil
+}
+
+func TestFilterHandlerTestExternal(t *testing.T) {
+	service := &filterExternalTestServiceStub{}
+	handler := newFilterHandler(encoder{}, service)
+	router := chi.NewRouter()
+	handler.Routes(router)
+
+	post := func(body string) *httptest.ResponseRecorder {
+		service.called = false
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/external/test", strings.NewReader(body))
+		router.ServeHTTP(recorder, request)
+		return recorder
+	}
+
+	t.Run("runs the posted external filter", func(t *testing.T) {
+		recorder := post(`{"name":"hook","type":"WEBHOOK","webhook_host":"https://mock.local/hook","webhook_expect_status":200}`)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.True(t, service.called)
+		assert.Equal(t, "hook", service.external.Name)
+		assert.Contains(t, recorder.Body.String(), `"success":true`)
+	})
+
+	t.Run("rejects malformed json", func(t *testing.T) {
+		recorder := post(`{"type":`)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.False(t, service.called)
+	})
+
+	t.Run("rejects null body", func(t *testing.T) {
+		recorder := post(`null`)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.False(t, service.called)
+	})
+}

--- a/internal/http/filter_test.go
+++ b/internal/http/filter_test.go
@@ -52,6 +52,11 @@ type filterExternalTestServiceStub struct {
 func (s *filterExternalTestServiceStub) TestExternal(_ context.Context, external *domain.FilterExternal) (*domain.FilterExternalTestResult, error) {
 	s.called = true
 	s.external = external
+
+	if external.Type != domain.ExternalFilterTypeWebhook {
+		return nil, domain.ErrExternalFilterTypeUnsupported
+	}
+
 	return &domain.FilterExternalTestResult{Success: true}, nil
 }
 
@@ -90,5 +95,12 @@ func TestFilterHandlerTestExternal(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.False(t, service.called)
+	})
+
+	t.Run("rejects unknown type", func(t *testing.T) {
+		recorder := post(`{"name":"hook","type":"FOO"}`)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), "BAD_REQUEST_PARAMS")
 	})
 }

--- a/web/src/api/APIClient.ts
+++ b/web/src/api/APIClient.ts
@@ -332,6 +332,11 @@ export const APIClient = {
       body: { identifiers }
     }),
     delete: (id: number) => appClient.Delete(`api/filters/${id}`),
+    external: {
+      test: (external: ExternalFilter) => appClient.Post<ExternalFilterTestResult>("api/filters/external/test", {
+        body: external
+      })
+    },
     notifications: {
       get: (filterId: number) => appClient.Get<FilterNotification[]>(`api/filters/${filterId}/notifications`),
       update: (filterId: number, notifications: FilterNotification[]) => 

--- a/web/src/i18n/locales/cs/filters.json
+++ b/web/src/i18n/locales/cs/filters.json
@@ -420,6 +420,19 @@
       "onErrorTooltip": "Vyberte co dělat při chybě tohoto externího filtru.",
       "remove": "Odstranit externí",
       "close": "Zavřít",
+      "test": "Otestovat",
+      "testing": "Testuji",
+      "testResult": {
+        "dismiss": "Zavřít",
+        "status": {
+          "EXEC": "Skript skončil s kódem {{status}} (očekáváno {{expected}}) za {{duration}} ms",
+          "WEBHOOK": "Webhook odpověděl stavem {{status}} (očekáváno {{expected}}) za {{duration}} ms"
+        },
+        "error": {
+          "EXEC": "Skript selhal: {{error}}",
+          "WEBHOOK": "Požadavek na webhook selhal: {{error}}"
+        }
+      },
       "types": {
         "EXEC": "Spustit",
         "WEBHOOK": "Webhook"

--- a/web/src/i18n/locales/de/filters.json
+++ b/web/src/i18n/locales/de/filters.json
@@ -420,6 +420,19 @@
     "onErrorTooltip": "Auswählen, was bei einem Fehler für diesen externen Filter getan werden soll.",
     "remove": "Extern entfernen",
     "close": "Schließen",
+    "test": "Testen",
+    "testing": "Wird getestet",
+    "testResult": {
+      "dismiss": "Ausblenden",
+      "status": {
+        "EXEC": "Skript wurde mit Code {{status}} beendet (erwartet {{expected}}) in {{duration}} ms",
+        "WEBHOOK": "Webhook antwortete mit Status {{status}} (erwartet {{expected}}) in {{duration}} ms"
+      },
+      "error": {
+        "EXEC": "Skript fehlgeschlagen: {{error}}",
+        "WEBHOOK": "Webhook-Anfrage fehlgeschlagen: {{error}}"
+      }
+    },
     "types": {
       "EXEC": "Exec",
       "WEBHOOK": "Webhook"

--- a/web/src/i18n/locales/en/filters.json
+++ b/web/src/i18n/locales/en/filters.json
@@ -420,6 +420,19 @@
     "onErrorTooltip": "Select what to do on error for this external filter.",
     "remove": "Remove External",
     "close": "Close",
+    "test": "Test",
+    "testing": "Testing",
+    "testResult": {
+      "dismiss": "Dismiss",
+      "status": {
+        "EXEC": "Script exited with code {{status}} (expected {{expected}}) in {{duration}} ms",
+        "WEBHOOK": "Webhook responded with status {{status}} (expected {{expected}}) in {{duration}} ms"
+      },
+      "error": {
+        "EXEC": "Script failed: {{error}}",
+        "WEBHOOK": "Webhook request failed: {{error}}"
+      }
+    },
     "types": {
       "EXEC": "Exec",
       "WEBHOOK": "Webhook"

--- a/web/src/i18n/locales/es/filters.json
+++ b/web/src/i18n/locales/es/filters.json
@@ -420,6 +420,19 @@
     "onErrorTooltip": "Selecciona qué hacer en caso de error para este filtro externo.",
     "remove": "Eliminar externo",
     "close": "Cerrar",
+    "test": "Probar",
+    "testing": "Probando",
+    "testResult": {
+      "dismiss": "Descartar",
+      "status": {
+        "EXEC": "El script terminó con código {{status}} (esperado {{expected}}) en {{duration}} ms",
+        "WEBHOOK": "El webhook respondió con estado {{status}} (esperado {{expected}}) en {{duration}} ms"
+      },
+      "error": {
+        "EXEC": "El script falló: {{error}}",
+        "WEBHOOK": "La solicitud al webhook falló: {{error}}"
+      }
+    },
     "types": {
       "EXEC": "Exec",
       "WEBHOOK": "Webhook"

--- a/web/src/i18n/locales/fr/filters.json
+++ b/web/src/i18n/locales/fr/filters.json
@@ -420,6 +420,19 @@
     "onErrorTooltip": "Sélectionner l'action en cas d'erreur pour ce filtre externe.",
     "remove": "Supprimer l'externe",
     "close": "Fermer",
+    "test": "Tester",
+    "testing": "Test en cours",
+    "testResult": {
+      "dismiss": "Fermer",
+      "status": {
+        "EXEC": "Le script s'est terminé avec le code {{status}} (attendu {{expected}}) en {{duration}} ms",
+        "WEBHOOK": "Le webhook a répondu avec le statut {{status}} (attendu {{expected}}) en {{duration}} ms"
+      },
+      "error": {
+        "EXEC": "Échec du script : {{error}}",
+        "WEBHOOK": "Échec de la requête webhook : {{error}}"
+      }
+    },
     "types": {
       "EXEC": "Exec",
       "WEBHOOK": "Webhook"

--- a/web/src/i18n/locales/no/filters.json
+++ b/web/src/i18n/locales/no/filters.json
@@ -420,6 +420,19 @@
     "onErrorTooltip": "Velg hva som skal gjøres ved feil for dette eksterne filteret.",
     "remove": "Fjern ekstern",
     "close": "Lukk",
+    "test": "Test",
+    "testing": "Tester",
+    "testResult": {
+      "dismiss": "Lukk",
+      "status": {
+        "EXEC": "Skriptet avsluttet med kode {{status}} (forventet {{expected}}) på {{duration}} ms",
+        "WEBHOOK": "Webhook svarte med status {{status}} (forventet {{expected}}) på {{duration}} ms"
+      },
+      "error": {
+        "EXEC": "Skriptet feilet: {{error}}",
+        "WEBHOOK": "Webhook-forespørselen feilet: {{error}}"
+      }
+    },
     "types": {
       "EXEC": "Exec",
       "WEBHOOK": "Webhook"

--- a/web/src/i18n/locales/ru/filters.json
+++ b/web/src/i18n/locales/ru/filters.json
@@ -420,6 +420,19 @@
     "onErrorTooltip": "Выберите действие при ошибке этого внешнего фильтра.",
     "remove": "Удалить внешний",
     "close": "Закрыть",
+    "test": "Проверить",
+    "testing": "Проверка",
+    "testResult": {
+      "dismiss": "Закрыть",
+      "status": {
+        "EXEC": "Скрипт завершился с кодом {{status}} (ожидалось {{expected}}) за {{duration}} мс",
+        "WEBHOOK": "Вебхук ответил статусом {{status}} (ожидалось {{expected}}) за {{duration}} мс"
+      },
+      "error": {
+        "EXEC": "Ошибка скрипта: {{error}}",
+        "WEBHOOK": "Ошибка запроса к вебхуку: {{error}}"
+      }
+    },
     "types": {
       "EXEC": "Выполнение",
       "WEBHOOK": "Webhook"

--- a/web/src/i18n/locales/zh-CN/filters.json
+++ b/web/src/i18n/locales/zh-CN/filters.json
@@ -420,6 +420,19 @@
     "onErrorTooltip": "选择此外部过滤器发生错误时的处理方式。",
     "remove": "移除外部过滤器",
     "close": "关闭",
+    "test": "测试",
+    "testing": "测试中",
+    "testResult": {
+      "dismiss": "关闭",
+      "status": {
+        "EXEC": "脚本以退出码 {{status}} 结束（预期 {{expected}}），耗时 {{duration}} 毫秒",
+        "WEBHOOK": "Webhook 返回状态码 {{status}}（预期 {{expected}}），耗时 {{duration}} 毫秒"
+      },
+      "error": {
+        "EXEC": "脚本执行失败：{{error}}",
+        "WEBHOOK": "Webhook 请求失败：{{error}}"
+      }
+    },
     "types": {
       "EXEC": "执行命令",
       "WEBHOOK": "Webhook"

--- a/web/src/screens/filters/sections/External.tsx
+++ b/web/src/screens/filters/sections/External.tsx
@@ -4,13 +4,15 @@
  */
 
 import { useRef } from "react";
-import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/24/solid";
+import { useMutation } from "@tanstack/react-query";
+import { ChevronDownIcon, ChevronRightIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import { ArrowDownIcon, ArrowUpIcon, SquaresPlusIcon } from "@heroicons/react/24/outline";
 import { Field, FieldArray, FieldArrayRenderProps, FieldProps, useFormikContext } from "formik";
 import { useTranslation } from "react-i18next";
 
 import { classNames } from "@utils";
 import { useToggle } from "@hooks/hooks";
+import { APIClient } from "@api/APIClient";
 import { TextAreaAutoResize } from "@components/inputs/input";
 import { EmptyListState } from "@components/emptystates";
 import { NumberField, Select, TextField } from "@components/inputs";
@@ -103,6 +105,10 @@ function FilterExternalItem({ idx, external, initialEdit, remove, move }: Filter
 
   const [deleteModalIsOpen, toggleDeleteModal] = useToggle(false);
   const [edit, toggleEdit] = useToggle(initialEdit);
+
+  const testMutation = useMutation({
+    mutationFn: (external: ExternalFilter) => APIClient.filters.external.test(external)
+  });
 
   const removeAction = () => {
     remove(idx);
@@ -239,22 +245,39 @@ function FilterExternalItem({ idx, external, initialEdit, remove, move }: Filter
 
             <TypeForm external={external} idx={idx} />
 
-            <div className="pt-6 pb-4 space-x-2 flex justify-between">
-              <button
-                type="button"
-                className="inline-flex items-center justify-center px-4 py-2 rounded-md sm:text-sm bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden"
-                onClick={toggleDeleteModal}
-              >
-                {t("external.remove")}
-              </button>
+            <div className="pt-6 pb-4">
+              {testMutation.data && (
+                <TestResult result={testMutation.data} dismiss={testMutation.reset} />
+              )}
 
-              <button
-                type="button"
-                className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden"
-                onClick={toggleEdit}
-              >
-                {t("external.close")}
-              </button>
+              <div className="space-x-2 flex justify-between">
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center px-4 py-2 rounded-md sm:text-sm bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden"
+                  onClick={toggleDeleteModal}
+                >
+                  {t("external.remove")}
+                </button>
+
+                <div className="space-x-2">
+                  <button
+                    type="button"
+                    className="bg-white dark:bg-gray-700 py-2 px-4 cursor-pointer border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={testMutation.isPending}
+                    onClick={() => testMutation.mutate(external)}
+                  >
+                    {testMutation.isPending ? t("external.testing") : t("external.test")}
+                  </button>
+
+                  <button
+                    type="button"
+                    className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden"
+                    onClick={toggleEdit}
+                  >
+                    {t("external.close")}
+                  </button>
+                </div>
+              </div>
             </div>
           </FilterPage>
         </div>
@@ -386,4 +409,46 @@ const TypeForm = ({ external, idx }: TypeFormProps) => {
     return null;
   }
   }
+};
+
+interface TestResultProps {
+  result: ExternalFilterTestResult;
+  dismiss: () => void;
+}
+
+const TestResult = ({ result, dismiss }: TestResultProps) => {
+  const { t } = useTranslation("filters");
+
+  return (
+    <div
+      className={classNames(
+        result.success
+          ? "border-green-500 bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-300"
+          : "border-red-500 bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-300",
+        "mb-4 px-4 py-3 border rounded-md text-sm"
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="font-medium break-all">
+          {result.error
+            ? t(`external.testResult.error.${result.type}`, { error: result.error })
+            : t(`external.testResult.status.${result.type}`, { status: result.status, expected: result.expect_status, duration: result.duration_ms })}
+        </p>
+        <button
+          type="button"
+          className="shrink-0 cursor-pointer"
+          aria-label={t("external.testResult.dismiss")}
+          onClick={dismiss}
+        >
+          <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+
+      {result.output && (
+        <pre className="mt-2 px-3 py-2 max-h-64 overflow-auto whitespace-pre-wrap break-all rounded-sm font-mono text-xs bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-300">
+          {result.output}
+        </pre>
+      )}
+    </div>
+  );
 };

--- a/web/src/types/Filter.d.ts
+++ b/web/src/types/Filter.d.ts
@@ -161,6 +161,16 @@ interface ExternalFilter {
   filter_id?: number;
 }
 
+interface ExternalFilterTestResult {
+  type: ExternalType;
+  success: boolean;
+  status: number;
+  expect_status: number;
+  output: string;
+  error?: string;
+  duration_ms: number;
+}
+
 interface FilterDownloads {
   period_count: number;
 }


### PR DESCRIPTION
# Description

Adds a Test button to each external filter in the filter form so a webhook or script can be verified without saving the filter or waiting for an announce. The response is shown in a box right above the buttons.

- New `POST /api/filters/external/test` takes the external filter as it is in the form and runs it against a sample release so macros expand. Returns a `FilterExternalTestResult` with type, success, status (HTTP status or exit code), expected status, output (response body or script output, capped at 4 KB), error and duration.
- Works for both `WEBHOOK` and `EXEC`.
- Failures such as connection refused, missing host or program not found are reported inside the result rather than as HTTP errors, so the box always renders and the global error toast stays quiet.
- UI: Test button next to Close on every external item, a green box when the status matches the expected one and a red box otherwise, with the raw output in a monospace block and a dismiss control. Button disables while the request is in flight.
- `execCmd` now captures stdout and stderr into a bounded 4 KB buffer via `Run()` instead of the stdout pipe loop. In passing this fixes the empty program name in the "could not find program" error and the duration being measured before the command started.
- `webhook` always reads up to 4 KB of the response body (it was drained anyway) and returns the retry error without wrapping it a second time with the same message.
- Locale strings added for all 8 languages.

Notes:

- Torrent file macros expand to empty during a test since the sample release carries no torrent.
- A blank expected HTTP status is sent as `0`, so a test reports "expected 0" and fails. This mirrors the announce path, which also compares against `0`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

* `go test ./...` passes. New unit tests in `internal/filter/service_test.go` cover the webhook path (httptest server, expected status match and mismatch, missing host, unknown type), the exec path (`sh -c` with stdout, stderr and exit code, missing program) and the bounded output buffer.
* `pnpm --dir web build` passes and the touched web files are lint clean.
* Verified in a real browser with a throwaway `test/e2e` Playwright run: webhook success, status mismatch, connection error, and exec with stdout and stderr, in both dark and light theme.

## Screenshots (for UI changes)

<img width="1238" height="503" alt="image" src="https://github.com/user-attachments/assets/cced834c-7aa4-4ac4-ad28-da2dab4b2991" />

<img width="1238" height="503" alt="image" src="https://github.com/user-attachments/assets/5c020706-fe41-4558-b61d-94020df411fb" />


## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
