### PR TITLE
fix(lists): assert pointer client type when refreshing arr lists

### DIFF
--- a/internal/action/service.go
+++ b/internal/action/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/internal/downloader"
 	"github.com/autobrr/autobrr/internal/events"
-	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/autobrr/autobrr/pkg/sharedhttp"
 
 	"github.com/rs/zerolog"
@@ -119,27 +118,4 @@ func (s *Service) DeleteByFilterID(ctx context.Context, filterID int) error {
 
 func (s *Service) ToggleEnabled(actionID int) error {
 	return s.repo.ToggleEnabled(actionID)
-}
-
-func (s *Service) getClientInstance[T any](ctx context.Context, clientID int32) (*T, error) {
-	instance, err := s.downloaderSvc.GetInstance(ctx, clientID)
-	if err != nil {
-		return nil, err
-	}
-
-	cfg := instance.Config()
-	if cfg == nil {
-		return nil, errors.New("client %d has no config", clientID)
-	}
-
-	if !cfg.Enabled {
-		return nil, errors.New("client %s %s not enabled", cfg.Type, cfg.Name)
-	}
-
-	client, err := instance.ClientAs[T]()
-	if err != nil {
-		return nil, err
-	}
-
-	return &client, nil
 }

--- a/internal/list/processor.go
+++ b/internal/list/processor.go
@@ -40,12 +40,7 @@ func (s *Service) getClientInstance[T any](ctx context.Context, clientID int) (*
 		return nil, errors.Errorf("client %s %s not enabled", cfg.Type, cfg.Name)
 	}
 
-	client, err := instance.ClientAs[T]()
-	if err != nil {
-		return nil, err
-	}
-
-	return &client, nil
+	return instance.ClientAs[*T]()
 }
 
 func (s *Service) getProcessor(ctx context.Context, list *domain.List) (Processor, error) {

--- a/internal/list/processor_test.go
+++ b/internal/list/processor_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package list
+
+import (
+	"context"
+	"testing"
+
+	"github.com/autobrr/autobrr/internal/domain"
+	"github.com/autobrr/autobrr/internal/downloader"
+	"github.com/autobrr/autobrr/pkg/arr/lidarr"
+	"github.com/autobrr/autobrr/pkg/arr/radarr"
+	"github.com/autobrr/autobrr/pkg/arr/readarr"
+	"github.com/autobrr/autobrr/pkg/arr/sonarr"
+	"github.com/autobrr/autobrr/pkg/arr/sportarr"
+	"github.com/autobrr/autobrr/pkg/arr/whisparr"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDownloaderService struct {
+	instance *downloader.Instance
+}
+
+func (m *mockDownloaderService) GetInstance(_ context.Context, _ int32) (*downloader.Instance, error) {
+	return m.instance, nil
+}
+
+func TestService_getProcessor(t *testing.T) {
+	type fields struct {
+		clientType domain.DownloaderType
+		client     any
+	}
+	type args struct {
+		list *domain.List
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name:    "lidarr",
+			fields:  fields{clientType: domain.DownloaderTypeLidarr, client: &lidarr.Client{}},
+			args:    args{list: &domain.List{Type: domain.ListTypeLidarr, ClientID: 1}},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "radarr",
+			fields:  fields{clientType: domain.DownloaderTypeRadarr, client: &radarr.Client{}},
+			args:    args{list: &domain.List{Type: domain.ListTypeRadarr, ClientID: 1}},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "readarr",
+			fields:  fields{clientType: domain.DownloaderTypeReadarr, client: &readarr.Client{}},
+			args:    args{list: &domain.List{Type: domain.ListTypeReadarr, ClientID: 1}},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "sonarr",
+			fields:  fields{clientType: domain.DownloaderTypeSonarr, client: &sonarr.Client{}},
+			args:    args{list: &domain.List{Type: domain.ListTypeSonarr, ClientID: 1}},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "sportarr",
+			fields:  fields{clientType: domain.DownloaderTypeSportarr, client: &sportarr.Client{}},
+			args:    args{list: &domain.List{Type: domain.ListTypeSportarr, ClientID: 1}},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "whisparr",
+			fields:  fields{clientType: domain.DownloaderTypeWhisparr, client: &whisparr.Client{}},
+			args:    args{list: &domain.List{Type: domain.ListTypeWhisparr, ClientID: 1}},
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "client type mismatch",
+			fields:  fields{clientType: domain.DownloaderTypeRadarr, client: &radarr.Client{}},
+			args:    args{list: &domain.List{Type: domain.ListTypeSonarr, ClientID: 1}},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &domain.Downloader{ID: 1, Type: tt.fields.clientType, Enabled: true}
+			s := &Service{
+				log:           zerolog.Nop(),
+				downloaderSvc: &mockDownloaderService{instance: downloader.NewInstance(cfg, tt.fields.client)},
+			}
+
+			got, err := s.getProcessor(t.Context(), tt.args.list)
+			if !tt.wantErr(t, err) {
+				return
+			}
+			if err == nil {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Since #2650, `getClientInstance` in `internal/list/processor.go` asserted the cached download client as a value type while the cache stores pointers. Every arr list refresh (Lidarr, Radarr, Readarr, Sonarr, Sportarr, Whisparr) failed with:

```
download client 1 (RADARR) has runtime type *radarr.Client
```

Also removes `action.Service.getClientInstance`. #2650 added it with the same assertion and nothing calls it.

Reported on Discord by TRaSH.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* Tested a `develop` binary and this branch against a Radarr instance in Docker with one movie in the library. On `develop`, the per-list refresh, `POST /api/webhook/lists/trigger/arr`, and `POST /api/webhook/lists/trigger/1` all returned 500 with the error above. On this branch, all three returned 204, the list status became `SUCCESS`, and the attached filter received `The?Matrix` in its `shows` field.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Yes. Claude Code (Fable 5.1) diagnosed the bug, wrote the fix and the regression test, and ran the Docker field test. I reviewed everything.
