### PR TITLE
fix(feeds): set InfoURL from torznab guid

### DIFF
--- a/internal/feed/torznab.go
+++ b/internal/feed/torznab.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -144,7 +145,18 @@ func (j *TorznabJob) processItems(items []torznab.FeedItem) ([]*domain.Release, 
 
 		rls.TorrentName = item.Title
 		rls.DownloadURL = item.Link
-		rls.InfoURL = item.GUID
+
+		if comments := strings.TrimSpace(item.Comments); rls.InfoURL == "" && comments != "" {
+			if u, err := url.Parse(comments); err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != "" {
+				rls.InfoURL = comments
+			}
+		}
+
+		if guid := strings.TrimSpace(item.GUID); rls.InfoURL == "" && guid != "" {
+			if u, err := url.Parse(guid); err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != "" {
+				rls.InfoURL = guid
+			}
+		}
 
 		if item.Enclosure != nil && item.Enclosure.Type == "application/x-bittorrent" {
 			rls.DownloadURL = item.Enclosure.URL

--- a/internal/feed/torznab.go
+++ b/internal/feed/torznab.go
@@ -144,6 +144,7 @@ func (j *TorznabJob) processItems(items []torznab.FeedItem) ([]*domain.Release, 
 
 		rls.TorrentName = item.Title
 		rls.DownloadURL = item.Link
+		rls.InfoURL = item.GUID
 
 		if item.Enclosure != nil && item.Enclosure.Type == "application/x-bittorrent" {
 			rls.DownloadURL = item.Enclosure.URL


### PR DESCRIPTION
# Description
Added torrent info link to torznab sources. When using prowlarr as a torznab feed, the releases page doesn't show option to go to the torrent info page. Sonarr seems to parse this info from the comments https://github.com/Sonarr/Sonarr/blob/4fbc481780ca260cd180ad5c48a43520a958880a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs#L73-L76. Did the same here with GUID as a backup if it's not there. 

Fixes #2674 

## Type of change

<!--- Delete options that are not relevant. --->

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

<!--- Describe how you verified your change. For indexer/IRC changes, the mock indexer
      (see CONTRIBUTING.md) is the easiest way. Backend changes should pass `go test ./...`. --->

* Manually tested change in docker and verified that the info URL for the release is correct

## Screenshots (for UI changes)

<!--- Delete this section if your change has no visible UI. --->
<img width="1065" height="86" alt="image" src="https://github.com/user-attachments/assets/340d06f3-7615-4154-8823-a2f00771b25c" />

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I have linked any related issue and updated docs if needed

## AI disclosure
AI wrote the commit messages.