### PR TITLE
fix(web): handle invalid filter ids in filter route

### DIFF
--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -68,6 +68,9 @@ export const FilterGetByIdRoute = createRoute({
   path: '$filterId',
   params: {
     parse: (params) => {
+      if (!/^[1-9]\d*$/.test(params.filterId)) {
+        throw notFound();
+      }
       const filterId = z.int().safeParse(Number(params.filterId));
       if (!filterId.success) {
         throw notFound();

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -66,14 +66,16 @@ const FilterIndexRoute = createRoute({
 export const FilterGetByIdRoute = createRoute({
   getParentRoute: () => FiltersRoute,
   path: '$filterId',
-  parseParams: (params) => {
-    const filterId = z.int().safeParse(Number(params.filterId));
-    if (!filterId.success) {
-      throw notFound();
-    }
-    return { filterId: filterId.data };
+  params: {
+    parse: (params) => {
+      const filterId = z.int().safeParse(Number(params.filterId));
+      if (!filterId.success) {
+        throw notFound();
+      }
+      return { filterId: filterId.data };
+    },
+    stringify: ({ filterId }) => ({ filterId: `${filterId}` }),
   },
-  stringifyParams: ({ filterId }) => ({ filterId: `${filterId}` }),
   loader: async ({ context, params }) => {
     try {
       const filter = await context.queryClient.query({ ...FilterByIdQueryOptions(params.filterId), staleTime: "static" })

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -66,9 +66,13 @@ const FilterIndexRoute = createRoute({
 export const FilterGetByIdRoute = createRoute({
   getParentRoute: () => FiltersRoute,
   path: '$filterId',
-  parseParams: (params) => ({
-    filterId: z.int().parse(Number(params.filterId)),
-  }),
+  parseParams: (params) => {
+    const filterId = z.int().safeParse(Number(params.filterId));
+    if (!filterId.success) {
+      throw notFound();
+    }
+    return { filterId: filterId.data };
+  },
   stringifyParams: ({ filterId }) => ({ filterId: `${filterId}` }),
   loader: async ({ context, params }) => {
     try {

--- a/web/test/filter-route-params.test.tsx
+++ b/web/test/filter-route-params.test.tsx
@@ -14,7 +14,7 @@ test("numeric filter id parses to a number", () => {
   expect(parse("42")).toEqual({ filterId: 42 });
 });
 
-test.each(["does-not-exist", "1.5", "NaN", "Infinity"])("filter id %s throws notFound instead of a parse error", (filterId) => {
+test.each(["does-not-exist", "1.5", "NaN", "Infinity", "1e3", "0x10", " ", "", "-1", "+5", "01", "0", "99999999999999999999"])("filter id %s throws notFound instead of a parse error", (filterId) => {
   let thrown: unknown;
   try {
     parse(filterId);

--- a/web/test/filter-route-params.test.tsx
+++ b/web/test/filter-route-params.test.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { isNotFound } from "@tanstack/react-router";
+import { expect, test } from "vitest";
+
+import { FilterGetByIdRoute } from "@app/routes";
+
+const parse = (filterId: string) => FilterGetByIdRoute.options.parseParams?.({ filterId });
+
+test("numeric filter id parses to a number", () => {
+  expect(parse("42")).toEqual({ filterId: 42 });
+});
+
+test.each(["does-not-exist", "1.5", "NaN", "Infinity"])("filter id %s throws notFound instead of a parse error", (filterId) => {
+  let thrown: unknown;
+  try {
+    parse(filterId);
+  } catch (err) {
+    thrown = err;
+  }
+  expect(isNotFound(thrown)).toBe(true);
+});

--- a/web/test/filter-route-params.test.tsx
+++ b/web/test/filter-route-params.test.tsx
@@ -8,7 +8,7 @@ import { expect, test } from "vitest";
 
 import { FilterGetByIdRoute } from "@app/routes";
 
-const parse = (filterId: string) => FilterGetByIdRoute.options.parseParams?.({ filterId });
+const parse = (filterId: string) => FilterGetByIdRoute.options.params?.parse?.({ filterId });
 
 test("numeric filter id parses to a number", () => {
   expect(parse("42")).toEqual({ filterId: 42 });


### PR DESCRIPTION
# Description

Opening a filter URL with a non-numeric id like `/filters/does-not-exist` rendered the generic error page with a `PathParamError` instead of the filter not-found screen, since `z.int().parse` threw before the loader could raise `notFound()`.

- `FilterGetByIdRoute` now uses `safeParse` and throws `notFound()` for non-integer ids, so the route's `FilterNotFound` component renders
- Migrate the route from the deprecated `parseParams`/`stringifyParams` options to `params.parse`/`params.stringify`
- Add `web/test/filter-route-params.test.tsx` covering valid and invalid ids

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* `pnpm --dir web test`, `pnpm --dir web lint`, and `tsc --noEmit` pass
* Opened `/filters/does-not-exist` locally and confirmed the filter not-found page renders

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally

