### PR TITLE
fix(arr): handle error object in bad request responses

### DIFF
--- a/pkg/arr/lidarr/lidarr.go
+++ b/pkg/arr/lidarr/lidarr.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/autobrr/autobrr/pkg/arr"
 	"github.com/autobrr/autobrr/pkg/errors"
 	"github.com/autobrr/autobrr/pkg/sharedhttp"
 
@@ -103,6 +104,11 @@ func (c *Client) Push(ctx context.Context, release Release) ([]string, error) {
 	if status == http.StatusBadRequest {
 		badRequestResponses := make([]*BadRequestResponse, 0)
 		if err = json.Unmarshal(res, &badRequestResponses); err != nil {
+			var errResp arr.ErrorResponse
+			if errJSON := json.Unmarshal(res, &errResp); errJSON == nil && errResp.String() != "" {
+				return nil, errors.New("lidarr: %s", errResp.String())
+			}
+
 			return nil, errors.Wrap(err, "could not unmarshal data")
 		}
 

--- a/pkg/arr/radarr/radarr.go
+++ b/pkg/arr/radarr/radarr.go
@@ -103,6 +103,11 @@ func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string
 	if status == http.StatusBadRequest {
 		badRequestResponses := make([]*BadRequestResponse, 0)
 		if err = json.Unmarshal(res, &badRequestResponses); err != nil {
+			var errResp arr.ErrorResponse
+			if errJSON := json.Unmarshal(res, &errResp); errJSON == nil && errResp.String() != "" {
+				return nil, errors.New("radarr: %s", errResp.String())
+			}
+
 			return nil, errors.Wrap(err, "could not unmarshal data")
 		}
 

--- a/pkg/arr/readarr/readarr.go
+++ b/pkg/arr/readarr/readarr.go
@@ -103,6 +103,11 @@ func (c *Client) Push(ctx context.Context, release Release) ([]string, error) {
 		badRequestResponses := make([]*BadRequestResponse, 0)
 
 		if err = json.Unmarshal(res, &badRequestResponses); err != nil {
+			var errResp arr.ErrorResponse
+			if errJSON := json.Unmarshal(res, &errResp); errJSON == nil && errResp.String() != "" {
+				return nil, errors.New("readarr: %s", errResp.String())
+			}
+
 			return nil, errors.Wrap(err, "could not unmarshal data")
 		}
 

--- a/pkg/arr/shared.go
+++ b/pkg/arr/shared.go
@@ -58,3 +58,24 @@ type QualityRevision struct {
 	Real     int64 `json:"real"`
 	IsRepack bool  `json:"isRepack,omitempty"`
 }
+
+// ErrorResponse represents an unhandled exception or API error returned by Servarr apps as a single JSON object.
+type ErrorResponse struct {
+	Message     string `json:"message"`
+	Description string `json:"description,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Detail      string `json:"detail,omitempty"`
+}
+
+func (e ErrorResponse) String() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Detail != "" {
+		return e.Detail
+	}
+	if e.Title != "" {
+		return e.Title
+	}
+	return e.Description
+}

--- a/pkg/arr/sonarr/sonarr.go
+++ b/pkg/arr/sonarr/sonarr.go
@@ -105,6 +105,11 @@ func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string
 		badRequestResponses := make([]*BadRequestResponse, 0)
 
 		if err = json.Unmarshal(res, &badRequestResponses); err != nil {
+			var errResp arr.ErrorResponse
+			if errJSON := json.Unmarshal(res, &errResp); errJSON == nil && errResp.String() != "" {
+				return nil, errors.New("sonarr: %s", errResp.String())
+			}
+
 			return nil, errors.Wrap(err, "could not unmarshal data")
 		}
 

--- a/pkg/arr/sportarr/sportarr.go
+++ b/pkg/arr/sportarr/sportarr.go
@@ -103,6 +103,11 @@ func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string
 		badRequestResponses := make([]*BadRequestResponse, 0)
 
 		if err = json.Unmarshal(res, &badRequestResponses); err != nil {
+			var errResp arr.ErrorResponse
+			if errJSON := json.Unmarshal(res, &errResp); errJSON == nil && errResp.String() != "" {
+				return nil, errors.New("sportarr: %s", errResp.String())
+			}
+
 			return nil, errors.Wrap(err, "could not unmarshal data")
 		}
 

--- a/pkg/arr/whisparr/testdata/release_push_error_object.json
+++ b/pkg/arr/whisparr/testdata/release_push_error_object.json
@@ -1,0 +1,4 @@
+{
+  "message": "Indexer with name 'IPTorrents' could not be found",
+  "description": "NzbDrone.Core.Indexers.ResolveIndexerException: Indexer with name 'IPTorrents' could not be found\n   at NzbDrone.Core.Indexers.IndexerFactory.ResolveIndexer(Nullable`1 id, String name)"
+}

--- a/pkg/arr/whisparr/whisparr.go
+++ b/pkg/arr/whisparr/whisparr.go
@@ -133,6 +133,11 @@ func (c *Client) Push(ctx context.Context, release ReleasePushRequest) ([]string
 		badRequestResponses := make([]*BadRequestResponse, 0)
 
 		if err = json.Unmarshal(res, &badRequestResponses); err != nil {
+			var errResp arr.ErrorResponse
+			if errJSON := json.Unmarshal(res, &errResp); errJSON == nil && errResp.String() != "" {
+				return nil, errors.New("whisparr: %s", errResp.String())
+			}
+
 			return nil, errors.Wrap(err, "could not unmarshal data")
 		}
 

--- a/pkg/arr/whisparr/whisparr_test.go
+++ b/pkg/arr/whisparr/whisparr_test.go
@@ -240,3 +240,34 @@ func TestClient_Push_temporarilyRejected(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"Waiting for a better quality release"}, rejections)
 }
+
+func TestClient_Push_badRequest_errorObject(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/release/push", func(w http.ResponseWriter, r *http.Request) {
+		payload, err := os.ReadFile("testdata/release_push_error_object.json")
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(payload)
+	})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	rejections, err := newTestClient(ts.URL, VersionV3).Push(t.Context(), ReleasePushRequest{
+		Title:            "JimSlip 26 09 11 Charlotte Rose Third Visit Part 1 XXX XviD-iPT Team",
+		DownloadUrl:      ts.URL + "/download",
+		Size:             309750000,
+		Indexer:          "IPTorrents",
+		Protocol:         "torrent",
+		DownloadProtocol: "torrent",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, rejections)
+	assert.Equal(t, "whisparr: Indexer with name 'IPTorrents' could not be found", err.Error())
+}
+


### PR DESCRIPTION
### Description

When Servarr applications (Whisparr, Radarr, Sonarr, Lidarr, Readarr, Sportarr) encounter server-side errors (such as `ResolveIndexerException: Indexer with name '...' could not be found`), ASP.NET Core returns an `HTTP 400 Bad Request` with a single JSON error object (`{"message": "...", "description": "..."}`) rather than a validation error array (`[]*BadRequestResponse`).

Previously, all `pkg/arr/*` clients attempted to unmarshal every `HTTP 400` directly into `[]*BadRequestResponse`. When a single error object was returned, this resulted in an unmarshal error:
```
could not unmarshal data: json: cannot unmarshal object into Go value of type []*whisparr.BadRequestResponse
```
which masked the actual server error message.

### Changes

- Added `arr.ErrorResponse` to `pkg/arr/shared.go` with a `String()` method to extract the human-readable error message.
- Updated `Push()` in `whisparr`, `radarr`, `sonarr`, `lidarr`, `readarr`, and `sportarr` to fall back to unmarshaling into `arr.ErrorResponse` when `[]*BadRequestResponse` unmarshaling fails on `HTTP 400`.
- Added testdata and unit test in `pkg/arr/whisparr/whisparr_test.go` verifying that error objects are correctly parsed and reported as errors.