### PR TITLE
fix(dashboard): bucket release stats in UTC so charts show correct dates/times

### DIFF
--- a/internal/database/release.go
+++ b/internal/database/release.go
@@ -1038,19 +1038,19 @@ func minDateKey[T any](m map[string]*T) string {
 
 func (repo *ReleaseRepo) statsDayExpr() string {
 	if repo.db.Driver == "sqlite" {
-		// substr instead of strftime: both timestamp formats found in old
-		// databases share the YYYY-MM-DD HH prefix, and skipping per-row date
-		// parsing roughly halves the scan cost on large tables
-		return "substr(timestamp, 1, 10)"
+		// strftime normalizes the stored offset to UTC for both the RFC3339 and the
+		// legacy space-separated forms, so buckets match Postgres (timestamptz).
+		// substr returned the raw local hour/day, which broke the dashboard charts.
+		return "strftime('%Y-%m-%d', timestamp)"
 	}
-	return "to_char(timestamp, 'YYYY-MM-DD')"
+	return "to_char(timestamp AT TIME ZONE 'UTC', 'YYYY-MM-DD')"
 }
 
 func (repo *ReleaseRepo) statsHourExpr() string {
 	if repo.db.Driver == "sqlite" {
-		return "CAST(substr(timestamp, 12, 2) AS INTEGER)"
+		return "CAST(strftime('%H', timestamp) AS INTEGER)"
 	}
-	return "EXTRACT(HOUR FROM timestamp)::int"
+	return "EXTRACT(HOUR FROM timestamp AT TIME ZONE 'UTC')::int"
 }
 
 func (repo *ReleaseRepo) statsQueryRows(ctx context.Context, qb sq.SelectBuilder, scan func(rows *sql.Rows) error) error {

--- a/internal/database/release_test.go
+++ b/internal/database/release_test.go
@@ -767,6 +767,66 @@ func TestReleaseRepo_StatsDashboard(t *testing.T) {
 	}
 }
 
+func TestReleaseRepo_StatsBucketUTC(t *testing.T) {
+	ctx := t.Context()
+
+	for dbType, testDb := range testDBs {
+		db := testDb.db
+		log := setupLoggerForTest()
+
+		downloadClientRepo := NewDownloaderRepo(log, db)
+		filterRepo := NewFilterRepo(log, db)
+		repo := NewReleaseRepo(log, db)
+
+		mockData := getMockRelease()
+
+		t.Run(fmt.Sprintf("StatsBucketUTC_BucketsInUTC [%s]", dbType), func(t *testing.T) {
+			// Setup
+			mock := getMockDownloader()
+			err := downloadClientRepo.Store(ctx, &mock)
+			assert.NoError(t, err)
+
+			err = filterRepo.Store(ctx, getMockFilter())
+			assert.NoError(t, err)
+
+			createdFilters, err := filterRepo.ListFilters(ctx)
+			assert.NoError(t, err)
+			assert.NotNil(t, createdFilters)
+
+			mockData.FilterID = createdFilters[0].ID
+
+			// A recent release whose wall clock is in a non-UTC zone, so its local
+			// hour/day differ from UTC. The dashboard stats must bucket in UTC on both
+			// dialects; the pre-fix substr (sqlite) and no-AT-TIME-ZONE (postgres) code
+			// bucketed in local/server time, which is what this test guards against.
+			loc := time.FixedZone("UTC-4", -4*3600)
+			ts := time.Now().Add(-6 * time.Hour).In(loc)
+			mockData.Timestamp = ts
+
+			err = repo.Store(ctx, mockData)
+			assert.NoError(t, err)
+
+			// Execute
+			heatmap, err := repo.StatsHeatmap(ctx, 30)
+			assert.NoError(t, err)
+			assert.NotNil(t, heatmap)
+			assert.Len(t, heatmap.Heatmap, 168)
+
+			// Verify: the release lands in its UTC weekday+hour cell, not the local one.
+			utcIdx := int(ts.UTC().Weekday())*24 + ts.UTC().Hour()
+			localIdx := int(ts.Weekday())*24 + ts.Hour()
+			assert.NotEqual(t, utcIdx, localIdx, "the offset must make the UTC and local buckets differ [%s]", dbType)
+			assert.Equal(t, int64(1), heatmap.Heatmap[utcIdx], "release should be counted in the UTC bucket [%s]", dbType)
+			assert.Equal(t, int64(0), heatmap.Heatmap[localIdx], "release must not be counted in the local-time bucket [%s]", dbType)
+
+			// Cleanup
+			_ = repo.Delete(ctx, &domain.DeleteReleaseRequest{OlderThan: 0})
+			_ = filterRepo.Delete(ctx, createdFilters[0].ID)
+			_ = downloadClientRepo.Delete(ctx, mock.ID)
+		})
+	}
+}
+
 func TestReleaseRepo_Delete(t *testing.T) {
 	ctx := t.Context()
 

--- a/web/src/screens/dashboard/ActivityChart.tsx
+++ b/web/src/screens/dashboard/ActivityChart.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from "react-i18next";
 import { Chart } from "@tanstack/react-charts";
 import { defineChart, lineY, d3Curve } from "@tanstack/charts";
 import { tooltip } from "@tanstack/charts/tooltip";
-import { scaleUtc, scaleLinear } from "d3-scale";
+import { scaleTime, scaleLinear } from "d3-scale";
 import { curveMonotoneX } from "d3-shape";
 import { format } from "date-fns";
 
@@ -51,7 +51,7 @@ export const ActivityChart = () => {
   const definition = useMemo(() => {
     const points: ActivityDatum[] = (data?.daily ?? []).flatMap((day) =>
       series.map((s) => ({
-        date: new Date(`${day.date}T00:00:00Z`),
+        date: new Date(`${day.date}T00:00:00`),
         series: s.label,
         count: day[s.key]
       }))
@@ -70,7 +70,7 @@ export const ActivityChart = () => {
       ],
       scales: {
         x: {
-          scale: scaleUtc,
+          scale: scaleTime,
           grid: false,
           axis: {
             ticks: {

--- a/web/src/screens/dashboard/VolumeChart.tsx
+++ b/web/src/screens/dashboard/VolumeChart.tsx
@@ -17,7 +17,7 @@ import { humanFileSize } from "@utils";
 import { ChartCard, ChartError, ChartSkeleton } from "./charts";
 import { chartTheme, seriesColors, useIsDark } from "./chartTheme";
 
-const asDate = (value: string) => new Date(`${value}T00:00:00Z`);
+const asDate = (value: string) => new Date(`${value}T00:00:00`);
 
 export const VolumeChart = () => {
   const { t } = useTranslation("common");
@@ -44,7 +44,7 @@ export const VolumeChart = () => {
           grid: false,
           axis: {
             ticks: {
-              format: (value: string) => (asDate(value).getUTCDay() === 1 ? format(asDate(value), "MMM d") : "")
+              format: (value: string) => (asDate(value).getDay() === 1 ? format(asDate(value), "MMM d") : "")
             }
           }
         },


### PR DESCRIPTION
## Description

Fixes #2673.

The dashboard "Download volume" and "Activity by hour" charts showed the wrong dates and times. The root cause is a mismatch in how release timestamps are bucketed for stats:

- On Postgres the release.timestamp column is timestamptz (migration 44), so to_char/EXTRACT bucket in UTC.
- On SQLite the stats used substr() on the raw stored string, which keeps the local UTC offset written by time.Now().Format(time.RFC3339), so buckets were in the server's local time.

The charts assume the API grid is UTC and convert it to the viewer's local time. Because SQLite delivered a local-time grid, the heatmap hours were shifted a second time and the day labels rolled back a day for viewers west of UTC.

## Changes

- internal/database/release.go: statsDayExpr() and statsHourExpr() now normalize to UTC on both drivers. SQLite uses strftime('%Y-%m-%d' / '%H', timestamp), which normalizes the RFC3339-with-offset form and treats the legacy space-separated (CURRENT_TIMESTAMP, UTC) form as UTC. Postgres uses "... AT TIME ZONE 'UTC'" so bucketing is deterministic regardless of the session TimeZone. The API grid is now UTC on both databases.
- web/src/screens/dashboard/VolumeChart.tsx and ActivityChart.tsx: day keys are parsed as local midnight and formatted verbatim, so a UTC day bucket is labeled with that date in every timezone, instead of being parsed as UTC and then formatted in local time (which rolled the label back a day). HourHeatmap already converts the UTC grid to local hours, so it is correct now and is unchanged.
- Adds TestReleaseRepo_StatsBucketUTC, which stores a release with a non-UTC offset and asserts the stats bucket by UTC hour and day. It fails if the bucketing is reverted to local time.

## Testing

- go build ./... and go test ./internal/database/ pass on both SQLite and Postgres, run under TZ=America/New_York.
- The new test fails when the expressions are reverted to the old local-time bucketing.
- pnpm exec tsc --noEmit, pnpm lint, and pnpm test (52 tests) all pass. The volume-label test fails on the pre-fix code under a non-UTC timezone.

## Notes and tradeoffs

- strftime parses each row where substr did not. The stats queries filter by the selected range (WHERE timestamp >= cutoff, on the timestamp index), so this only touches the rows in range; the "all" range scans the table as it did before. Correctness needs the parse. Storing timestamps in UTC would let a later change restore the substring fast path.
- Day buckets are UTC days labeled verbatim, while the heatmap shows viewer-local hours. Showing day buckets in the viewer's own day would need the viewer timezone passed to the stats API, which is a larger change and is left out of scope here.

## AI disclosure

Most of this change was written with AI assistance (Claude, via Claude Code). It was human-reviewed and verified before submission: the SQLite and Postgres bucketing behavior was checked directly, the build and both-database tests were run under a non-UTC timezone, and the new test was confirmed to fail without the fix.
