### PR TITLE
feat(indexers): update XSpeeds IRC addr

### DIFF
--- a/internal/indexer/definitions/xspeeds.yaml
+++ b/internal/indexer/definitions/xspeeds.yaml
@@ -22,7 +22,7 @@ settings:
 
 irc:
   network: XSpeeds
-  server: irc.xspeeds.eu
+  server: 85.17.118.208
   port: 6697
   tls: true
   settings:


### PR DESCRIPTION
# Description

- Update the XSpeeds IRC server in `internal/indexer/definitions/xspeeds.yaml` from `irc.xspeeds.eu` to `85.17.118.208`
- The old hostname is abandoned and no longer resolves to a working server, so new XSpeeds networks created from the definition could not connect
- Port, TLS and the rest of the definition are unchanged

Note for existing users: this only affects networks created from the definition going forward. Anyone with an existing XSpeeds network needs to update the server address manually under Settings > IRC. The server certificate has no IP SANs, so connecting over TLS on port 6697 fails validation unless `TLS skip verify` is enabled on the network.

Fixes #2662

## Type of change

- [x] Indexer definition update

## How has this been tested?

* Definition-only change, no code touched. Server address taken from the report in #2662.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed

