### PR TITLE
fix(http): set session cookie Secure attribute per request

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -86,18 +86,6 @@ func (h *authHandler) login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set cookie options
-	h.sessionManager.Cookie.HttpOnly = true
-	h.sessionManager.Cookie.SameSite = http.SameSiteLaxMode
-	h.sessionManager.Cookie.Path = h.config.BaseURL
-
-	// autobrr does not support serving on TLS / https, so this is only available behind reverse proxy.
-	// When forwarded protocol is https we mark the cookie as Secure, but keep SameSite=Lax so OIDC
-	// callbacks returning from a different domain still include the session cookie.
-	if r.Header.Get("X-Forwarded-Proto") == "https" {
-		h.sessionManager.Cookie.Secure = true
-	}
-
 	if err := h.sessionManager.RenewToken(ctx); err != nil {
 		h.log.Error().Err(err).Str("username", data.Username).Str("remote_addr", r.RemoteAddr).Msg("failed to renew session token")
 		h.encoder.StatusError(w, http.StatusInternalServerError, errors.New("could not renew session token"))

--- a/internal/http/auth_test.go
+++ b/internal/http/auth_test.go
@@ -13,8 +13,11 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/autobrr/autobrr/internal/config"
 	"github.com/autobrr/autobrr/internal/domain"
 	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -128,7 +131,7 @@ func newHttpTestClient() *http.Client {
 func setupServer(srv *Server) chi.Router {
 	r := chi.NewRouter()
 	//r.Use(middleware.Logger)
-	r.Use(srv.sessionManager.LoadAndSave)
+	r.Use(srv.sessionMiddleware)
 
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("OK"))
@@ -142,6 +145,147 @@ func runTestServer(s chi.Router) *httptest.Server {
 
 func setupAuthHandler() {
 
+}
+
+func TestAuthHandlerLoginMixedSchemes(t *testing.T) {
+	srv := NewServer(Deps{
+		Log:            zerolog.Nop(),
+		Config:         &config.AppConfig{Config: &domain.Config{BaseURL: "/autobrr/"}},
+		SessionManager: scs.New(),
+	})
+	service := authServiceMock{users: map[string]*domain.User{
+		"test": {Username: "test", Password: "pass"},
+	}}
+	handler := newAuthHandler(encoder{}, zerolog.Nop(), srv, srv.config.Config, srv.sessionManager, service, &oidcAuthServiceMock{})
+	router := setupServer(srv)
+	router.Route("/autobrr/auth", handler.Routes)
+
+	login := func(secure bool, previous *http.Cookie) *http.Cookie {
+		t.Helper()
+
+		req := httptest.NewRequest(http.MethodPost, "/autobrr/auth/login", strings.NewReader(`{"username":"test","password":"pass","remember_me":true}`))
+		if secure {
+			req.Header.Set("X-Forwarded-Proto", "https")
+		}
+		if previous != nil {
+			req.AddCookie(previous)
+		}
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+		cookies := rec.Result().Cookies()
+		if !assert.Len(t, cookies, 1) {
+			return nil
+		}
+		cookie := cookies[0]
+		assert.Equal(t, secure, cookie.Secure)
+		assert.True(t, cookie.HttpOnly)
+		assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite)
+		assert.Equal(t, "/autobrr/", cookie.Path)
+		return cookie
+	}
+	validate := func(cookie *http.Cookie, status int) {
+		t.Helper()
+
+		req := httptest.NewRequest(http.MethodGet, "/autobrr/auth/validate", nil)
+		if cookie != nil && !cookie.Secure {
+			req.AddCookie(cookie)
+		}
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		assert.Equal(t, status, rec.Code)
+	}
+
+	httpCookie := login(false, nil)
+	validate(httpCookie, http.StatusOK)
+	login(true, nil)
+	validate(httpCookie, http.StatusOK)
+	newCookie := login(false, httpCookie)
+	validate(newCookie, http.StatusOK)
+	validate(httpCookie, http.StatusForbidden)
+
+	for _, secure := range []bool{false, true} {
+		cookie := login(secure, nil)
+		if cookie == nil {
+			continue
+		}
+		req := httptest.NewRequest(http.MethodPost, "/autobrr/auth/logout", nil)
+		req.AddCookie(cookie)
+		if secure {
+			req.Header.Set("X-Forwarded-Proto", "https")
+		}
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+		cookies := rec.Result().Cookies()
+		if assert.Len(t, cookies, 1) {
+			assert.Equal(t, secure, cookies[0].Secure)
+			assert.Equal(t, -1, cookies[0].MaxAge)
+			assert.Equal(t, "/autobrr/", cookies[0].Path)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i := range 20 {
+		wg.Go(func() { login(i%2 == 0, nil) })
+	}
+	wg.Wait()
+}
+
+func TestServer_sessionMiddleware(t *testing.T) {
+	for _, secure := range []bool{false, true} {
+		for _, mode := range []string{"header", "body", "empty", "renew", "destroy", "forbidden"} {
+			name := "http_" + mode
+			if secure {
+				name = "https_" + mode
+			}
+			t.Run(name, func(t *testing.T) {
+				srv := NewServer(Deps{
+					Log:            zerolog.Nop(),
+					Config:         &config.AppConfig{Config: &domain.Config{BaseURL: "/"}},
+					SessionManager: scs.New(),
+				})
+				handler := srv.sessionMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.SetCookie(w, &http.Cookie{Name: "other", Value: "value", Path: "/"})
+					srv.sessionManager.Put(r.Context(), "authenticated", true)
+					switch mode {
+					case "header":
+						w.WriteHeader(http.StatusNoContent)
+					case "body":
+						_, err := w.Write([]byte("OK"))
+						assert.NoError(t, err)
+					case "renew":
+						assert.NoError(t, srv.sessionManager.RenewToken(r.Context()))
+					case "destroy":
+						assert.NoError(t, srv.sessionManager.Destroy(r.Context()))
+					case "forbidden":
+						srv.sessionManager.Remove(r.Context(), "authenticated")
+						srv.IsAuthenticated(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+							assert.Fail(t, "unauthenticated request reached handler")
+						})).ServeHTTP(w, r)
+					}
+				}))
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				if secure {
+					req.Header.Set("X-Forwarded-Proto", "https")
+				}
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				cookies := rec.Result().Cookies()
+				if !assert.Len(t, cookies, 2) {
+					return
+				}
+				assert.Equal(t, "other", cookies[0].Name)
+				assert.False(t, cookies[0].Secure)
+				assert.Equal(t, "autobrr_user_session", cookies[1].Name)
+				assert.Equal(t, secure, cookies[1].Secure)
+				if mode == "destroy" || mode == "forbidden" {
+					assert.Equal(t, -1, cookies[1].MaxAge)
+					assert.Empty(t, cookies[1].Value)
+				}
+			})
+		}
+	}
 }
 
 func TestAuthHandlerLogin(t *testing.T) {

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -16,6 +16,58 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+func (s *Server) sessionMiddleware(next http.Handler) http.Handler {
+	handler := s.sessionManager.LoadAndSave(next)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Forwarded-Proto") != "https" {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// SCS must write its cookie before we add Secure, including when the handler writes no response.
+		sw := &secureSessionResponseWriter{ResponseWriter: w, cookieName: s.sessionManager.Cookie.Name}
+		handler.ServeHTTP(sw, r)
+		sw.secureCookie()
+	})
+}
+
+type secureSessionResponseWriter struct {
+	http.ResponseWriter
+	cookieName string
+	written    bool
+}
+
+func (s *secureSessionResponseWriter) secureCookie() {
+	if s.written {
+		return
+	}
+
+	for i, cookie := range s.Header()["Set-Cookie"] {
+		if strings.HasPrefix(cookie, s.cookieName+"=") {
+			s.Header()["Set-Cookie"][i] = cookie + "; Secure"
+		}
+	}
+	s.written = true
+}
+
+func (s *secureSessionResponseWriter) WriteHeader(status int) {
+	if status >= http.StatusOK {
+		s.secureCookie()
+	}
+	s.ResponseWriter.WriteHeader(status)
+}
+
+func (s *secureSessionResponseWriter) Write(data []byte) (int, error) {
+	s.secureCookie()
+
+	return s.ResponseWriter.Write(data)
+}
+
+func (s *secureSessionResponseWriter) Unwrap() http.ResponseWriter {
+	return s.ResponseWriter
+}
+
 func (s *Server) IsAuthenticated(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if token := r.Header.Get("X-API-Token"); token != "" {

--- a/internal/http/oidc.go
+++ b/internal/http/oidc.go
@@ -234,17 +234,6 @@ func (h *OIDCHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set cookie options
-	h.sessionManager.Cookie.HttpOnly = true
-	h.sessionManager.Cookie.SameSite = http.SameSiteLaxMode
-	h.sessionManager.Cookie.Path = h.config.BaseURL
-
-	// If forwarded protocol is https then set cookie secure. We keep SameSite=Lax to allow the
-	// session cookie to accompany OIDC callbacks originating from another domain.
-	if r.Header.Get("X-Forwarded-Proto") == "https" {
-		h.sessionManager.Cookie.Secure = true
-	}
-
 	// Set session values using sessionManager
 	h.sessionManager.Put(r.Context(), "authenticated", true)
 	h.sessionManager.Put(r.Context(), "username", claims.Username)

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -81,6 +81,10 @@ func NewServer(deps Deps) *Server {
 	sessionManager.Lifetime = 24 * time.Hour * 30
 	sessionManager.Cookie.Name = "autobrr_user_session"
 	sessionManager.Cookie.Persist = false
+	sessionManager.Cookie.HttpOnly = true
+	sessionManager.Cookie.SameSite = http.SameSiteLaxMode
+	sessionManager.Cookie.Path = deps.Config.Config.BaseURL
+	sessionManager.Cookie.Secure = false
 
 	srv := &Server{
 		log:    deps.Log.With().Str("module", "http").Logger(),
@@ -176,7 +180,7 @@ func (s *Server) Handler() http.Handler {
 	})
 
 	r.Use(c.Handler)
-	r.Use(s.sessionManager.LoadAndSave)
+	r.Use(s.sessionMiddleware)
 
 	encoder := newEncoder(s.log)
 


### PR DESCRIPTION
# Description

Since the scs session migration in #2158 the `Secure` attribute on the session cookie has been process-global state: the login and OIDC callback handlers set `sessionManager.Cookie.Secure = true` whenever a request arrived with `X-Forwarded-Proto: https`, and nothing ever reset it. After a single HTTPS login, every cookie the server wrote afterwards carried `Secure`, including cookies for plain-HTTP requests from the LAN. Browsers refuse to store a `Secure` cookie delivered over HTTP, the login had already renewed the token, so every following request was unauthenticated and returned 403 until a restart. It was also an unsynchronised write to shared state from concurrent request handlers.

- Set `HttpOnly`, `SameSite=Lax`, `Path` and `Secure=false` once on the session manager in `NewServer` and stop mutating them from handlers
- Add `Server.sessionMiddleware` wrapping scs `LoadAndSave`: for `X-Forwarded-Proto: https` requests a response writer wrapper appends `Secure` to the session `Set-Cookie` header, on the first `WriteHeader`/`Write` or after the handler if it wrote nothing
- Applies to the session-deleting cookie on logout and on 403 as well, so browsers actually clear a `Secure` cookie
- The wrapper exposes `Unwrap`, so scs's `Flush` via `http.ResponseController` still reaches the real writer and SSE keeps streaming over HTTPS
- Remove the per-request cookie mutation from `authHandler.login` and `OIDCHandler.handleCallback`

Fixes #2676

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* `go test -race ./internal/http/`, `go vet`, `gofmt` and `go build ./...` pass
* New `TestAuthHandlerLoginMixedSchemes`: HTTP login, HTTPS login, then HTTP login again returns a non-`Secure` cookie and a valid session; logout over both schemes returns a matching delete cookie; 20 concurrent mixed-scheme logins under the race detector
* New `TestServer_sessionMiddleware`: `Secure` is added only on HTTPS requests, only to the session cookie, across header-only, body, renew, destroy and 403 response paths

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran `go fmt` and the test suite passes locally
- [x] I have linked any related issue and updated docs if needed

## AI disclosure

Yes. The root-cause analysis, the fix and the tests were written with Claude Code (Claude Fable 5.1) and reviewed, verified and adjusted by me.
