### PR TITLE
chore(web): fix lint errors and warnings

### DIFF
--- a/web/src/components/Checkbox.tsx
+++ b/web/src/components/Checkbox.tsx
@@ -52,7 +52,9 @@ export const Checkbox = ({
       name={name}
       checked={value}
       onChange={(newValue) => {
-        !disabled && setValue(newValue);
+        if (!disabled) {
+          setValue(newValue);
+        }
       }}
       className={classNames(
         disabled

--- a/web/src/components/alerts/ErrorPage.tsx
+++ b/web/src/components/alerts/ErrorPage.tsx
@@ -88,7 +88,7 @@ export const ErrorPage = ({ error, reset }: ErrorPageProps) => {
           </span>
           <button
             type="button"
-            className="text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:outline-hidden focus:ring-red-300 font-medium rounded-lg text-sm px-3 py-1.5 mr-2 text-center inline-flex items-center dark:bg-red-800 dark:hover:bg-red-900"
+            className="text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:outline-hidden focus:ring-red-300 font-medium rounded-lg text-sm px-3 py-1.5 mr-2 text-center inline-flex items-center dark:bg-red-800 dark:hover:bg-red-900 cursor-pointer"
             onClick={(event) => {
               event.preventDefault();
               reset();

--- a/web/src/components/alerts/NotFound.tsx
+++ b/web/src/components/alerts/NotFound.tsx
@@ -50,7 +50,7 @@ export const NotFound = () => {
       <div className="flex justify-center">
         <Link to="/">
           <button
-            className="w-48 flex justify-center py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+            className="w-48 flex justify-center py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
           >
             {t("notFound.backToDashboard")}
           </button>

--- a/web/src/components/data-table/Buttons.tsx
+++ b/web/src/components/data-table/Buttons.tsx
@@ -17,6 +17,7 @@ export const TableButton = ({ children, className, disabled, onClick }: ButtonPr
   <button
     type="button"
     className={classNames(
+      "cursor-pointer disabled:cursor-not-allowed",
       className ?? "",
       "relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-800 text-sm font-medium rounded-md text-gray-700 dark:text-gray-500 bg-white dark:bg-gray-800 hover:bg-gray-50"
     )}

--- a/web/src/components/data-table/Cells.tsx
+++ b/web/src/components/data-table/Cells.tsx
@@ -184,7 +184,7 @@ const RetryActionButton = ({ status }: RetryActionButtonProps) => {
   };
 
   return (
-    <button className="flex items-center px-1.5 py-1 ml-2 rounded-sm transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600" onClick={replayAction}>
+    <button className="flex items-center px-1.5 py-1 ml-2 rounded-sm transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 cursor-pointer" onClick={replayAction}>
       <span className="mr-1.5">{t("releaseTable.retry")}</span>
       {mutation.isPending
         ? <RingResizeSpinner className="text-blue-500 w-4 h-4 iconHeight" aria-hidden="true" />

--- a/web/src/components/debug.tsx
+++ b/web/src/components/debug.tsx
@@ -24,7 +24,7 @@ export const DEBUG: FC<DebugProps> = ({ values }) => {
   );
 };
 
-export function LogDebug(...data: any[]): void {
+export function LogDebug(...data: unknown[]): void {
   if (!import.meta.env.DEV) {
     return;
   }

--- a/web/src/components/emptystates/index.tsx
+++ b/web/src/components/emptystates/index.tsx
@@ -31,7 +31,7 @@ export const EmptySimple = ({
         <button
           type="button"
           onClick={buttonAction}
-          className="inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+          className="inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
         >
           <PlusIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
           {buttonText}
@@ -54,7 +54,7 @@ export function EmptyListState({ text, buttonText, buttonOnClick }: EmptyListSta
       {buttonText && buttonOnClick && (
         <button
           type="button"
-          className="relative inline-flex items-center px-4 py-2 mt-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+          className="relative inline-flex items-center px-4 py-2 mt-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
           onClick={buttonOnClick}
         >
           {buttonText}

--- a/web/src/components/fields/text.tsx
+++ b/web/src/components/fields/text.tsx
@@ -64,7 +64,7 @@ export const KeyField = ({ value }: KeyFieldProps) => {
         </div>
         <button
           type="button"
-          className="-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-gray-700 hover:bg-gray-100  text-sm font-medium text-gray-700 bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700  focus:outline-hidden"
+          className="-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-gray-700 hover:bg-gray-100  text-sm font-medium text-gray-700 bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700  focus:outline-hidden cursor-pointer"
           onClick={toggleVisibility}
           title={t("keyField.show")}
         >
@@ -72,7 +72,7 @@ export const KeyField = ({ value }: KeyFieldProps) => {
         </button>
         <button
           type="button"
-          className="-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-gray-700 hover:bg-gray-100  text-sm font-medium rounded-r-md text-gray-700 dark:text-gray-100 bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 focus:outline-hidden"
+          className="-ml-px relative inline-flex items-center space-x-2 px-4 py-2 border border-gray-300 dark:border-gray-700 hover:bg-gray-100  text-sm font-medium rounded-r-md text-gray-700 dark:text-gray-100 bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 focus:outline-hidden cursor-pointer"
           onClick={handleCopyClick}
           title={t("keyField.copyToClipboard")}
         >

--- a/web/src/components/header/Header.tsx
+++ b/web/src/components/header/Header.tsx
@@ -62,7 +62,7 @@ export const Header = () => {
                 <RightNav logoutMutation={logoutMutation.mutate} />
                 <div className="-mr-2 flex sm:hidden">
                   {/* Mobile menu button */}
-                  <DisclosureButton className="bg-gray-200 dark:bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-600 dark:text-gray-400 hover:text-white hover:bg-gray-700">
+                  <DisclosureButton className="bg-gray-200 dark:bg-gray-800 inline-flex items-center justify-center p-2 rounded-md text-gray-600 dark:text-gray-400 hover:text-white hover:bg-gray-700 cursor-pointer">
                     <span className="sr-only">{t("header.openMainMenu")}</span>
                     {open ? (
                       <XMarkIcon

--- a/web/src/components/header/MobileNav.tsx
+++ b/web/src/components/header/MobileNav.tsx
@@ -47,7 +47,7 @@ export const MobileNav = (props: RightNavProps) => {
             e.preventDefault();
             props.logoutMutation();
           }}
-          className="w-full shadow-xs border bg-gray-100 border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-white block px-3 py-2 rounded-md text-base font-medium text-left"
+          className="w-full shadow-xs border bg-gray-100 border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-white block px-3 py-2 rounded-md text-base font-medium text-left cursor-pointer"
         >
           {t("userMenu.logout")}
         </button>

--- a/web/src/components/header/RightNav.tsx
+++ b/web/src/components/header/RightNav.tsx
@@ -68,6 +68,7 @@ export const RightNav = (props: RightNavProps) => {
             <>
               <MenuButton
                 className={classNames(
+                  "cursor-pointer",
                   open ? "bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-white" : "hover:text-gray-900 dark:hover:text-white",
                   "text-gray-600 dark:text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-800 px-3 py-2 rounded-2xl text-sm font-medium",
                   "max-w-xs rounded-full flex items-center text-sm px-3 py-2",
@@ -164,6 +165,7 @@ export const RightNav = (props: RightNavProps) => {
                           props.logoutMutation();
                         }}
                         className={classNames(
+                          "cursor-pointer",
                           active
                             ? "bg-gray-100 dark:bg-gray-600"
                             : "",

--- a/web/src/components/hot-toast/components/toast-icon.tsx
+++ b/web/src/components/hot-toast/components/toast-icon.tsx
@@ -34,7 +34,7 @@ to {
   opacity: 1;
 }`;
 
-export const AnimatedIconWrapper = styled('div')`
+const AnimatedIconWrapper = styled('div')`
   position: relative;
   transform: scale(0.6);
   opacity: 0.4;

--- a/web/src/components/inputs/input.tsx
+++ b/web/src/components/inputs/input.tsx
@@ -551,7 +551,7 @@ export const PasswordField = ({
                   placeholder={placeholder}
                 />
 
-                <div className="absolute inset-y-0 right-0 px-3 flex items-center" onClick={toggleVisibility}>
+                <div className="absolute inset-y-0 right-0 px-3 flex items-center cursor-pointer" onClick={toggleVisibility}>
                   {!isVisible ? <EyeIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" />
                     : <EyeSlashIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" />}
                 </div>

--- a/web/src/components/inputs/input_wide.tsx
+++ b/web/src/components/inputs/input_wide.tsx
@@ -174,7 +174,7 @@ export const PasswordFieldWide = ({
                   autoComplete={autoComplete}
                   data-1p-ignore
                 />
-                <div className="absolute inset-y-0 right-0 px-3 flex items-center" onClick={toggleVisibility}>
+                <div className="absolute inset-y-0 right-0 px-3 flex items-center cursor-pointer" onClick={toggleVisibility}>
                   {!isVisible ? <EyeIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" /> : <EyeSlashIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true" />}
                 </div>
               </div>

--- a/web/src/components/layouts.tsx
+++ b/web/src/components/layouts.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { Navigate, Outlet } from "@tanstack/react-router";
+import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+import { Header } from "@components/header";
+import { AuthContext, SettingsContext } from "@utils/Context";
+
+export function AuthenticatedLayout() {
+  const isLoggedIn = AuthContext.useSelector((s) => s.isLoggedIn);
+  if (!isLoggedIn) {
+    return <Navigate to="/login" search={{ redirect: location.pathname + location.search }} />;
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <Outlet />
+    </div>
+  )
+}
+
+export const RootComponent = () => {
+  const settings = SettingsContext.useValue();
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Outlet />
+      {settings.debug ? (
+        <>
+          {import.meta.env.DEV && <TanStackRouterDevtools />}
+          {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/components/modals/index.tsx
+++ b/web/src/components/modals/index.tsx
@@ -213,7 +213,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
                     <button
                       type="button"
                       disabled={!isInputCorrect}
-                      className={`w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 ${
+                      className={`cursor-pointer disabled:cursor-not-allowed w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 ${
                         isInputCorrect ? "bg-red-600 text-white hover:bg-red-700" : "bg-gray-300"
                       } text-base font-medium focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm`}
                       onClick={handleForceRun}
@@ -222,7 +222,7 @@ export const ForceRunModal: FC<ForceRunModalProps> = (props: ForceRunModalProps)
                     </button>
                     <button
                       type="button"
-                      className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-xs px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+                      className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-xs px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer"
                       onClick={handleCancel}
                     >
                       {t("modal.cancel")}

--- a/web/src/components/notifications/Toast.tsx
+++ b/web/src/components/notifications/Toast.tsx
@@ -41,7 +41,7 @@ const Toast: FC<Props> = ({ type, body, t }) => {
           </div>
           <div className="ml-4 shrink-0 flex">
             <button
-              className="bg-white dark:bg-gray-700 rounded-md inline-flex text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="bg-white dark:bg-gray-700 rounded-md inline-flex text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               onClick={() => {
                 toast.dismiss(t?.id);
               }}

--- a/web/src/components/panels/index.tsx
+++ b/web/src/components/panels/index.tsx
@@ -273,7 +273,7 @@ function SlideOverForm<DataType>({
 
                 <button
                   type="button"
-                  className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
                   onClick={(e) => {
                     e.preventDefault();
                     toggle();
@@ -283,7 +283,7 @@ function SlideOverForm<DataType>({
                 </button>
                 <button
                   type="button"
-                  className="ml-4 inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                  className="ml-4 inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer"
                   onClick={(e) => {
                     e.preventDefault();
                     form.handleSubmit();

--- a/web/src/components/tooltips/Tooltip.tsx
+++ b/web/src/components/tooltips/Tooltip.tsx
@@ -109,7 +109,7 @@ export const Tooltip = ({
     <>
       <div
         ref={setTriggerRef}
-        className="truncate"
+        className="truncate cursor-pointer"
         onClick={handleClick}
         onTouchStart={handleTouch}
       >

--- a/web/src/forms/filters/FilterAddForm.tsx
+++ b/web/src/forms/filters/FilterAddForm.tsx
@@ -115,7 +115,7 @@ function FilterAddFormPanel({ toggle, inputRef }: FilterAddFormPanelProps) {
               <div className="h-7 flex items-center">
                 <button
                   type="button"
-                  className="light:bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  className="light:bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
                   onClick={toggle}
                 >
                   <span className="sr-only">{t("addForm.closePanel")}</span>
@@ -169,14 +169,14 @@ function FilterAddFormPanel({ toggle, inputRef }: FilterAddFormPanelProps) {
           <div className="space-x-3 flex justify-end">
             <button
               type="button"
-              className="bg-white dark:bg-gray-800 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="bg-white dark:bg-gray-800 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               onClick={toggle}
             >
               {t("addForm.cancel")}
             </button>
             <button
               type="submit"
-              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
             >
               {t("addForm.create")}
             </button>

--- a/web/src/forms/settings/APIKeyAddForm.tsx
+++ b/web/src/forms/settings/APIKeyAddForm.tsx
@@ -97,7 +97,7 @@ function APIKeyAddFormPanel({ toggle }: APIKeyAddFormPanelProps) {
               <div className="h-7 flex items-center">
                 <button
                   type="button"
-                  className="light:bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  className="light:bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
                   onClick={toggle}
                 >
                   <span className="sr-only">{t("forms.apiKey.closePanel")}</span>
@@ -147,14 +147,14 @@ function APIKeyAddFormPanel({ toggle }: APIKeyAddFormPanelProps) {
           <div className="space-x-3 flex justify-end">
             <button
               type="button"
-              className="bg-white dark:bg-gray-800 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="bg-white dark:bg-gray-800 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               onClick={toggle}
             >
               {t("forms.apiKey.cancel")}
             </button>
             <button
               type="submit"
-              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
             >
               {t("forms.apiKey.create")}
             </button>

--- a/web/src/forms/settings/DownloaderForms.tsx
+++ b/web/src/forms/settings/DownloaderForms.tsx
@@ -463,7 +463,7 @@ export interface componentMapType {
   [key: string]: ReactElement;
 }
 
-export const componentMap: componentMapType = {
+const componentMap: componentMapType = {
   DELUGE_V1: <FormFieldsDeluge />,
   DELUGE_V2: <FormFieldsDeluge />,
   QBITTORRENT: <FormFieldsQbit />,
@@ -643,7 +643,7 @@ function FormFieldsRulesTransmission() {
   );
 }
 
-export const rulesComponentMap: componentMapType = {
+const rulesComponentMap: componentMapType = {
   DELUGE_V1: <FormFieldsRulesBasic />,
   DELUGE_V2: <FormFieldsRulesBasic />,
   QBITTORRENT: <FormFieldsRulesQbit />,

--- a/web/src/forms/settings/DownloaderForms.tsx
+++ b/web/src/forms/settings/DownloaderForms.tsx
@@ -692,7 +692,7 @@ function DownloaderFormButtons({
         {type === "UPDATE" && (
           <button
             type="button"
-            className="inline-flex items-center justify-center px-4 py-2 border border-transparent font-medium rounded-md text-red-700 dark:text-white bg-red-100 dark:bg-red-700 hover:bg-red-200 dark:hover:bg-red-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:text-sm"
+            className="inline-flex items-center justify-center px-4 py-2 border border-transparent font-medium rounded-md text-red-700 dark:text-white bg-red-100 dark:bg-red-700 hover:bg-red-200 dark:hover:bg-red-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:text-sm cursor-pointer"
             onClick={toggleDeleteModal}
           >
             {t("forms.downloadClient.remove")}
@@ -746,14 +746,14 @@ function DownloaderFormButtons({
 
           <button
             type="button"
-            className="mr-4 bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+            className="mr-4 bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
             onClick={cancelFn}
           >
             {t("forms.downloadClient.cancel")}
           </button>
           <button
             type="submit"
-            className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+            className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
           >
             {type === "CREATE" ? t("forms.downloadClient.create") : t("forms.downloadClient.save")}
           </button>
@@ -873,7 +873,7 @@ function DownloaderAddFormPanel({ toggle }: DownloaderAddFormPanelProps) {
               <div className="h-7 flex items-center">
                 <button
                   type="button"
-                  className="bg-white dark:bg-gray-800 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                  className="bg-white dark:bg-gray-800 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
                   onClick={toggle}
                 >
                   <span className="sr-only">{t("settings:forms.downloadClient.closePanel")}</span>
@@ -1055,7 +1055,7 @@ function DownloaderUpdateFormPanel({ toggle, data: client }: DownloaderUpdateFor
                 <div className="h-7 flex items-center">
                   <button
                     type="button"
-                    className="bg-white dark:bg-gray-800 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                    className="bg-white dark:bg-gray-800 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
                     onClick={toggle}
                   >
                     <span className="sr-only">{t("settings:forms.downloadClient.closePanel")}</span>

--- a/web/src/forms/settings/FeedForms.tsx
+++ b/web/src/forms/settings/FeedForms.tsx
@@ -15,7 +15,7 @@ import { SlideOver } from "@components/panels";
 import { NumberFieldWide, PasswordFieldWide, SwitchGroupWide, TextFieldWide } from "@components/inputs";
 import { SelectFieldBasic } from "@components/inputs/select_wide";
 import { sleep } from "@utils";
-import { ImplementationBadges } from "@screens/settings/Indexer";
+import { ImplementationBadge } from "@screens/settings/Indexer";
 import { FeedDownloadTypeOptions } from "@domain/constants";
 import { UpdateFormProps } from "@forms/_shared";
 import { useFormContext, useFormValues } from "@hooks/form";
@@ -156,7 +156,7 @@ export function FeedUpdateForm({ isOpen, toggle, data}: UpdateFormProps<Feed>) {
                 </label>
               </div>
               <div className="flex justify-end sm:col-span-2">
-                {ImplementationBadges[feed.type.toLowerCase()]}
+                <ImplementationBadge implementation={feed.type} />
               </div>
             </div>
 

--- a/web/src/forms/settings/FeedForms.tsx
+++ b/web/src/forms/settings/FeedForms.tsx
@@ -379,7 +379,7 @@ function FeedCategoriesSection({ feedID }: { feedID: number }) {
             return (
               <div key={category.id} className="space-y-2">
                 <label
-                  className="flex items-center justify-between gap-3 text-sm text-gray-700 dark:text-gray-200"
+                  className="flex items-center justify-between gap-3 text-sm text-gray-700 dark:text-gray-200 cursor-pointer"
                   onClick={(event) => event.stopPropagation()}
                 >
                   <span className="flex items-center gap-3">
@@ -388,7 +388,7 @@ function FeedCategoriesSection({ feedID }: { feedID: number }) {
                       checked={(values.categories ?? []).includes(category.id)}
                       onChange={() => toggleParentCategory(category.id, childIds)}
                       onClick={(event) => event.stopPropagation()}
-                      className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+                      className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 cursor-pointer"
                     />
                     <span className="font-medium truncate">{category.name}</span>
                   </span>
@@ -398,7 +398,7 @@ function FeedCategoriesSection({ feedID }: { feedID: number }) {
                 {category.subcategories.map((subCategory) => (
                   <label
                     key={subCategory.id}
-                    className="flex items-center justify-between gap-3 pl-6 text-sm text-gray-700 dark:text-gray-200"
+                    className="flex items-center justify-between gap-3 pl-6 text-sm text-gray-700 dark:text-gray-200 cursor-pointer"
                     onClick={(event) => event.stopPropagation()}
                   >
                     <span className="flex items-center gap-3">

--- a/web/src/forms/settings/IndexerForms.tsx
+++ b/web/src/forms/settings/IndexerForms.tsx
@@ -334,7 +334,7 @@ function FeedCategoriesDraftSection({ feedType }: { feedType: FeedType }) {
                       checked={categoriesValue.includes(category.id)}
                       onChange={() => toggleParentCategory(category.id, childIds)}
                       onClick={(event) => event.stopPropagation()}
-                      className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+                      className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 cursor-pointer"
                     />
                     <span className="font-medium truncate">{category.name}</span>
                   </span>
@@ -700,7 +700,7 @@ function IndexerAddFormPanel({ toggle }: IndexerAddFormPanelProps) {
               <div className="h-7 flex items-center">
                 <button
                   type="button"
-                  className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                  className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 cursor-pointer"
                   onClick={toggle}
                 >
                   <span className="sr-only">{t("forms.indexer.closePanel")}</span>
@@ -757,14 +757,14 @@ function IndexerAddFormPanel({ toggle }: IndexerAddFormPanelProps) {
           <div className="space-x-3 flex justify-end">
             <button
               type="button"
-              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               onClick={toggle}
             >
               {t("forms.indexer.cancel")}
             </button>
             <button
               type="submit"
-              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
             >
               {t("forms.indexer.save")}
             </button>

--- a/web/src/forms/settings/IrcForms.tsx
+++ b/web/src/forms/settings/IrcForms.tsx
@@ -81,7 +81,7 @@ const ChannelsFieldArray = ({ channels }: ChannelsFieldArrayProps) => {
 
               <button
                 type="button"
-                className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
                 onClick={() => form.removeFieldValue("channels", index)}
               >
                 <span className="sr-only">{t("forms.irc.remove")}</span>
@@ -96,7 +96,7 @@ const ChannelsFieldArray = ({ channels }: ChannelsFieldArrayProps) => {
         )}
         <button
           type="button"
-          className="border dark:border-gray-600 dark:bg-gray-700 my-4 px-4 py-2 text-sm text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 rounded-sm self-center text-center"
+          className="border dark:border-gray-600 dark:bg-gray-700 my-4 px-4 py-2 text-sm text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 rounded-sm self-center text-center cursor-pointer"
           onClick={() => form.pushFieldValue("channels", { name: "", password: "", enabled: true })}
         >
           {t("forms.irc.addChannel")}

--- a/web/src/forms/settings/ListForms.tsx
+++ b/web/src/forms/settings/ListForms.tsx
@@ -390,7 +390,7 @@ function ListUpdateFormPanel({ toggle, data }: ListUpdateFormPanelProps) {
                 <div className="h-7 flex items-center">
                   <button
                     type="button"
-                    className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                    className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 cursor-pointer"
                     onClick={toggle}
                   >
                     <span className="sr-only">{t("forms.list.closePanel")}</span>

--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -494,7 +494,7 @@ function NotificationAddFormPanel({ toggle }: NotificationAddFormPanelProps) {
               <div className="h-7 flex items-center">
                 <button
                   type="button"
-                  className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                  className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 cursor-pointer"
                   onClick={toggle}
                 >
                   <span className="sr-only">{t("settings:forms.notification.closePanel")}</span>
@@ -551,21 +551,21 @@ function NotificationAddFormPanel({ toggle }: NotificationAddFormPanelProps) {
           <div className="space-x-3 flex justify-end">
             <button
               type="button"
-              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               onClick={() => testNotification(values)}
             >
               {t("settings:forms.notification.test")}
             </button>
             <button
               type="button"
-              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               onClick={toggle}
             >
               {t("settings:forms.notification.cancel")}
             </button>
             <button
               type="submit"
-              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
             >
               {t("settings:forms.notification.save")}
             </button>

--- a/web/src/forms/settings/NotificationForms.tsx
+++ b/web/src/forms/settings/NotificationForms.tsx
@@ -764,7 +764,7 @@ const EventSounds = () => {
       ...PushoverSoundOptions,
       ...customSounds
     ];
-  }, [soundsQuery.data]);
+  }, [soundsQuery.data, t]);
 
   return (
     <fieldset className="">

--- a/web/src/forms/settings/ProxyForms.tsx
+++ b/web/src/forms/settings/ProxyForms.tsx
@@ -103,7 +103,7 @@ function ProxyAddFormPanel({ toggle }: ProxyAddFormPanelProps) {
               <div className="h-7 flex items-center">
                 <button
                   type="button"
-                  className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+                  className="bg-white dark:bg-gray-700 rounded-md text-gray-400 hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-blue-500 cursor-pointer"
                   onClick={toggle}
                 >
                   <span className="sr-only">{t("forms.proxy.closePanel")}</span>
@@ -138,21 +138,21 @@ function ProxyAddFormPanel({ toggle }: ProxyAddFormPanelProps) {
           <div className="space-x-3 flex justify-end">
             <button
               type="button"
-              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               onClick={() => testProxy(values)}
             >
               {t("forms.proxy.test")}
             </button>
             <button
               type="button"
-              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               onClick={toggle}
             >
               {t("forms.proxy.cancel")}
             </button>
             <button
               type="submit"
-              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="inline-flex justify-center py-2 px-4 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
             >
               {t("forms.proxy.save")}
             </button>

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -7,9 +7,7 @@ import {
   createRootRouteWithContext,
   createRoute,
   createRouter,
-  Navigate,
   notFound,
-  Outlet,
   redirect,
 } from "@tanstack/react-router";
 import { z } from "zod";
@@ -38,23 +36,21 @@ import NotificationSettings from "@screens/settings/Notifications";
 import ApplicationSettings from "@screens/settings/Application";
 import { Logs } from "@screens/Logs";
 import IrcSettings from "@screens/settings/Irc";
-import { Header } from "@components/header";
 import { RingResizeSpinner } from "@components/Icons";
 import APISettings from "@screens/settings/Api";
 import { Releases } from "@screens/Releases";
 import IndexerSettings from "@screens/settings/Indexer";
-import DownloaderSettings from "@screens/settings/Downloaders.tsx";
+import DownloaderSettings from "@screens/settings/Downloaders";
 import FeedSettings from "@screens/settings/Feed";
 import { Dashboard } from "@screens/Dashboard";
 import AccountSettings from "@screens/settings/Account";
-import { AuthContext, SettingsContext } from "@utils/Context";
-import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { AuthContext } from "@utils/Context";
 import { queryClient } from "@api/QueryClient";
 import ProxySettings from "@screens/settings/Proxy";
 import ListsSettings from "@screens/settings/Lists";
 
 import { ErrorPage } from "@components/alerts";
+import { AuthenticatedLayout, RootComponent } from "@components/layouts";
 
 const DashboardRoute = createRoute({
   getParentRoute: () => AuthIndexRoute,
@@ -343,40 +339,11 @@ export const AuthRoute = createRoute({
   },
 })
 
-function AuthenticatedLayout() {
-  const isLoggedIn = AuthContext.useSelector((s) => s.isLoggedIn);
-  if (!isLoggedIn) {
-    return <Navigate to="/login" search={{ redirect: location.pathname + location.search }} />;
-  }
-
-  return (
-    <div className="flex flex-col min-h-screen">
-      <Header />
-      <Outlet />
-    </div>
-  )
-}
-
 export const AuthIndexRoute = createRoute({
   getParentRoute: () => AuthRoute,
   component: AuthenticatedLayout,
   id: 'authenticated-routes',
 });
-
-export const RootComponent = () => {
-  const settings = SettingsContext.useValue();
-  return (
-    <div className="flex flex-col min-h-screen">
-      <Outlet />
-      {settings.debug ? (
-        <>
-          {import.meta.env.DEV && <TanStackRouterDevtools />}
-          {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
-        </>
-      ) : null}
-    </div>
-  )
-}
 
 export const RootRoute = createRootRouteWithContext<{
   queryClient: QueryClient

--- a/web/src/screens/Logs.tsx
+++ b/web/src/screens/Logs.tsx
@@ -94,8 +94,7 @@ export const Logs = () => {
       const newLogs = logs.filter(log => pattern.test(log.message));
       setFilteredLogs(newLogs);
       setIsInvalidRegex(false);
-    } catch (error) {
-      // Handle regex errors by showing nothing when the regex pattern is invalid
+    } catch {
       setFilteredLogs([]);
       setIsInvalidRegex(true);
     }

--- a/web/src/screens/Logs.tsx
+++ b/web/src/screens/Logs.tsx
@@ -135,7 +135,7 @@ export const Logs = () => {
             <button
               type="button"
               onClick={handleClearLogs}
-              className="px-4 py-2"
+              className="px-4 py-2 cursor-pointer"
               title={t("logs.clearTitle")}
             >
               <TrashIcon className="w-5 h-5 text-gray-700 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-400" aria-hidden="true" />
@@ -280,6 +280,7 @@ const LogFilesItem = ({ file }: LogFilesItemProps) => {
           <div className="logFilesItem">
             <button
               className={classNames(
+                "cursor-pointer",
                 "text-gray-900 dark:text-gray-300",
                 "font-medium group flex rounded-md items-center px-2 py-2 text-sm"
               )}
@@ -321,7 +322,7 @@ const LogsDropdown = () => {
 
   return (
     <Menu as="div">
-      <MenuButton className="px-4 py-2">
+      <MenuButton className="px-4 py-2 cursor-pointer">
         <Cog6ToothIcon
           className="w-5 h-5 text-gray-700 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-400"
           aria-hidden="true"

--- a/web/src/screens/Releases.tsx
+++ b/web/src/screens/Releases.tsx
@@ -31,7 +31,7 @@ export const Releases = () => {
               e.preventDefault();
               setIsHintOpen((state) => !state);
             }}
-            className="inline-flex whitespace-nowrap items-center shadow-md border rounded-md mx-1 px-1 text-black bg-lime-100 hover:bg-lime-200 border-lime-500 dark:text-white dark:bg-lime-950 dark:hover:bg-lime-900 dark:border-lime-800"
+            className="inline-flex whitespace-nowrap items-center shadow-md border rounded-md mx-1 px-1 text-black bg-lime-100 hover:bg-lime-200 border-lime-500 dark:text-white dark:bg-lime-950 dark:hover:bg-lime-900 dark:border-lime-800 cursor-pointer"
 
           >
             {t("releaseSearch.clickHere")}

--- a/web/src/screens/auth/Login.tsx
+++ b/web/src/screens/auth/Login.tsx
@@ -266,7 +266,7 @@ export const Login = () => {
 
                                     <button
                                         type="submit"
-                                        className="w-full flex items-center justify-center py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                                        className="w-full flex items-center justify-center py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer"
                                     >
                                         <RocketLaunchIcon className="w-4 h-4 mr-1.5"/>
                                         {t("signIn")}
@@ -292,7 +292,7 @@ export const Login = () => {
                                 <button
                                     type="button"
                                     onClick={handleOIDCLogin}
-                                    className="w-full flex items-center justify-center gap-3 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-900 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+                                    className="w-full flex items-center justify-center gap-3 py-2 px-4 border border-gray-300 dark:border-gray-700 rounded-md shadow-xs text-sm font-medium text-gray-900 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
                                 >
                                     <FontAwesomeIcon icon={faOpenid} className="h-5 w-5"/>
                                     <span>{t("openidConnect")}</span>
@@ -333,7 +333,7 @@ function PasswordInputField({name, value, onChange, onBlur, isValid}: PasswordFi
                             : "border-gray-300 dark:border-gray-700 focus:ring-blue-500 dark:focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500"
                     )}
                 />
-                <div className="absolute inset-y-0 right-0 px-3 flex items-center" onClick={toggleVisibility}>
+                <div className="absolute inset-y-0 right-0 px-3 flex items-center cursor-pointer" onClick={toggleVisibility}>
                     {!isVisible ? <EyeIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true"/> : <EyeSlashIcon className="h-5 w-5 text-gray-400 hover:text-gray-500" aria-hidden="true"/>}
                 </div>
             </div>

--- a/web/src/screens/auth/Login.tsx
+++ b/web/src/screens/auth/Login.tsx
@@ -107,7 +107,7 @@ export const Login = () => {
                 ));
             });
         }
-    }, [queryErrorResetBoundary, oidcConfig, setAuth, router]);
+    }, [queryErrorResetBoundary, oidcConfig, setAuth, router, t]);
 
     const loginMutation = useMutation({
         mutationFn: (data: LoginFormFields) => APIClient.auth.login(data.username, data.password, data.remember_me),
@@ -139,7 +139,7 @@ export const Login = () => {
         } else if (auth.isLoggedIn) {
             router.history.push("/")
         }
-    }, [auth.isLoggedIn, search.redirect, router.history]) // eslint-disable-line
+    }, [auth.isLoggedIn, search.redirect, router.history])
 
     return (
         <div className="flex min-h-full flex-1 flex-col justify-center py-12 sm:px-6 lg:px-8">

--- a/web/src/screens/auth/Onboarding.tsx
+++ b/web/src/screens/auth/Onboarding.tsx
@@ -97,7 +97,7 @@ export const Onboarding = () => {
               </div>
               <button
                 type="submit"
-                className="mt-6 w-full flex items-center justify-center py-2 px-4 border border-transparent transition rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                className="mt-6 w-full flex items-center justify-center py-2 px-4 border border-transparent transition rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               >
                 <UserPlusIcon className="w-4 h-4 mr-1.5" />
                 {t("createAccount")}

--- a/web/src/screens/dashboard/ActivityChart.tsx
+++ b/web/src/screens/dashboard/ActivityChart.tsx
@@ -14,7 +14,8 @@ import { curveMonotoneX } from "d3-shape";
 import { format } from "date-fns";
 
 import { ReleasesActivityQueryOptions } from "@api/queries";
-import { ChartCard, ChartError, ChartLegend, ChartSkeleton, RangeSelect, chartTheme, seriesColors, useIsDark } from "./charts";
+import { ChartCard, ChartError, ChartLegend, ChartSkeleton, RangeSelect } from "./charts";
+import { chartTheme, seriesColors, useIsDark } from "./chartTheme";
 
 interface ActivityDatum {
   date: Date;

--- a/web/src/screens/dashboard/DashboardGrid.tsx
+++ b/web/src/screens/dashboard/DashboardGrid.tsx
@@ -124,7 +124,7 @@ const SortableWidget = ({ def, hidden, editing, committing, onToggle }: Sortable
           <button
             type="button"
             onClick={onToggle}
-            className="inline-flex size-9 items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 ease-in-out hover:bg-white hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            className="inline-flex size-9 items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 ease-in-out hover:bg-white hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-200 cursor-pointer"
             title={hidden ? t("dashboardCustomize.show") : t("dashboardCustomize.hide")}
             aria-label={hidden ? t("dashboardCustomize.show") : t("dashboardCustomize.hide")}
           >
@@ -315,7 +315,7 @@ export const DashboardGrid = () => {
           <button
             type="button"
             onClick={() => setSettings((current) => ({ ...current, incognitoMode: !current.incognitoMode }))}
-            className="inline-flex size-9 items-center justify-center rounded-md text-gray-500 transition-colors duration-200 ease-in-out hover:bg-gray-100 hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            className="inline-flex size-9 items-center justify-center rounded-md text-gray-500 transition-colors duration-200 ease-in-out hover:bg-gray-100 hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-200 cursor-pointer"
             aria-label={t("releaseTable.goIncognito")}
             title={t("releaseTable.goIncognito")}
           >
@@ -330,14 +330,14 @@ export const DashboardGrid = () => {
               <button
                 type="button"
                 onClick={() => DashboardConfigContext.set({ version: 1, widgets: [] })}
-                className="min-h-9 rounded-md px-2.5 py-1.5 text-sm text-gray-500 transition-colors duration-200 ease-in-out hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+                className="min-h-9 rounded-md px-2.5 py-1.5 text-sm text-gray-500 transition-colors duration-200 ease-in-out hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 cursor-pointer"
               >
                 {t("dashboardCustomize.reset")}
               </button>
               <button
                 type="button"
                 onClick={() => setEditing(false)}
-                className="min-h-9 rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors duration-200 ease-in-out hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                className="min-h-9 rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors duration-200 ease-in-out hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 cursor-pointer"
               >
                 {t("dashboardCustomize.done")}
               </button>
@@ -346,7 +346,7 @@ export const DashboardGrid = () => {
             <button
               type="button"
               onClick={() => setEditing(true)}
-              className="flex min-h-9 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-gray-500 transition-colors duration-200 ease-in-out hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+              className="flex min-h-9 items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-gray-500 transition-colors duration-200 ease-in-out hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 cursor-pointer"
             >
               <Squares2X2Icon className="h-4 w-4" aria-hidden="true" />
               {t("dashboardCustomize.customize")}

--- a/web/src/screens/dashboard/HourHeatmap.tsx
+++ b/web/src/screens/dashboard/HourHeatmap.tsx
@@ -12,7 +12,8 @@ import { tooltip } from "@tanstack/charts/tooltip";
 import { scaleBand, scaleQuantize } from "d3-scale";
 
 import { ReleasesHeatmapQueryOptions } from "@api/queries";
-import { ChartCard, ChartError, ChartSkeleton, chartTheme, sequentialRamp, useIsDark } from "./charts";
+import { ChartCard, ChartError, ChartSkeleton } from "./charts";
+import { chartTheme, sequentialRamp, useIsDark } from "./chartTheme";
 
 interface HeatmapDatum {
   hour: number;

--- a/web/src/screens/dashboard/TopLists.tsx
+++ b/web/src/screens/dashboard/TopLists.tsx
@@ -8,7 +8,8 @@ import { useTranslation } from "react-i18next";
 
 import { ReleasesTopFiltersQueryOptions, ReleasesTopIndexersQueryOptions } from "@api/queries";
 import { SettingsContext } from "@utils/Context";
-import { ChartCard, ChartError, ChartSkeleton, seriesColors, useIsDark } from "./charts";
+import { ChartCard, ChartError, ChartSkeleton } from "./charts";
+import { seriesColors, useIsDark } from "./chartTheme";
 
 interface BreakdownRow {
   name: string;

--- a/web/src/screens/dashboard/VolumeChart.tsx
+++ b/web/src/screens/dashboard/VolumeChart.tsx
@@ -14,7 +14,8 @@ import { format } from "date-fns";
 
 import { ReleasesVolumeQueryOptions } from "@api/queries";
 import { humanFileSize } from "@utils";
-import { ChartCard, ChartError, ChartSkeleton, chartTheme, seriesColors, useIsDark } from "./charts";
+import { ChartCard, ChartError, ChartSkeleton } from "./charts";
+import { chartTheme, seriesColors, useIsDark } from "./chartTheme";
 
 const asDate = (value: string) => new Date(`${value}T00:00:00Z`);
 

--- a/web/src/screens/dashboard/chartTheme.ts
+++ b/web/src/screens/dashboard/chartTheme.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useSyncExternalStore } from "react";
+import { SettingsContext } from "@utils/Context";
+
+const subscribeToColorScheme = (onChange: () => void) => {
+  const mq = window.matchMedia("(prefers-color-scheme: dark)");
+  mq.addEventListener("change", onChange);
+  return () => mq.removeEventListener("change", onChange);
+};
+
+export const useIsDark = (): boolean => {
+  const settings = SettingsContext.useValue();
+  const prefersDark = useSyncExternalStore(
+    subscribeToColorScheme,
+    () => window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+  return settings.theme === "dark" || (settings.theme === "system" && prefersDark);
+};
+
+// Tailwind hues the app already uses (green-600, blue-500, zinc, red),
+// validated for CVD separation and surface contrast against the card
+// surfaces (#ffffff / #27272a). Rejected is deliberately gray: it is
+// context next to the series that matter, and a warm hue beside the green
+// fails colorblind separation. Keep the series order approved, matches,
+// rejected, errored when they share a chart.
+export const seriesColors = (dark: boolean) => ({
+  approved: "#16a34a",
+  matches: "#3b82f6",
+  rejected: dark ? "#71717a" : "#a1a1aa",
+  errored: dark ? "#ef4444" : "#dc2626"
+});
+
+export const sequentialRamp = (dark: boolean): string[] =>
+  dark
+    ? ["#1e3a8a", "#1d4ed8", "#3b82f6", "#60a5fa", "#bfdbfe"]
+    : ["#bfdbfe", "#93c5fd", "#60a5fa", "#2563eb", "#1e40af"];
+
+export const chartTheme = (dark: boolean) => ({
+  foreground: dark ? "#d4d4d8" : "#3f3f46",
+  muted: dark ? "#a1a1aa" : "#71717a",
+  grid: dark ? "#3f3f46" : "#e4e4e7",
+  background: dark ? "#27272a" : "#ffffff",
+  palette: Object.values(seriesColors(dark))
+});

--- a/web/src/screens/dashboard/charts.tsx
+++ b/web/src/screens/dashboard/charts.tsx
@@ -3,51 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useSyncExternalStore } from "react";
 import { useTranslation } from "react-i18next";
-import { SettingsContext } from "@utils/Context";
 import { classNames } from "@utils";
-
-const subscribeToColorScheme = (onChange: () => void) => {
-  const mq = window.matchMedia("(prefers-color-scheme: dark)");
-  mq.addEventListener("change", onChange);
-  return () => mq.removeEventListener("change", onChange);
-};
-
-export const useIsDark = (): boolean => {
-  const settings = SettingsContext.useValue();
-  const prefersDark = useSyncExternalStore(
-    subscribeToColorScheme,
-    () => window.matchMedia("(prefers-color-scheme: dark)").matches
-  );
-  return settings.theme === "dark" || (settings.theme === "system" && prefersDark);
-};
-
-// Tailwind hues the app already uses (green-600, blue-500, zinc, red),
-// validated for CVD separation and surface contrast against the card
-// surfaces (#ffffff / #27272a). Rejected is deliberately gray: it is
-// context next to the series that matter, and a warm hue beside the green
-// fails colorblind separation. Keep the series order approved, matches,
-// rejected, errored when they share a chart.
-export const seriesColors = (dark: boolean) => ({
-  approved: "#16a34a",
-  matches: "#3b82f6",
-  rejected: dark ? "#71717a" : "#a1a1aa",
-  errored: dark ? "#ef4444" : "#dc2626"
-});
-
-export const sequentialRamp = (dark: boolean): string[] =>
-  dark
-    ? ["#1e3a8a", "#1d4ed8", "#3b82f6", "#60a5fa", "#bfdbfe"]
-    : ["#bfdbfe", "#93c5fd", "#60a5fa", "#2563eb", "#1e40af"];
-
-export const chartTheme = (dark: boolean) => ({
-  foreground: dark ? "#d4d4d8" : "#3f3f46",
-  muted: dark ? "#a1a1aa" : "#71717a",
-  grid: dark ? "#3f3f46" : "#e4e4e7",
-  background: dark ? "#27272a" : "#ffffff",
-  palette: Object.values(seriesColors(dark))
-});
 
 interface ChartCardProps {
   title: string;

--- a/web/src/screens/filters/Details.tsx
+++ b/web/src/screens/filters/Details.tsx
@@ -121,7 +121,7 @@ const FormButtonsGroup = ({ deleteAction, reset, isLoading }: FormButtonsGroupPr
       <div className="px-0.5 mt-8 flex flex-col-reverse sm:flex-row flex-wrap-reverse justify-between">
         <button
           type="button"
-          className="flex items-center justify-center px-4 py-2 rounded-md sm:text-sm transition bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden"
+          className="flex items-center justify-center px-4 py-2 rounded-md sm:text-sm transition bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden cursor-pointer"
           onClick={toggleDeleteModal}
         >
           {t("details.delete")}
@@ -130,7 +130,7 @@ const FormButtonsGroup = ({ deleteAction, reset, isLoading }: FormButtonsGroupPr
         <div className="flex justify-between mb-4 sm:mb-0">
           <button
             type="button"
-            className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 transition rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+            className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 transition rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
             onClick={(e) => {
               e.preventDefault();
               reset();
@@ -142,7 +142,7 @@ const FormButtonsGroup = ({ deleteAction, reset, isLoading }: FormButtonsGroupPr
           </button>
           <button
             type="submit"
-            className="ml-1 sm:ml-4 flex items-center px-4 py-2 border border-transparent transition shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            className="ml-1 sm:ml-4 flex items-center px-4 py-2 border border-transparent transition shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer"
           >
             {t("details.save")}
           </button>

--- a/web/src/screens/filters/Importer.tsx
+++ b/web/src/screens/filters/Importer.tsx
@@ -46,7 +46,7 @@ const ModalLower = ({ isOpen, setIsOpen, onImportClick }: ModalLowerProps) => {
   <div className="bg-gray-50 dark:bg-gray-800 border-t border-gray-300 dark:border-gray-700 px-4 py-3 sm:px-4 sm:flex sm:flex-row-reverse">
     <button
       type="button"
-      className="w-full inline-flex justify-center rounded-md border border-blue-500 shadow-xs px-4 py-2 bg-blue-700 text-base font-medium text-white hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm"
+      className="w-full inline-flex justify-center rounded-md border border-blue-500 shadow-xs px-4 py-2 bg-blue-700 text-base font-medium text-white hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer"
       onClick={(e) => {
         e.preventDefault();
         if (isOpen) {
@@ -59,7 +59,7 @@ const ModalLower = ({ isOpen, setIsOpen, onImportClick }: ModalLowerProps) => {
     </button>
     <button
       type="button"
-      className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-xs px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+      className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:border-gray-600 shadow-xs px-4 py-2 bg-white dark:bg-gray-700 text-base font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm cursor-pointer"
       onClick={(e) => {
         e.preventDefault();
         setIsOpen(false);

--- a/web/src/screens/filters/List.tsx
+++ b/web/src/screens/filters/List.tsx
@@ -143,7 +143,7 @@ const ToggleAllFiltersCheckbox = ({ filters }: { filters: Filter[] }) => {
       <input
         type="checkbox"
         ref={checkboxRef}
-        className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800"
+        className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 cursor-pointer disabled:cursor-not-allowed"
         onChange={handleToggleAll}
         disabled={mutation.isPending || filters.length === 0}
         title={t("list.toggleAllTitle")}
@@ -178,7 +178,7 @@ export function Filters() {
           {({ open }) => (
             <>
               <button
-                className="relative inline-flex items-center px-4 py-2 shadow-xs text-sm font-medium rounded-l-md transition text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                className="relative inline-flex items-center px-4 py-2 shadow-xs text-sm font-medium rounded-l-md transition text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
                 onClick={(e: { stopPropagation: () => void; }) => {
                   if (!open) {
                     e.stopPropagation();
@@ -189,7 +189,7 @@ export function Filters() {
                 <PlusIcon className="h-5 w-5 mr-1" />
                 {t("list.create")}
               </button>
-              <MenuButton className="relative inline-flex items-center px-2 py-2 border-l border-spacing-1 dark:border-black shadow-xs text-sm font-medium rounded-r-md transition text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500">
+              <MenuButton className="relative inline-flex items-center px-2 py-2 border-l border-spacing-1 dark:border-black shadow-xs text-sm font-medium rounded-r-md transition text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer">
                 <ChevronDownIcon className="h-5 w-5" />
               </MenuButton>
               <Transition
@@ -208,6 +208,7 @@ export function Filters() {
                       <button
                         type="button"
                         className={classNames(
+                          "cursor-pointer",
                           active ? "bg-gray-50 dark:bg-gray-600" : "",
                           "flex items-center w-full text-left py-2 px-3 text-sm font-medium text-gray-700 dark:text-gray-200 rounded-md focus:outline-hidden"
                         )}
@@ -331,6 +332,7 @@ const StatusButton = ({ data, label, value, currentValue, dispatch }: StatusButt
   return (
     <button
       className={classNames(
+        "cursor-pointer",
         "py-4 pb-4 text-left text-xs tracking-wider transition border-b-2",
         currentValue === value
           ? "font-bold  border-blue-500 dark:text-gray-100 text-gray-950"
@@ -455,7 +457,7 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
         title={t("list.removeTitle", { name: filter.name })}
         text={t("list.removeText")}
       />
-      <MenuButton className="px-4 py-2">
+      <MenuButton className="px-4 py-2 cursor-pointer">
         <EllipsisHorizontalIcon
           className="w-5 h-5 text-gray-700 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-400"
           aria-hidden="true"
@@ -503,6 +505,7 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-blue-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -522,6 +525,7 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-blue-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -542,6 +546,7 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-blue-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -562,6 +567,7 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-blue-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -584,6 +590,7 @@ const FilterItemDropdown = ({ filter, onToggle }: FilterItemDropdownProps) => {
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-red-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}

--- a/web/src/screens/filters/List.tsx
+++ b/web/src/screens/filters/List.tsx
@@ -252,7 +252,7 @@ function filteredData(data: Filter[], status: string) {
   };
 }
 
-function FilterList({ toggleCreateFilter }: any) {
+function FilterList({ toggleCreateFilter }: { toggleCreateFilter: () => void }) {
   const { t } = useTranslation("filters");
   const filterListState = FilterListContext.useValue();
 
@@ -872,7 +872,7 @@ const ListboxFilter = ({
 );
 
 // a unique option from a list
-const IndexerSelectFilter = ({ dispatch }: any) => {
+const IndexerSelectFilter = ({ dispatch }: { dispatch: Dispatch<Actions> }) => {
   const { t } = useTranslation("filters");
   const filterListState = FilterListContext.useValue();
 
@@ -936,7 +936,7 @@ const FilterOption = ({ label, value }: FilterOptionProps) => (
   </ListboxOption>
 );
 
-export const SortSelectFilter = ({ dispatch }: any) => {
+export const SortSelectFilter = ({ dispatch }: { dispatch: Dispatch<Actions> }) => {
   const { t } = useTranslation("filters");
   const filterListState = FilterListContext.useValue();
 

--- a/web/src/screens/filters/NotFound.tsx
+++ b/web/src/screens/filters/NotFound.tsx
@@ -54,7 +54,7 @@ export const FilterNotFound = () => {
       <div className="flex justify-center">
         <Link to="/filters">
           <button
-            className="w-48 flex justify-center py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+            className="w-48 flex justify-center py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
           >
             {t("notFound.backToFilters")}
           </button>

--- a/web/src/screens/filters/sections/Actions.tsx
+++ b/web/src/screens/filters/sections/Actions.tsx
@@ -95,7 +95,7 @@ export function Actions() {
         <div className="ml-4 mt-4 shrink-0">
           <button
             type="button"
-            className="relative inline-flex items-center px-4 py-2 border border-transparent transition shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+            className="relative inline-flex items-center px-4 py-2 border border-transparent transition shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
             onClick={() => form.pushFieldValue("actions", newAction)}
           >
             <BoltIcon
@@ -241,7 +241,7 @@ function FilterActionsItem({ action, actionTypeOptions, clients, idx, initialEdi
           )}
         </form.Field>
 
-        <button className="pl-2 pr-0 sm:px-4 py-4 w-full flex items-center" type="button" onClick={toggleEdit}>
+        <button className="pl-2 pr-0 sm:px-4 py-4 w-full flex items-center cursor-pointer" type="button" onClick={toggleEdit}>
           <div className="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
             <div className="flex text-sm truncate">
               <p className="font-medium text-dark-600 dark:text-gray-100 truncate">
@@ -304,7 +304,7 @@ function FilterActionsItem({ action, actionTypeOptions, clients, idx, initialEdi
             <div className="pt-6 pb-4 flex space-x-2 justify-between">
               <button
                 type="button"
-                className="inline-flex items-center justify-center px-4 py-2 rounded-md sm:text-sm bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden"
+                className="inline-flex items-center justify-center px-4 py-2 rounded-md sm:text-sm bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden cursor-pointer"
                 onClick={toggleDeleteModal}
               >
                 {t("filters:actionsSection.removeAction")}
@@ -312,7 +312,7 @@ function FilterActionsItem({ action, actionTypeOptions, clients, idx, initialEdi
 
               <button
                 type="button"
-                className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden"
+                className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden cursor-pointer"
                 onClick={toggleEdit}
               >
                 {t("filters:actionsSection.close")}

--- a/web/src/screens/filters/sections/External.tsx
+++ b/web/src/screens/filters/sections/External.tsx
@@ -70,7 +70,7 @@ export function External() {
         <div className="ml-4 mt-4 shrink-0">
           <button
             type="button"
-            className="relative inline-flex items-center px-4 py-2 transition border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+            className="relative inline-flex items-center px-4 py-2 transition border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
             onClick={push}
           >
             <SquaresPlusIcon
@@ -255,7 +255,7 @@ function FilterExternalItem({ idx, external, initialEdit, remove, move }: Filter
               <div className="space-x-2 flex justify-between">
                 <button
                   type="button"
-                  className="inline-flex items-center justify-center px-4 py-2 rounded-md sm:text-sm bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden"
+                  className="inline-flex items-center justify-center px-4 py-2 rounded-md sm:text-sm bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden cursor-pointer"
                   onClick={toggleDeleteModal}
                 >
                   {t("external.remove")}
@@ -273,7 +273,7 @@ function FilterExternalItem({ idx, external, initialEdit, remove, move }: Filter
 
                   <button
                     type="button"
-                    className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden"
+                    className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden cursor-pointer"
                     onClick={toggleEdit}
                   >
                     {t("external.close")}

--- a/web/src/screens/filters/sections/Notifications.tsx
+++ b/web/src/screens/filters/sections/Notifications.tsx
@@ -81,7 +81,7 @@ export function Notifications() {
           {availableToAdd.length > 0 && (
             <button
               type="button"
-              className="relative inline-flex items-center px-4 py-2 border border-transparent transition shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+              className="relative inline-flex items-center px-4 py-2 border border-transparent transition shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               onClick={() => push(createNewNotification())}
             >
               <BellIcon className="w-5 h-5 mr-1" aria-hidden="true" />
@@ -168,7 +168,7 @@ function NotificationItem({ notification, availableNotifications, idx, initialEd
           "flex items-center transition px-2 sm:px-6 rounded-md my-1 border border-gray-150 dark:border-gray-750 hover:bg-gray-200 dark:hover:bg-gray-850"
         )}
       >
-        <button className="px-4 py-4 w-full flex items-center" type="button" onClick={toggleEdit}>
+        <button className="px-4 py-4 w-full flex items-center cursor-pointer" type="button" onClick={toggleEdit}>
           <div className="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
             <div className="flex text-sm truncate">
               <p className="font-medium text-dark-600 dark:text-gray-100 truncate">
@@ -278,7 +278,7 @@ function NotificationItem({ notification, availableNotifications, idx, initialEd
             <div className="pt-6 pb-4 flex space-x-2 justify-between">
               <button
                 type="button"
-                className="inline-flex items-center justify-center px-4 py-2 rounded-md sm:text-sm bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden"
+                className="inline-flex items-center justify-center px-4 py-2 rounded-md sm:text-sm bg-red-700 dark:bg-red-900 dark:hover:bg-red-700 hover:bg-red-800 text-white focus:outline-hidden cursor-pointer"
                 onClick={toggleDeleteModal}
               >
                 {t("notificationsSection.removeNotification")}
@@ -286,7 +286,7 @@ function NotificationItem({ notification, availableNotifications, idx, initialEd
 
               <button
                 type="button"
-                className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden"
+                className="bg-white dark:bg-gray-700 py-2 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-xs text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden cursor-pointer"
                 onClick={toggleEdit}
               >
                 {t("notificationsSection.close")}

--- a/web/src/screens/filters/sections/_components.tsx
+++ b/web/src/screens/filters/sections/_components.tsx
@@ -128,6 +128,7 @@ export const CollapsibleSection = ({
           <button
             type="button"
             className={classNames(
+              "cursor-pointer",
               isOpen ? "rotate-0" : "-rotate-90",
               "text-sm font-medium text-white transition-transform"
             )}

--- a/web/src/screens/releases/ReleaseTable.tsx
+++ b/web/src/screens/releases/ReleaseTable.tsx
@@ -437,7 +437,7 @@ export const ReleaseTable = () => {
               <div className="absolute -bottom-11 right-0 p-2">
                 <button
                   onClick={toggleReleaseNames}
-                  className="p-2 absolute bottom-0 right-0 bg-gray-750 text-white rounded-full opacity-10 hover:opacity-100 transition-opacity duration-300"
+                  className="p-2 absolute bottom-0 right-0 bg-gray-750 text-white rounded-full opacity-10 hover:opacity-100 transition-opacity duration-300 cursor-pointer"
                   aria-label={t("releaseTable.toggleView")}
                   title={t("releaseTable.goIncognito")}
                 >

--- a/web/src/screens/settings/Account.tsx
+++ b/web/src/screens/settings/Account.tsx
@@ -160,7 +160,7 @@ function Credentials() {
             <div className="flex justify-end">
               <button
                 type="submit"
-                className="mt-4 w-auto flex items-center py-2 px-4 transition rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+                className="mt-4 w-auto flex items-center py-2 px-4 transition rounded-md shadow-xs text-sm font-medium text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
               >
                 <UserIcon className="w-4 h-4 mr-1" />
                 {t("account.save")}

--- a/web/src/screens/settings/Api.tsx
+++ b/web/src/screens/settings/Api.tsx
@@ -36,7 +36,7 @@ function APISettings() {
       rightSide={
         <button
           type="button"
-          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer"
           onClick={toggleAddForm}
         >
           <PlusIcon className="h-5 w-5 mr-1" />
@@ -120,6 +120,7 @@ function APIListItem({ apikey }: ApiKeyItemProps) {
             <div>
               <button
                 className={classNames(
+                  "cursor-pointer",
                   "text-gray-900 dark:text-gray-300",
                   "sm:hidden font-medium group rounded-md items-center px-2 py-2 text-sm"
                 )}
@@ -141,6 +142,7 @@ function APIListItem({ apikey }: ApiKeyItemProps) {
         <div className="col-span-1 hidden sm:flex items-center text-sm font-medium text-gray-900 dark:text-white">
           <button
             className={classNames(
+              "cursor-pointer",
               "text-gray-900 dark:text-gray-300",
               "font-medium group flex rounded-md items-center px-2 py-2 text-sm"
             )}

--- a/web/src/screens/settings/Downloaders.tsx
+++ b/web/src/screens/settings/Downloaders.tsx
@@ -161,7 +161,7 @@ function DownloaderSettings() {
       rightSide={
         <button
           type="button"
-          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
           onClick={toggleAddClient}
         >
           <PlusIcon className="h-5 w-5 mr-1" />

--- a/web/src/screens/settings/Feed.tsx
+++ b/web/src/screens/settings/Feed.tsx
@@ -26,7 +26,7 @@ import Toast from "@components/notifications/Toast";
 import { DeleteModal, ForceRunModal } from "@components/modals";
 import { FeedUpdateForm } from "@forms/settings/FeedForms";
 import { EmptySimple } from "@components/emptystates";
-import { ImplementationBadges } from "./Indexer";
+import { ImplementationBadge } from "./Indexer";
 import { ArrowPathIcon } from "@heroicons/react/24/solid";
 import { ExternalLink } from "@components/ExternalLink";
 import { Section } from "./_components";
@@ -195,7 +195,7 @@ function ListItem({ feed }: ListItemProps) {
           </span>
         </div>
         <div className="hidden md:flex col-span-2 py-3 items-center">
-          {ImplementationBadges[feed.type.toLowerCase()]}
+          <ImplementationBadge implementation={feed.type} />
         </div>
         <div className="hidden md:flex col-span-2 py-3 items-center sm:px-4">
           <span title={simplifyDate(feed.last_run)}>

--- a/web/src/screens/settings/Feed.tsx
+++ b/web/src/screens/settings/Feed.tsx
@@ -321,7 +321,7 @@ const FeedItemDropdown = ({
         title={t("listScreens.feeds.forceRunTitle", { name: feed.name })}
         text={t("listScreens.feeds.forceRunText", { name: feed.name })}
       />
-      <MenuButton className="px-4 py-2">
+      <MenuButton className="px-4 py-2 cursor-pointer">
         <EllipsisHorizontalIcon
           className="w-5 h-5 text-gray-700 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-400"
           aria-hidden="true"
@@ -345,6 +345,7 @@ const FeedItemDropdown = ({
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-blue-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -365,6 +366,7 @@ const FeedItemDropdown = ({
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-blue-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -388,6 +390,7 @@ const FeedItemDropdown = ({
                 <button
                   onClick={() => toggleForceRunModal()}
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-blue-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -419,6 +422,7 @@ const FeedItemDropdown = ({
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-red-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -442,6 +446,7 @@ const FeedItemDropdown = ({
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-red-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}

--- a/web/src/screens/settings/Indexer.tsx
+++ b/web/src/screens/settings/Indexer.tsx
@@ -197,7 +197,7 @@ function IndexerSettings() {
         <button
           type="button"
           onClick={toggleAddIndexer}
-          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
         >
           <PlusIcon className="h-5 w-5 mr-1" />
           {t("listScreens.common.addNew")}
@@ -339,7 +339,7 @@ function DeprecatedIndexers() {
               type="button"
               onClick={() => setPendingAction({ type: "prune", identifiers: [] })}
               disabled={pruneMutation.isPending}
-              className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-red-600 dark:bg-red-600 hover:bg-red-700 dark:hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50"
+              className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-red-600 dark:bg-red-600 hover:bg-red-700 dark:hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
             >
               <ArchiveBoxXMarkIcon className="h-5 w-5 mr-1" />
               {t("listScreens.indexers.deprecated.pruneAll")}
@@ -403,7 +403,7 @@ function DeprecatedIndexers() {
                           name: meta?.name || indexer.name
                         })}
                         disabled={pruneMutation.isPending}
-                        className="text-sm font-medium text-amber-700 hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-300 disabled:opacity-50"
+                        className="text-sm font-medium text-amber-700 hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-300 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
                       >
                         {t("listScreens.indexers.deprecated.pruneOne")}
                       </button>
@@ -416,7 +416,7 @@ function DeprecatedIndexers() {
                           name: meta?.name || indexer.name
                         })}
                         disabled={purgeMutation.isPending}
-                        className="inline-flex items-center text-sm font-medium text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 disabled:opacity-50"
+                        className="inline-flex items-center text-sm font-medium text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
                       >
                         <TrashIcon className="h-4 w-4 mr-1" aria-hidden="true" />
                         {t("listScreens.indexers.deprecated.purge")}

--- a/web/src/screens/settings/Indexer.tsx
+++ b/web/src/screens/settings/Indexer.tsx
@@ -102,12 +102,14 @@ const ImplementationBadgeRSS = () => (
   </span>
 );
 
-export const ImplementationBadges: componentMapType = {
+const ImplementationBadges: componentMapType = {
   irc: <ImplementationBadgeIRC />,
   torznab: <ImplementationBadgeTorznab />,
   newznab: <ImplementationBadgeNewznab />,
   rss: <ImplementationBadgeRSS />
 };
+
+export const ImplementationBadge = ({ implementation }: { implementation: string }) => ImplementationBadges[implementation.toLowerCase()] ?? null;
 
 interface ListItemProps {
   indexer: IndexerDefinition;

--- a/web/src/screens/settings/Irc.tsx
+++ b/web/src/screens/settings/Irc.tsx
@@ -186,7 +186,7 @@ const IrcSettings = () => {
         <button
           type="button"
           onClick={toggleAddNetwork}
-          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
         >
           <PlusIcon className="h-5 w-5 mr-1" />
           {t("forms.irc.addNew")}
@@ -227,7 +227,7 @@ const IrcSettings = () => {
         </ul>
         <div className="flex gap-x-2">
           <button
-            className="flex items-center text-gray-800 dark:text-gray-400 p-1 px-2 rounded-sm shadow-sm bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
+            className="flex items-center text-gray-800 dark:text-gray-400 p-1 px-2 rounded-sm shadow-sm bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer"
             onClick={toggleExpand}
             title={expandNetworks ? t("forms.irc.collapseTitle") : t("forms.irc.expandTitle")}
           >
@@ -450,7 +450,7 @@ const ChannelItem = ({ network, channel }: ChannelItemProps) => {
       )}
     >
       <div
-        className="grid grid-cols-12 gap-4 items-center py-4 "
+        className="grid grid-cols-12 gap-4 items-center py-4 cursor-pointer"
         onClick={toggleView}
       >
         <div className="col-span-5 sm:col-span-4 flex flex-col md:px-6 pl-2 sm:pl-0">
@@ -482,7 +482,7 @@ const ChannelItem = ({ network, channel }: ChannelItemProps) => {
           </span>
         </div>
         <div className="col-span-1 flex items-center justify-end">
-          <button className="hover:text-gray-500 px-2 mx-2 py-1 dark:bg-gray-800 rounded-sm dark:border-gray-900">
+          <button className="hover:text-gray-500 px-2 mx-2 py-1 dark:bg-gray-800 rounded-sm dark:border-gray-900 cursor-pointer">
             {viewChannel ? t("forms.irc.hide") : t("forms.irc.view")}
           </button>
         </div>
@@ -613,7 +613,7 @@ const ListItemDropdown = ({
         title={t("forms.irc.removeNetworkTitle", { name: network.name })}
         text={t("forms.irc.removeNetworkText")}
       />
-      <MenuButton className="px-4 py-2">
+      <MenuButton className="px-4 py-2 cursor-pointer">
         <EllipsisHorizontalIcon
           className="w-5 h-5 text-gray-700 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-400"
           aria-hidden="true"
@@ -637,6 +637,7 @@ const ListItemDropdown = ({
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-blue-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -677,6 +678,7 @@ const ListItemDropdown = ({
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer disabled:cursor-not-allowed",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm",
                     network.enabled
                       ? active ? "bg-blue-600 text-white" : "text-gray-900 dark:text-gray-300"
@@ -705,6 +707,7 @@ const ListItemDropdown = ({
               {({ active }) => (
                 <button
                   className={classNames(
+                    "cursor-pointer",
                     active ? "bg-red-600 text-white" : "text-gray-900 dark:text-gray-300",
                     "font-medium group flex rounded-md items-center w-full px-2 py-2 text-sm"
                   )}
@@ -761,7 +764,7 @@ const ReprocessAnnounceButton = ({ networkId, channel, msg }: ReprocessAnnounceP
 
   return (
     <div className="block">
-    <button className="flex items-center justify-center size-5 mr-1 p-1 rounded-sm transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600" onClick={reprocessAnnounce} title={t("forms.irc.reprocessAnnounce")}>
+    <button className="flex items-center justify-center size-5 mr-1 p-1 rounded-sm transition border-gray-500 bg-gray-250 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 cursor-pointer" onClick={reprocessAnnounce} title={t("forms.irc.reprocessAnnounce")}>
       {mutation.isPending
         ? <RingResizeSpinner className="text-blue-500 iconHeight" aria-hidden="true" />
         : <ArrowPathIcon />
@@ -898,7 +901,7 @@ const IRCLogsDropdown = () => {
   //  at IRCLogsDropdown (http://localhost:3000/src/screens/settings/Irc.tsx?t=1694269937935:1354:53)
   return (
     <Menu as="div" className="relative">
-      <MenuButton className="flex items-center text-gray-800 dark:text-gray-400 p-1 px-2 rounded-sm shadow-sm bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">
+      <MenuButton className="flex items-center text-gray-800 dark:text-gray-400 p-1 px-2 rounded-sm shadow-sm bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer">
         <span className="flex items-center">{t("forms.irc.options")} <Cog6ToothIcon className="ml-1 w-4 h-4" /></span>
       </MenuButton>
       <Transition

--- a/web/src/screens/settings/Logs.tsx
+++ b/web/src/screens/settings/Logs.tsx
@@ -13,7 +13,8 @@ import { ConfigQueryOptions } from "@api/queries";
 import { SettingsKeys } from "@api/query_keys";
 import { toast } from "@components/hot-toast";
 import Toast from "@components/notifications/Toast";
-import { LogLevelOptions, SelectOption } from "@domain/constants";
+import { LogLevelOptions } from "@domain/constants";
+import { MultiSelectOption } from "@components/inputs/select";
 
 import { Section, RowItem } from "./_components";
 import * as common from "@components/inputs/common";
@@ -21,9 +22,9 @@ import { LogFiles } from "@screens/Logs";
 
 type SelectWrapperProps = {
   id: string;
-  value: unknown;
-  onChange: any;
-  options: unknown[];
+  value?: string;
+  onChange: (value: string) => void;
+  options: MultiSelectOption[];
 };
 
 const SelectWrapper = ({ id, value, onChange, options }: SelectWrapperProps) => {
@@ -55,8 +56,12 @@ const SelectWrapper = ({ id, value, onChange, options }: SelectWrapperProps) => 
           baseUnit: 2
         }
       })}
-      value={value && options.find((o: any) => o.value == value)}
-      onChange={onChange}
+      value={options.find((o) => o.value == value)}
+      onChange={(newValue: unknown) => {
+        if (newValue) {
+          onChange(String((newValue as MultiSelectOption).value));
+        }
+      }}
       options={options}
     />
   );
@@ -99,7 +104,7 @@ function LogSettings() {
                     id="log_level"
                     value={config?.log_level}
                     options={LogLevelOptions}
-                    onChange={(value: SelectOption) => setLogLevelUpdateMutation.mutate(value.value)}
+                    onChange={(value) => setLogLevelUpdateMutation.mutate(value)}
                   />
                 }
               />

--- a/web/src/screens/settings/Notifications.tsx
+++ b/web/src/screens/settings/Notifications.tsx
@@ -43,7 +43,7 @@ function NotificationSettings() {
         <button
           type="button"
           onClick={toggleAddNotifications}
-          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 cursor-pointer"
         >
           <PlusIcon className="h-5 w-5 mr-1" />
           {t("listScreens.common.addNew")}

--- a/web/src/screens/settings/Proxy.tsx
+++ b/web/src/screens/settings/Proxy.tsx
@@ -122,7 +122,7 @@ function ProxySettings() {
         <button
           type="button"
           onClick={toggleAddProxy}
-          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500"
+          className="relative inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-blue-600 dark:bg-blue-600 hover:bg-blue-700 dark:hover:bg-blue-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:focus:ring-blue-500 cursor-pointer"
         >
           <PlusIcon className="h-5 w-5 mr-1"/>
           {t("listScreens.common.addNew")}

--- a/web/src/screens/settings/Releases.tsx
+++ b/web/src/screens/settings/Releases.tsx
@@ -365,7 +365,7 @@ function CleanupItemDropdown({ job, toggleUpdate, forceRun}: CleanupItemDropdown
         text={t("releases.removeCleanupJobText")}
       />
 
-      <MenuButton className="px-4 py-2">
+      <MenuButton className="px-4 py-2 cursor-pointer">
         <EllipsisHorizontalIcon
           className="cursor-pointer w-5 h-5 text-gray-700 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-400"
           aria-hidden="true"

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -82,24 +82,6 @@ export function slugify(str: string) {
     .replace(/[-\s]+/g, "-");
 }
 
-// WARNING: This is not a drop in replacement solution and
-// it might not work for some edge cases. Test your code!
-export const get = <T> (obj: T, path: string|Array<any>, defValue?: string) => {
-  // If path is not defined or it has false value
-  if (!path)
-    return undefined;
-  // Check if path is string or array. Regex : ensure that we do not have '.' and brackets.
-  // Regex explained: https://regexr.com/58j0k
-  const pathArray = Array.isArray(path) ? path : path.match(/([^[.\]])+/g);
-  // Find value
-  const result = pathArray && pathArray.reduce(
-    (prevObj, key) => prevObj && prevObj[key],
-    obj
-  );
-  // If found value is undefined return default value; otherwise return the value
-  return result === undefined ? defValue : result;
-};
-
 const UNITS = ['byte', 'kilobyte', 'megabyte', 'gigabyte', 'terabyte', 'petabyte']
 const BYTES_PER_KB = 1000
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -148,22 +148,8 @@ export default ({ mode }: ConfigEnv) => {
       }
     },
     experimental: {
-      renderBuiltUrl(filename: string, { hostId, hostType, type }: {
-        hostId: string,
-        hostType: 'js' | 'css' | 'html',
-        type: 'public' | 'asset'
-      }) {
-        // console.debug(filename, hostId, hostType, type)
+      renderBuiltUrl(filename: string) {
         return '{{.AssetBaseUrl}}' + filename
-        // if (type === 'public') {
-        //   return 'https://www.domain.com/' + filename
-        // }
-        // else if (path.extname(hostId) === '.js') {
-        //   return { runtime: `window.__assetsPath(${JSON.stringify(filename)})` }
-        // }
-        // else {
-        //   return 'https://cdn.domain.com/assets/' + filename
-        // }
       }
     }
   });


### PR DESCRIPTION
# Description

Clears every ESLint error and warning in `web/` so `pnpm --dir web lint` passes with `--max-warnings 0`.

- Replace `any` with real types in `filters/List.tsx`, `settings/Logs.tsx`, `debug.tsx`; drop the unused `get` helper from `utils`
- Remove unused catch binding, unused `renderBuiltUrl` params, and a stale `eslint-disable`
- Add missing `t` dependency to two hook dependency arrays
- Fix `react-refresh/only-export-components`: move layout components out of `routes.tsx` into `components/layouts.tsx`, move chart theme helpers into `dashboard/chartTheme.ts`, wrap the indexer badge map in an `ImplementationBadge` component, un-export module-local maps

No functional change.

## Type of change

- [x] Refactor / maintenance (no functional change)

## How has this been tested?

* `pnpm --dir web lint`, `pnpm --dir web build`, and `pnpm --dir web test` all pass

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
